### PR TITLE
feat: civilization history overlay + dynamic overlay width system

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -85,6 +85,9 @@ type GameEngine struct {
 	// resets so that legacy bonuses and civilization history accumulate across multiple runs.
 	legacyBonuses      map[string]bool // epochKey -> true if succumb legacy bonus active
 	catastropheHistory []string        // narrative civilization log entries
+
+	// History collector — periodic metric samples for the history overlay.
+	History *HistoryCollector
 }
 
 // BuildQueueItem represents a building under construction
@@ -119,6 +122,7 @@ func NewGameEngine() *GameEngine {
 		epochEventFired:  make(map[string]bool),
 		survivedEpochs:   make(map[string]bool),
 		legacyBonuses:    make(map[string]bool),
+		History:          NewHistoryCollector(),
 	}
 	ge.applyAgeUnlocks("primitive_age")
 	// Give starting resources — enough for first hut + a little food
@@ -134,6 +138,12 @@ func NewGameEngine() *GameEngine {
 	ge.addLog("event", "★ Wonder available: Sacred Grove — build it to unlock +0.5x speed!")
 	ge.addLog("info", "  5. Later: [cyan]assign food gathering_camp 3[-] — assign workers to buildings!")
 	ge.addLog("info", "  Type [cyan]help[-] for all commands.")
+	// Subscribe to age advances to record markers in history.
+	// IMPORTANT: Bus handlers run under the engine write lock — do NOT call GetState().
+	ge.Bus.Subscribe(EventAgeAdvanced, func(e EventData) {
+		ageName, _ := e.Payload["new_age"].(string)
+		ge.History.MarkAge(ge.tick, ageName)
+	})
 	return ge
 }
 
@@ -406,6 +416,32 @@ func (ge *GameEngine) doTick() {
 
 	// Recalculate tick speed from all sources
 	ge.recalculateTickSpeed()
+
+	// Record periodic history sample (every historySampleInterval ticks).
+	// All data is read directly from engine fields — no GetState() call here.
+	if ge.tick%historySampleInterval == 0 {
+		ageOrderMap := ge.progress.GetAgeOrder()
+		ageOrder := ageOrderMap[ge.age]
+		snap := ge.Resources.Snapshot()
+		foodRate := 0.0
+		knowRate := 0.0
+		if fr, ok := snap["food"]; ok {
+			foodRate = fr.Rate
+		}
+		if kr, ok := snap["knowledge"]; ok {
+			knowRate = kr.Rate
+		}
+		faith := snap["faith"].Amount
+		ge.History.Sample(ge.tick, HistorySample{
+			Population: float64(ge.Workers.TotalPop()),
+			FoodRate:   foodRate,
+			KnowRate:   knowRate,
+			Faith:      faith,
+			ProdAll:    ge.permanentBonuses["production_all"],
+			TickSpeed:  ge.tickSpeedBonus,
+			AgeOrder:   ageOrder,
+		})
+	}
 }
 
 // processResearch handles research tick
@@ -2107,6 +2143,7 @@ func (ge *GameEngine) GetState() GameState {
 			return out
 		}(),
 		CatastropheHistory: ge.catastropheHistory,
+		History:            ge.History,
 	}
 }
 

