### PR TITLE
fix: changelog page hangs — switch from GitHub API to raw CHANGELOG.md

### DIFF
--- a/site/changelog.html
+++ b/site/changelog.html
@@ -178,20 +178,49 @@
 
         <!-- ═══ SCRIPTS ══════════════════════════════════════════════════ -->
         <script>
-        const REPO = "espresso20/ageforge";
-        const API  = `https://api.github.com/repos/${REPO}/releases?per_page=30`;
+        const REPO     = "espresso20/ageforge";
+        const RAW_URL  = `https://raw.githubusercontent.com/${REPO}/master/CHANGELOG.md`;
+        const GH_RELEASES = `https://github.com/${REPO}/releases`;
 
-        // Very small markdown-to-HTML converter for release body content.
-        function renderMarkdown(md) {
+        function escHtml(s) {
+            return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+        }
+
+        // Parse CHANGELOG.md into an array of {version, date, body} objects.
+        // Handles entries like:  ## [v3.3.0] — 2026-03-18
+        function parseChangelog(text) {
+            const entries = [];
+            const sections = text.split(/^## /m).slice(1); // drop header before first ##
+
+            for (const section of sections) {
+                const lines = section.split("\n");
+                const heading = lines[0].trim();
+
+                // Skip [Unreleased]
+                if (/unreleased/i.test(heading)) continue;
+
+                // Extract version + date from:  [v3.3.0] — 2026-03-18
+                const m = heading.match(/\[([^\]]+)\](?:\s*[—-]+\s*(\S+))?/);
+                if (!m) continue;
+
+                const version = m[1];
+                const date    = m[2] || "";
+                const body    = lines.slice(1).join("\n").replace(/^---\s*$/m, "").trim();
+
+                entries.push({ version, date, body });
+            }
+            return entries;
+        }
+
+        // Convert the body of a changelog entry (### sections + lists) to HTML.
+        function renderBody(md) {
             if (!md) return "<em style='color:var(--muted)'>No notes for this release.</em>";
             const lines = md.split("\n");
             let html = "";
             let inList = false;
 
-            for (let raw of lines) {
+            for (const raw of lines) {
                 const line = raw.trimEnd();
-
-                // h3
                 if (/^### (.+)/.test(line)) {
                     if (inList) { html += "</ul>"; inList = false; }
                     const text = line.replace(/^### /, "");
@@ -200,76 +229,72 @@
                     if (/fixed/i.test(text))   cls = "sec-fixed";
                     if (/changed/i.test(text)) cls = "sec-changed";
                     html += `<h3 class="${cls}">${escHtml(text)}</h3>`;
-                    continue;
-                }
-                // h2
-                if (/^## (.+)/.test(line)) {
-                    if (inList) { html += "</ul>"; inList = false; }
-                    html += `<h3 class="sec-other">${escHtml(line.replace(/^## /, ""))}</h3>`;
-                    continue;
-                }
-                // list item
-                if (/^[-*] (.+)/.test(line)) {
+                } else if (/^[-*] (.+)/.test(line)) {
                     if (!inList) { html += "<ul>"; inList = true; }
                     html += `<li>${escHtml(line.replace(/^[-*] /, ""))}</li>`;
-                    continue;
-                }
-                // blank line
-                if (line === "") {
+                } else if (line === "") {
                     if (inList) { html += "</ul>"; inList = false; }
-                    continue;
+                } else {
+                    if (inList) { html += "</ul>"; inList = false; }
+                    html += `<p>${escHtml(line)}</p>`;
                 }
-                // paragraph
-                if (inList) { html += "</ul>"; inList = false; }
-                html += `<p>${escHtml(line)}</p>`;
             }
             if (inList) html += "</ul>";
             return html;
         }
 
-        function escHtml(s) {
-            return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
-        }
-
         function fmtDate(iso) {
+            if (!iso) return "";
             const d = new Date(iso);
-            return d.toLocaleDateString("en-US", { year:"numeric", month:"long", day:"numeric" });
+            return isNaN(d) ? iso : d.toLocaleDateString("en-US", { year:"numeric", month:"long", day:"numeric" });
         }
 
-        async function loadReleases() {
+        async function loadChangelog() {
             const feed = document.getElementById("cl-feed");
-            try {
-                const res = await fetch(API, {
-                    headers: { Accept: "application/vnd.github+json" }
-                });
-                if (!res.ok) throw new Error(`GitHub API ${res.status}`);
-                const releases = await res.json();
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 8000);
 
-                if (!releases.length) {
+            try {
+                const res = await fetch(RAW_URL, { signal: controller.signal });
+                clearTimeout(timeout);
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const text = await res.text();
+                const entries = parseChangelog(text);
+
+                if (!entries.length) {
                     feed.innerHTML = `<div class="cl-empty">No releases yet.</div>`;
                     return;
                 }
 
-                feed.innerHTML = releases.map(r => `
+                feed.innerHTML = entries.map(e => `
                     <article class="cl-entry">
                         <div>
-                            <span class="cl-tag">${escHtml(r.tag_name)}</span>
-                            <span class="cl-date">${fmtDate(r.published_at)}</span>
+                            <span class="cl-tag">${escHtml(e.version)}</span>
+                            ${e.date ? `<span class="cl-date">${escHtml(fmtDate(e.date))}</span>` : ""}
                         </div>
-                        <div class="cl-body">${renderMarkdown(r.body)}</div>
+                        <div class="cl-body">${renderBody(e.body)}</div>
                         <a class="cl-gh-link"
-                           href="${escHtml(r.html_url)}"
+                           href="${GH_RELEASES}/tag/${encodeURIComponent(e.version)}"
                            target="_blank" rel="noopener">
                             View on GitHub ↗
                         </a>
                     </article>
                 `).join("");
             } catch (err) {
-                feed.innerHTML = `<div class="cl-error">Could not load releases: ${escHtml(err.message)}</div>`;
+                clearTimeout(timeout);
+                const msg = err.name === "AbortError" ? "Request timed out." : escHtml(err.message);
+                feed.innerHTML = `
+                    <div class="cl-error">
+                        Could not load changelog: ${msg}<br><br>
+                        <a href="${GH_RELEASES}" target="_blank" rel="noopener"
+                           style="color:var(--muted);text-decoration:underline">
+                            View releases on GitHub ↗
+                        </a>
+                    </div>`;
             }
         }
 
-        loadReleases();
+        loadChangelog();
         </script>
     </body>
 </html>


### PR DESCRIPTION
## Problem
The changelog page fetches from the GitHub Releases API, which is rate-limited at **60 unauthenticated requests/hour**. Once hit, the fetch either hangs indefinitely (no timeout was set) or returns a 403 — leaving the page stuck on "Loading releases…"

## Fix
- Fetch `CHANGELOG.md` directly from `raw.githubusercontent.com` — no rate limits for public repos
- Parse the `## [vX.Y.Z] — YYYY-MM-DD` format client-side (already used by our release process)
- Add an **8-second `AbortController` timeout** so failure is fast, not a forever spin
- Error fallback now shows a direct link to GitHub releases page

## Test plan
- [ ] Load changelog page — should render immediately
- [ ] All versions, dates, and section headers (Added/Fixed/Changed) should display correctly
- [ ] Disconnect from internet — should show error + GitHub fallback link within 8 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)