### PR TITLE
feat: wonder completion required to advance ages

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -1469,6 +1469,13 @@ func (ge *GameEngine) AdvanceAge() error {
 	if !ge.ageReady {
 		nextAge := ge.progress.CheckAdvancement(ge.age, ge.Resources, ge.Buildings)
 		if nextAge == "" {
+			// Check if wonder is the only blocker
+			wonderKey := ge.progress.WonderForAge(ge.age)
+			if wonderKey != "" && ge.Buildings.GetCount(wonderKey) < 1 {
+				if def, ok := ge.Buildings.defs[wonderKey]; ok {
+					return fmt.Errorf("you must complete the %s wonder before advancing — use 'wonder collect' then 'build %s'", def.Name, wonderKey)
+				}
+			}
 			return fmt.Errorf("age requirements not met yet — check the Stats tab for what's needed")
 		}
 	}
@@ -2075,15 +2082,28 @@ func (ge *GameEngine) GetState() GameState {
 		tickInterval = MinTickInterval
 	}
 
+	// Wonder gate: show which wonder must be built before advancing
+	wonderKey := ge.progress.WonderForAge(ge.age)
+	currentAgeWonderKey := ""
+	currentAgeWonderName := ""
+	if wonderKey != "" && ge.Buildings.GetCount(wonderKey) < 1 {
+		currentAgeWonderKey = wonderKey
+		if def, ok := ge.Buildings.defs[wonderKey]; ok {
+			currentAgeWonderName = def.Name
+		}
+	}
+
 	return GameState{
-		Tick:           ge.tick,
-		Age:            ge.age,
-		AgeName:        ge.progress.GetAgeName(ge.age),
-		AgeReady:       ge.ageReady,
-		NextAge:        nextAge,
-		NextAgeName:    nextAgeName,
-		NextAgeResReqs: nextAgeResReqs,
-		NextAgeBldReqs: nextAgeBldReqs,
+		Tick:                 ge.tick,
+		Age:                  ge.age,
+		AgeName:              ge.progress.GetAgeName(ge.age),
+		AgeReady:             ge.ageReady,
+		CurrentAgeWonderKey:  currentAgeWonderKey,
+		CurrentAgeWonderName: currentAgeWonderName,
+		NextAge:              nextAge,
+		NextAgeName:          nextAgeName,
+		NextAgeResReqs:       nextAgeResReqs,
+		NextAgeBldReqs:       nextAgeBldReqs,
 		Resources:      ge.Resources.Snapshot(),
 		Buildings:      ge.Buildings.Snapshot(ge.Resources, ge.buildQueue, ge.Workers.GetAssignedCount),
 		BuildQueue:     queue,

--- a/game/progress.go
+++ b/game/progress.go
@@ -4,8 +4,9 @@ import "github.com/espresso20/ageforge/config"
 
 // ProgressManager handles age progression
 type ProgressManager struct {
-	ages     []config.AgeDef
-	ageIndex map[string]int
+	ages       []config.AgeDef
+	ageIndex   map[string]int
+	ageWonders map[string]string // ageKey -> wonder building key (or "")
 }
 
 // NewProgressManager creates a new progress manager
@@ -15,7 +16,17 @@ func NewProgressManager() *ProgressManager {
 	for i, a := range ages {
 		idx[a.Key] = i
 	}
-	return &ProgressManager{ages: ages, ageIndex: idx}
+	pm := &ProgressManager{ages: ages, ageIndex: idx, ageWonders: make(map[string]string)}
+	allBuildings := config.BuildingByKey()
+	for _, age := range ages {
+		for _, bKey := range age.UnlockBuildings {
+			if def, ok := allBuildings[bKey]; ok && def.Category == "wonder" {
+				pm.ageWonders[age.Key] = bKey
+				break
+			}
+		}
+	}
+	return pm
 }
 
 // GetAgeName returns the display name for an age key
@@ -53,7 +64,18 @@ func (pm *ProgressManager) CheckAdvancement(currentKey string, resources *Resour
 			return ""
 		}
 	}
+	// Require current age's wonder to be built before advancing
+	if wonderKey := pm.ageWonders[currentKey]; wonderKey != "" {
+		if buildings.GetCount(wonderKey) < 1 {
+			return ""
+		}
+	}
 	return nextKey
+}
+
+// WonderForAge returns the wonder building key for the given age, or "" if none.
+func (pm *ProgressManager) WonderForAge(ageKey string) string {
+	return pm.ageWonders[ageKey]
 }
 
 // GetUnlocks returns what an age unlocks