--- a/game/history.go
+++ b/game/history.go
@@ -1,0 +1,64 @@
+package game
+
+const historyMaxSamples = 300
+const historySampleInterval = 10 // every 10 ticks (~20s at 1x, ~13s at 1.5x)
+
+// HistorySample is a point-in-time snapshot of key metrics.
+type HistorySample struct {
+	Tick       int     `json:"tick"`
+	Population float64 `json:"population"`
+	FoodRate   float64 `json:"food_rate"`
+	KnowRate   float64 `json:"know_rate"`
+	Faith      float64 `json:"faith"`
+	ProdAll    float64 `json:"prod_all"`
+	TickSpeed  float64 `json:"tick_speed"`
+	AgeOrder   int     `json:"age_order"`
+}
+
+// AgeMarker records when an age advance occurred.
+type AgeMarker struct {
+	Tick    int    `json:"tick"`
+	AgeName string `json:"age_name"`
+}
+
+// HistoryCollector accumulates periodic metric samples and age-advance events.
+type HistoryCollector struct {
+	Samples    []HistorySample `json:"samples"`
+	AgeMarkers []AgeMarker     `json:"age_markers"`
+}
+
+// NewHistoryCollector returns an empty collector.
+func NewHistoryCollector() *HistoryCollector {
+	return &HistoryCollector{}
+}
+
+// Sample records a snapshot. Called from doTick() every historySampleInterval ticks.
+func (h *HistoryCollector) Sample(tick int, s HistorySample) {
+	if h == nil {
+		return
+	}
+	s.Tick = tick
+	if len(h.Samples) >= historyMaxSamples {
+		h.Samples = h.Samples[1:] // ring: drop oldest
+	}
+	h.Samples = append(h.Samples, s)
+}
+
+// MarkAge records an age advance event and prunes markers outside the sample window.
+func (h *HistoryCollector) MarkAge(tick int, ageName string) {
+	if h == nil {
+		return
+	}
+	h.AgeMarkers = append(h.AgeMarkers, AgeMarker{Tick: tick, AgeName: ageName})
+	// keep only markers that fall within the current sample window
+	if len(h.Samples) > 0 {
+		oldest := h.Samples[0].Tick
+		kept := h.AgeMarkers[:0]
+		for _, m := range h.AgeMarkers {
+			if m.Tick >= oldest {
+				kept = append(kept, m)
+			}
+		}
+		h.AgeMarkers = kept
+	}
+}

--- a/game/save.go
+++ b/game/save.go
@@ -64,6 +64,8 @@ type GameSave struct {
 	Ruins              map[string]int  `json:"ruins,omitempty"`
 	LegacyBonuses      map[string]bool `json:"legacy_bonuses,omitempty"`
 	CatastropheHistory []string        `json:"catastrophe_history,omitempty"`
+	// History overlay samples
+	History *HistoryCollector `json:"history,omitempty"`
 	// Integrity fields
 	CheaterBadge bool   `json:"cheater_badge,omitempty"`
 	EliteBadge   bool   `json:"elite_badge,omitempty"`
@@ -375,6 +377,7 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 		Ruins:              ge.Buildings.GetAllRuins(),
 		LegacyBonuses:      copyBoolMap(ge.legacyBonuses),
 		CatastropheHistory: append([]string(nil), ge.catastropheHistory...),
+		History:            ge.History,
 	}
 }
 
@@ -522,6 +525,13 @@ func (ge *GameEngine) LoadGame(filename string) error {
 		ge.legacyBonuses = make(map[string]bool)
 	}
 	ge.catastropheHistory = save.CatastropheHistory
+
+	// Restore history collector
+	if save.History != nil {
+		ge.History = save.History
+	} else {
+		ge.History = NewHistoryCollector()
+	}
 
 	ge.recalculateRates()
 	ge.recalculateTickSpeed()

--- a/game/types.go
+++ b/game/types.go
@@ -44,6 +44,8 @@ type GameState struct {
 	// Phase 9: civilization history + legacy bonuses
 	LegacyBonuses      map[string]bool  // epochKey -> true if succumb legacy bonus is active
 	CatastropheHistory []string         // narrative log entries
+	// History overlay
+	History *HistoryCollector
 }
 
 // AgeAdvanceSummary holds data about what changed during an age advance transition.

--- a/ui/autocomplete.go
+++ b/ui/autocomplete.go
@@ -33,7 +33,7 @@ var commands = []string{
 	"wonder",
 	"dump", "exportlogs",
 	"milestones", "ms",
-	"techs", "army", "stats", "wonders", "logs", "epoch",
+	"techs", "army", "stats", "wonders", "logs", "epoch", "history",
 }
 
 // NewAutoCompleter returns an autocomplete function for the command input field.

