### PR TITLE
fix: add morale panel to workers overlay

### DIFF
--- a/ui/overlay_workers.go
+++ b/ui/overlay_workers.go
@@ -35,6 +35,27 @@ func workersProvider(state game.GameState, _ int) string {
 	idle := wt.IdleCount
 	housingLeft := maxPop - total
 
+	// ── Morale ───────────────────────────────────
+	sb.WriteString(workerSection("Morale"))
+	moraleColor := "green"
+	if state.Morale < 0.50 {
+		moraleColor = "red"
+	} else if state.Morale < 0.80 {
+		moraleColor = "yellow"
+	}
+	moraleBar := assignBar(int(state.Morale*20), 20, 20)
+	capStr := ""
+	if state.MoraleCap > 1.0 {
+		capStr = fmt.Sprintf("  [gray]cap: %.2f[-]", state.MoraleCap)
+	}
+	fmt.Fprintf(&sb, "  [white]Morale:[white] [%s]%.0f%%[-]%s  %s\n", moraleColor, state.Morale*100, capStr, moraleBar)
+	if state.Morale < 1.0 {
+		fmt.Fprintf(&sb, "  [%s]⚠ Output penalty active — all worker production ×%.0f%%[-]\n", moraleColor, state.Morale*100)
+	} else {
+		fmt.Fprint(&sb, "  [green]✓ Full output[-]\n")
+	}
+	sb.WriteString("\n")
+
 	// ── Summary ──────────────────────────────────
 	sb.WriteString(workerSection("Summary"))
 	fmt.Fprintf(&sb, "  [white]Pop:[white] [yellow]%d[white] / [green]%d[-]   [white]Idle:[white] [cyan]%d[-]   [white]Housing left:[white] [green]%d[-]\n",


### PR DESCRIPTION
## Summary
- Morale section was missing from the `workers` overlay — it was implemented in the engine and villager panel but `overlay_workers.go` was created on a separate branch before the morale PR landed, so it never got the display

## What it adds
A **Morale** panel at the top of the workers overlay showing:
- Color-coded morale % (green ≥80%, yellow 50–79%, red <50%)
- Fill bar (20-step)
- Wonder cap displayed when above 1.0
- Output penalty warning with exact multiplier when below 100%
- "✓ Full output" confirmation when at cap

## Test plan
- [ ] Open `workers` overlay — morale section should appear above Summary
- [ ] Verify color changes at 80% and 50% thresholds
- [ ] Build a wonder — cap should show as 1.05
- [ ] Let food go negative — morale drains, warning shows penalty %

🤖 Generated with [Claude Code](https://claude.com/claude-code)