--- a/game/types.go
+++ b/game/types.go
@@ -7,7 +7,9 @@ type GameState struct {
 	Tick           int
 	Age            string
 	AgeName        string
-	AgeReady       bool   // requirements met — player can type 'advance' to proceed
+	AgeReady            bool   // requirements met — player can type 'advance' to proceed
+	CurrentAgeWonderKey  string // wonder key required before advancing; "" if none or already built
+	CurrentAgeWonderName string // display name of that wonder
 	NextAge        string
 	NextAgeName    string
 	NextAgeResReqs map[string]float64

--- a/site/docs/ages.md
+++ b/site/docs/ages.md
@@ -1,6 +1,10 @@
 # The 22 Ages
 
-AgeForge spans 22 ages from primitive survival to transcendence. Each age unlocks new buildings, resources, and worker domains. Advancement is automatic once requirements are met.
+AgeForge spans 22 ages from primitive survival to transcendence. Each age unlocks new buildings, resources, and worker domains. Advancement requires meeting all resource and building requirements **and** completing the age's wonder.
+
+## Wonder Requirement
+
+Each age unlocks exactly one wonder building. You must **build that wonder** before you can advance to the next age — it is a hard requirement alongside the resource and building thresholds listed below. The age progress bar will show a red `✗ Wonder required: <name>` notice until it is complete. See [Wonders](wonders.md) for build costs and instructions.
 
 ## Epoch Overview
 

--- a/site/docs/wonders.md
+++ b/site/docs/wonders.md
@@ -17,6 +17,16 @@ Progress is shown in the **Wonders** overlay (`wonders`) with per-resource progr
 
 ---
 
+## Wonders and Age Advancement
+
+Completing a wonder is **required** to advance to the next age. Each age unlocks one wonder — you cannot type `advance` until that wonder is built.
+
+The wonder requirement appears in the **age progress bar** at the top of the screen alongside your other advancement requirements. If the wonder is still missing, you will see a red notice: `✗ Wonder required: <name>`.
+
+If you try to advance before completing your age's wonder, the game will tell you which wonder is blocking and remind you to use `wonder collect` then `build <key>`.
+
+---
+
 ## Wonder list
 
 ### 🌿 Sacred Grove

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -574,6 +574,11 @@ func (d *Dashboard) refreshAgeProgress(state game.GameState) {
 		}
 	}
 
+	// Wonder gate: show if current age wonder must still be completed
+	if state.CurrentAgeWonderKey != "" {
+		fmt.Fprintf(&sb, "[red]✗ Wonder required: %s[-]  ", state.CurrentAgeWonderName)
+	}
+
 	d.ageTV.SetText(sb.String())
 }
 


### PR DESCRIPTION
## Summary

- Wonders are now a **hard gate** for age advancement — you cannot `advance` until the current age's wonder is built
- `CheckAdvancement` in `ProgressManager` blocks until `GetCount(wonderKey) >= 1`
- Age progress bar shows `✗ Wonder required: <name>` in red until complete
- `advance` command returns a targeted error naming the blocking wonder and reminding the player to use `wonder collect` + `build <key>`
- `GameState` exposes `CurrentAgeWonderKey` / `CurrentAgeWonderName` for UI use
- Wiki updated: `wonders.md` and `ages.md` document the new requirement

## Test plan

- [ ] Start a new game — age progress bar shows the current wonder requirement
- [ ] Type `advance` before building the wonder — error names the specific wonder
- [ ] Complete the wonder — `✗ Wonder required` notice disappears from the progress bar
- [ ] Verify `advance` succeeds once wonder + resource/building reqs are all met
- [ ] Ages with no wonder (e.g. Primitive Age) still advance normally on resource/building reqs alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)