--- a/ui/braille.go
+++ b/ui/braille.go
@@ -1,0 +1,129 @@
+package ui
+
+import (
+	"fmt"
+	"math"
+)
+
+// braille dot bit positions: [col: 0=left, 1=right][row: 0=top .. 3=bottom]
+var brailleDot = [2][4]rune{
+	{0x01, 0x02, 0x04, 0x40},
+	{0x08, 0x10, 0x20, 0x80},
+}
+
+// BrailleLine renders values as a braille line graph, returning height string rows each width
+// braille characters wide. ageCols contains canvas column positions where age-advance markers
+// ('│') are drawn in otherwise-empty cells.
+func BrailleLine(values []float64, width, height int, ageCols []int) []string {
+	empty := make([]string, height)
+	if len(values) == 0 {
+		return empty
+	}
+
+	cW, cH := width*2, height*4
+	canvas := make([][]bool, cH)
+	for i := range canvas {
+		canvas[i] = make([]bool, cW)
+	}
+
+	minV, maxV := values[0], values[0]
+	for _, v := range values {
+		if v < minV {
+			minV = v
+		}
+		if v > maxV {
+			maxV = v
+		}
+	}
+	if maxV == minV {
+		maxV = minV + 1
+	}
+
+	// build set of age marker columns
+	ageset := make(map[int]bool, len(ageCols))
+	for _, c := range ageCols {
+		ageset[c] = true
+	}
+
+	// plot a connected line across the canvas
+	n := len(values)
+	prevX, prevY := -1, -1
+	for i, v := range values {
+		x := i * (cW - 1) / (n - 1)
+		norm := (v - minV) / (maxV - minV)
+		y := int((1.0-norm)*float64(cH-1) + 0.5)
+		if y < 0 {
+			y = 0
+		}
+		if y >= cH {
+			y = cH - 1
+		}
+		if prevX >= 0 {
+			steps := x - prevX
+			if steps < 1 {
+				steps = 1
+			}
+			for s := 0; s <= steps; s++ {
+				lx := prevX + s
+				ly := prevY + (y-prevY)*s/steps
+				if lx >= 0 && lx < cW && ly >= 0 && ly < cH {
+					canvas[ly][lx] = true
+				}
+			}
+		}
+		prevX, prevY = x, y
+	}
+
+	lines := make([]string, height)
+	for row := 0; row < height; row++ {
+		sb := make([]rune, 0, width)
+		for col := 0; col < width; col++ {
+			var ch rune = 0x2800
+			for dr := 0; dr < 4; dr++ {
+				for dc := 0; dc < 2; dc++ {
+					cr, cc := row*4+dr, col*2+dc
+					if cr < cH && cc < cW && canvas[cr][cc] {
+						ch |= brailleDot[dc][dr]
+					}
+				}
+			}
+			if ageset[col] && ch == 0x2800 {
+				sb = append(sb, '│')
+			} else {
+				sb = append(sb, ch)
+			}
+		}
+		lines[row] = string(sb)
+	}
+	return lines
+}
+
+// AgeMarkerCols converts age marker tick positions to canvas column indices.
+func AgeMarkerCols(markerTicks []int, firstTick, lastTick, width int) []int {
+	if lastTick <= firstTick {
+		return nil
+	}
+	cols := make([]int, 0, len(markerTicks))
+	for _, t := range markerTicks {
+		col := (t - firstTick) * (width - 1) / (lastTick - firstTick)
+		if col >= 0 && col < width {
+			cols = append(cols, col)
+		}
+	}
+	return cols
+}
+
+// fmtVal formats a float64 for compact display (K/M/B suffixes).
+func fmtVal(v float64) string {
+	abs := math.Abs(v)
+	if abs >= 1e9 {
+		return fmt.Sprintf("%.1fB", v/1e9)
+	}
+	if abs >= 1e6 {
+		return fmt.Sprintf("%.1fM", v/1e6)
+	}
+	if abs >= 1e3 {
+		return fmt.Sprintf("%.1fK", v/1e3)
+	}
+	return fmt.Sprintf("%.1f", v)
+}

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -103,6 +103,7 @@ func NewDashboard(app *tview.Application, engine *game.GameEngine, pages *tview.
 	d.overlayMgr.Register("wonders", "Wonders", wondersProvider)
 	d.overlayMgr.Register("logs", "Logs", logsProvider)
 	d.overlayMgr.Register("epoch", "Epoch", epochProvider)
+	d.overlayMgr.Register("history", "Civilization History", historyProvider)
 	d.devTab = newDevTab(engine)
 	return d
 }
