### PR TITLE
fix: age advancement splash ignores keypresses until auto-dismiss

### DIFF
--- a/ui/age_splash.go
+++ b/ui/age_splash.go
@@ -157,11 +157,10 @@ func ShowAgeSplashFull(app *tview.Application, pages *tview.Pages, oldAge, newAg
 		pages.SwitchToPage("dashboard")
 	}
 
-	// NOTE: SetInputCapture is called on the Flex, not the TextView, so that
-	// any key — including ones the TextView would consume for scrolling — will
-	// dismiss the splash. QueueUpdateDraw is required because this handler
-	// runs inside the tview event loop but pages.RemovePage modifies the layout.
-	overlay.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+	// SetInputCapture on titleTV (the focused child) so keypresses actually reach
+	// the capture handler. QueueUpdateDraw is required because pages.RemovePage
+	// modifies the layout and must run on the main goroutine.
+	titleTV.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		app.QueueUpdateDraw(func() {
 			dismiss()
 		})
@@ -178,4 +177,5 @@ func ShowAgeSplashFull(app *tview.Application, pages *tview.Pages, oldAge, newAg
 
 	pages.AddPage("age_splash", overlay, true, true)
 	pages.SwitchToPage("age_splash")
+	app.SetFocus(titleTV)
 }


### PR DESCRIPTION
## Summary

- Age advancement splash screen showed "Press any key to continue" but keypresses had no effect — screen only cleared after the 20-second auto-dismiss timer
- Root cause: `SetInputCapture` was attached to the `overlay` Flex container, but tview focuses the child `titleTV` (TextView) on page switch, so the Flex capture handler never fired
- Fix: moved `SetInputCapture` to `titleTV` and added `app.SetFocus(titleTV)` after `pages.SwitchToPage` to guarantee focus lands on the correct primitive

## Test plan

- [ ] Advance an age in-game and verify the splash dismisses immediately on any keypress
- [ ] Verify the 20-second auto-dismiss still works if no key is pressed
- [ ] `go build ./...` and `go test ./...` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)