### PR TITLE
chore: harden repo and website security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security vulnerability in AgeForge, **please do not open a public GitHub issue.**
+
+Instead, report it privately via one of these channels:
+
+- **Discord**: DM `espresso20` on the [AgeForge Discord](https://discord.gg/EPvyd5vjpj)
+- **GitHub**: Use [GitHub's private vulnerability reporting](https://github.com/espresso20/ageforge/security/advisories/new)
+
+Please include:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce it
+- Any relevant logs, screenshots, or proof-of-concept
+
+I'll acknowledge the report within 48 hours and aim to release a fix within 14 days for valid issues.
+
+## Scope
+
+AgeForge is a local terminal application — it reads/writes save files to disk and makes outbound-only network requests to check for updates (GitHub releases API). There is no server, no user accounts, and no data collection.
+
+The main attack surface is:
+
+| Area | Notes |
+|------|-------|
+| **Save file parsing** | Malformed JSON save files could cause crashes |
+| **Auto-updater** | Downloads binaries from GitHub releases; SHA256 is verified before install |
+| **Website** | Static Netlify site; no server-side code |
+
+## Supported Versions
+
+Only the latest release is actively maintained. If you're on an older version, please update before reporting.

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,9 @@
     X-Content-Type-Options     = "nosniff"
     Referrer-Policy            = "strict-origin-when-cross-origin"
     Cache-Control              = "public, max-age=3600"
+    Strict-Transport-Security  = "max-age=63072000; includeSubDomains"
+    Permissions-Policy         = "camera=(), microphone=(), geolocation=(), payment=()"
+    Content-Security-Policy    = "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; img-src 'self' raw.githubusercontent.com data:; connect-src api.github.com; frame-ancestors 'none'; base-uri 'self';"
 
 # Long-cache for fonts/assets
 [[headers]]


### PR DESCRIPTION
## Summary

- **`netlify.toml`** — adds `Strict-Transport-Security` (2yr HSTS), `Permissions-Policy` (block camera/mic/geo/payment), and a tight `Content-Security-Policy` (self + Google Fonts + GitHub API only)
- **`.github/dependabot.yml`** — weekly Go module security update PRs
- **`SECURITY.md`** — private vulnerability disclosure via Discord DM or GitHub private advisories; documents actual attack surface (save file parsing, auto-updater, static site)

## Test plan

- [ ] Deploy to Netlify and verify headers with [securityheaders.com](https://securityheaders.com)
- [ ] Confirm site still loads correctly (fonts, starfield, GitHub API calls for screenshots)
- [ ] Confirm SECURITY.md appears under repo Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)