@@ -375,7 +376,7 @@ func (d *Dashboard) updateSidebar(activeOverlay string) {
 }
 
 func buildSidebarText(active string) string {
-	commands := []string{"milestones", "research", "army", "trade", "stats", "wonders", "logs", "epoch"}
+	commands := []string{"milestones", "research", "army", "trade", "stats", "wonders", "logs", "epoch", "history"}
 	var sb strings.Builder
 	sb.WriteString("\n")
 	for _, cmd := range commands {

--- a/ui/input.go
+++ b/ui/input.go
@@ -86,6 +86,8 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 		return CommandResult{OverlayName: "logs"}
 	case "epoch":
 		return CommandResult{OverlayName: "epoch"}
+	case "history":
+		return CommandResult{OverlayName: "history"}
 	case "catastrophe", "cat":
 		return cmdCatastrophe(args, engine)
 	case "dump", "exportlogs":

--- a/ui/overlay.go
+++ b/ui/overlay.go
@@ -8,7 +8,7 @@ import (
 
 // OverlayProvider is a function that generates the full text content for a
 // floating panel from the current game state. Called every 500 ms by Refresh.
-type OverlayProvider func(state game.GameState) string
+type OverlayProvider func(state game.GameState, w int) string
 
 // overlayEntry holds the tview widgets and content provider for a text-based overlay.
 // The root Flex uses nested nil spacers to centre the TextView at ~85%×85% of the terminal.
@@ -39,18 +39,25 @@ type OverlayManager struct {
 	pages         *tview.Pages
 	app           *tview.Application
 	onClose       func() // called after hide to restore focus to the command input field
+	screenW       int    // updated every frame via SetBeforeDrawFunc
 }
 
 // NewOverlayManager creates an OverlayManager. onClose is called whenever an
 // overlay is closed so the caller can return focus to the command input field.
 func NewOverlayManager(pages *tview.Pages, app *tview.Application, onClose func()) *OverlayManager {
-	return &OverlayManager{
+	om := &OverlayManager{
 		entries:       make(map[string]*overlayEntry),
 		widgetEntries: make(map[string]*widgetEntry),
 		pages:         pages,
 		app:           app,
 		onClose:       onClose,
+		screenW:       120, // sensible default before first draw
 	}
+	app.SetBeforeDrawFunc(func(screen tcell.Screen) bool {
+		om.screenW, _ = screen.Size()
+		return false
+	})
+	return om
 }
 
 // Register adds a named text overlay backed by a TextView. Must be called before Show.
@@ -153,7 +160,7 @@ func (om *OverlayManager) buildWidgetRoot(we *widgetEntry, prim tview.Primitive)
 func (om *OverlayManager) Show(name string, state game.GameState) bool {
 	// Try text overlays first.
 	if e, ok := om.entries[name]; ok {
-		e.tv.SetText(e.provide(state))
+		e.tv.SetText(e.provide(state, om.screenW))
 		e.tv.ScrollToBeginning()
 		if om.active != name {
 			if om.active != "" {
@@ -204,7 +211,7 @@ func (om *OverlayManager) Refresh(state game.GameState) {
 	}
 	// Text overlay path.
 	if e, ok := om.entries[om.active]; ok {
-		e.tv.SetText(e.provide(state))
+		e.tv.SetText(e.provide(state, om.screenW))
 		return
 	}
 	// Widget overlay path — use in-place refresh if available, else rebuild.

--- a/ui/overlay_epoch.go
+++ b/ui/overlay_epoch.go
@@ -10,7 +10,7 @@ import (
 
 // epochProvider generates the epoch overlay text from the current game state.
 // Shows current epoch status, epoch history, legacy bonuses, and civilisation log.
-func epochProvider(state game.GameState) string {
+func epochProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 
 	sb.WriteString("[gold]═══ Epoch ═══[-]\n\n")

--- a/ui/overlay_history.go
+++ b/ui/overlay_history.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// historyProvider is the OverlayProvider for the history overlay.
+func historyProvider(state game.GameState) string {
+	return renderHistoryOverlay(state)
+}
+
+func renderHistoryOverlay(state game.GameState) string {
+	if state.History == nil || len(state.History.Samples) < 2 {
+		return "\n[gray] No history yet — play for a while and check back.[-]\n"
+	}
+
+	samples := state.History.Samples
+	n := len(samples)
+	firstTick := samples[0].Tick
+	lastTick := samples[n-1].Tick
+
+	// collect age marker ticks and names
+	var markerTicks []int
+	var markerNames []string
+	for _, m := range state.History.AgeMarkers {
+		markerTicks = append(markerTicks, m.Tick)
+		markerNames = append(markerNames, m.AgeName)
+	}
+
+	const graphW = 58 // braille chars wide
+	const graphH = 4  // rows tall per graph
+
+	ageCols := AgeMarkerCols(markerTicks, firstTick, lastTick, graphW)
+
+	type metricDef struct {
+		label  string
+		color  string
+		values func(game.HistorySample) float64
+		unit   string
+		rate   bool
+	}
+
+	metrics := []metricDef{
+		{"Population", "[cyan]", func(s game.HistorySample) float64 { return s.Population }, "workers", false},
+		{"Food Rate", "[green]", func(s game.HistorySample) float64 { return s.FoodRate }, "/tick", true},
+		{"Knowledge", "[yellow]", func(s game.HistorySample) float64 { return s.KnowRate }, "/tick", true},
+		{"Faith", "[#cc88ff]", func(s game.HistorySample) float64 { return s.Faith }, "", false},
+		{"Prod Bonus", "[orange]", func(s game.HistorySample) float64 { return s.ProdAll * 100 }, "%", false},
+		{"Tick Speed", "[gray]", func(s game.HistorySample) float64 { return s.TickSpeed }, "x", false},
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("\n[gold]═══ Civilization History ═══[-]\n")
+	sb.WriteString(fmt.Sprintf("[gray]Ticks %d – %d  │  %d samples  │  age advances marked │[-]\n\n",
+		firstTick, lastTick, n))
+
+	for _, m := range metrics {
+		vals := make([]float64, n)
+		for i, s := range samples {
+			vals[i] = m.values(s)
+		}
+
+		minV, maxV := vals[0], vals[0]
+		for _, v := range vals {
+			if v < minV {
+				minV = v
+			}
+			if v > maxV {
+				maxV = v
+			}
+		}
+
+		cur := vals[n-1]
+		prev := vals[n-2]
+		trend := "[white]→[-]"
+		if cur > prev*1.02 {
+			trend = "[green]↑[-]"
+		}
+		if cur < prev*0.98 {
+			trend = "[red]↓[-]"
+		}
+
+		curStr := fmtVal(cur)
+		if m.rate {
+			curStr = "+" + curStr
+		}
+
+		// header line
+		sb.WriteString(fmt.Sprintf("%s%-14s[-] %s %s%s  [gray]min:%-8s max:%s[-]\n",
+			m.color, m.label, trend, curStr, m.unit,
+			fmtVal(minV), fmtVal(maxV)))
+
+		// graph lines with y-axis labels
+		lines := BrailleLine(vals, graphW, graphH, ageCols)
+		yLabels := []string{
+			fmt.Sprintf("[gray]%-6s[-]", fmtVal(maxV)),
+			"      ",
+			fmt.Sprintf("[gray]%-6s[-]", fmtVal((maxV+minV)/2)),
+			"      ",
+		}
+		for i, line := range lines {
+			sb.WriteString(fmt.Sprintf("  %s %s%s[-]\n", yLabels[i], m.color, line))
+		}
+		sb.WriteString(fmt.Sprintf("  [gray]%-6s %s[-]\n", fmtVal(minV), strings.Repeat("─", graphW)))
+		sb.WriteString("\n")
+	}
+
+	// x-axis age labels
+	if len(markerNames) > 0 {
+		sb.WriteString("[gray]  Ages: ")
+		for i, name := range markerNames {
+			if i > 0 {
+				sb.WriteString(" → ")
+			}
+			sb.WriteString(name)
+		}
+		sb.WriteString("[-]\n")
+	}
+
+	return sb.String()
+}

--- a/ui/overlay_history.go
+++ b/ui/overlay_history.go
@@ -8,11 +8,11 @@ import (
 )
 
 // historyProvider is the OverlayProvider for the history overlay.
-func historyProvider(state game.GameState) string {
-	return renderHistoryOverlay(state)
+func historyProvider(state game.GameState, w int) string {
+	return renderHistoryOverlay(state, w)
 }
 
-func renderHistoryOverlay(state game.GameState) string {
+func renderHistoryOverlay(state game.GameState, w int) string {
 	if state.History == nil || len(state.History.Samples) < 2 {
 		return "\n[gray] No history yet — play for a while and check back.[-]\n"
 	}
@@ -30,7 +30,11 @@ func renderHistoryOverlay(state game.GameState) string {
 		markerNames = append(markerNames, m.AgeName)
 	}
 
-	const graphW = 58 // braille chars wide
+	// 85% overlay, minus y-axis label (8 chars), border/padding (6 chars)
+	graphW := int(float64(w)*0.85) - 14
+	if graphW < 20 {
+		graphW = 20
+	}
 	const graphH = 4  // rows tall per graph
 
 	ageCols := AgeMarkerCols(markerTicks, firstTick, lastTick, graphW)

--- a/ui/overlay_logs.go
+++ b/ui/overlay_logs.go
@@ -9,7 +9,7 @@ import (
 
 // logsProvider generates the logs overlay text from the current game state.
 // Shows the last ~50 game log entries, skipping debug entries, newest at the bottom.
-func logsProvider(state game.GameState) string {
+func logsProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 
 	sb.WriteString("[gold]═══ Game Log ═══[-]\n\n")

--- a/ui/overlay_milestones.go
+++ b/ui/overlay_milestones.go
@@ -11,7 +11,7 @@ import (
 // milestonesProvider generates the milestones overlay text from the current game state.
 // This is lifted from StatsTab.refreshMilestones — identical logic, returning a string
 // instead of calling SetText on a TextView.
-func milestonesProvider(state game.GameState) string {
+func milestonesProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 	ms := state.Milestones
 

--- a/ui/overlay_military.go
+++ b/ui/overlay_military.go
@@ -10,7 +10,7 @@ import (
 
 // militaryProvider generates the military overlay text from the current game state.
 // It mirrors the logic from MilitaryTab.Refresh — same data, formatted as plain text.
-func militaryProvider(state game.GameState) string {
+func militaryProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 	mil := state.Military
 

--- a/ui/overlay_research.go
+++ b/ui/overlay_research.go
@@ -36,7 +36,7 @@ func formatTechEffect(eff config.Effect) string {
 // Tech visibility rules: researched=green ✓, in-progress=yellow ⟳,
 // available=cyan ○, prereqs-met-but-age-locked=gray ○ (age locked),
 // locked=gray • with prerequisite names shown.
-func researchProvider(state game.GameState) string {
+func researchProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 
 	allTechs := config.TechByKey()

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -11,7 +11,7 @@ import (
 
 // statsProvider generates the stats overlay text from the current game state.
 // Covers: game statistics, active epoch events, and prestige upgrades/points.
-func statsProvider(state game.GameState) string {
+func statsProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 
 	// ─── Statistics ───

--- a/ui/overlay_trade.go
+++ b/ui/overlay_trade.go
@@ -10,7 +10,7 @@ import (
 
 // tradeProvider generates the trade overlay text from the current game state.
 // It mirrors the logic from TradeTab.Refresh — same data, formatted as plain text.
-func tradeProvider(state game.GameState) string {
+func tradeProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 	trade := state.Trade
 

--- a/ui/overlay_wonders.go
+++ b/ui/overlay_wonders.go
@@ -10,7 +10,7 @@ import (
 
 // wondersProvider generates the wonders overlay text from the current game state.
 // Text-only — no pixel art images. Shows wonder name, age, description, effects, and build status.
-func wondersProvider(state game.GameState) string {
+func wondersProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 
 	wonders := getWonderList()


### PR DESCRIPTION
## Summary

Two related changes in one PR: a new civilization history overlay, and a fix to the overlay system so all panels adapt to the actual terminal width.

---

## 1. Civilization History Overlay (new feature)

Adds a `history` command that opens a scrollable overlay showing braille line graphs of 6 key civilization metrics over time.

- **Braille line renderer** (`ui/braille.go`) — smooth connected line plots using Unicode braille characters (U+2800), 2×4 dot resolution per character
- **6 tracked metrics** — Population, Food Rate, Knowledge Rate, Faith, Production Bonus, Tick Speed — each with current value, trend arrow (↑↓→), and min/max labels
- **Age advances** shown as `│` markers across all graphs simultaneously
- **HistoryCollector** (`game/history.go`) — ring buffer of 300 samples every 10 ticks (~30s before first graph, ~1h rolling history)
- **Persisted to save JSON** — history survives restarts; old saves initialise with an empty collector
- `history` added to tab autocomplete

## 2. Dynamic overlay width (UI fix)

Previously all text overlays had a hardcoded graph/content width. The `OverlayProvider` function signature now receives the current terminal width:

```go
// before
type OverlayProvider func(state game.GameState) string
// after  
type OverlayProvider func(state game.GameState, w int) string
```

- `OverlayManager` captures real screen width each frame via `app.SetBeforeDrawFunc`
- History overlay uses width to compute `graphW` dynamically — graphs fill the full 85% overlay panel regardless of terminal size
- All other providers updated with `_ int` (unused but correct signature)

## Files

| File | Role |
|---|---|
| `game/history.go` | HistoryCollector, HistorySample, AgeMarker |
| `ui/braille.go` | BrailleLine renderer, AgeMarkerCols, fmtVal |
| `ui/overlay_history.go` | 6 braille graphs, dynamic graphW from terminal width |
| `ui/overlay.go` | OverlayProvider signature + screenW via SetBeforeDrawFunc |
| `ui/overlay_*.go` (8 files) | Signature updated to accept `_ int` |
| `game/engine.go` | History field, sampling, EventAgeAdvanced subscription |
| `game/types.go` | History in GameState |
| `game/save.go` | History serialised/restored |
| `ui/dashboard.go` | Overlay registered |
| `ui/input.go` | `history` command routed |
| `ui/autocomplete.go` | `history` in command list |

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] Run game, wait ~30s, type `history` — graphs fill overlay width
- [x] Resize terminal — graphs reflow to new width on next open
- [x] Advance an age — `│` markers appear on all 6 graphs
- [x] Save and reload — history data persists
- [x] ESC closes overlay, all other overlays (stats, wonders, epoch etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)