### PR TITLE
fix: correct energy and metallurgy lineage production rates on upgrade

### DIFF
--- a/config/buildings_lineage_energy.go
+++ b/config/buildings_lineage_energy.go
@@ -13,6 +13,8 @@ func buildingsLineageEnergy() []BuildingDef {
 	// =========================================================================
 
 	// tier 0 — industrial_age  output=coal  rate=10
+	// Resource pivot note: coal_plant (coal) → steam_turbine (electricity+coal bonus)
+	// Validator will show HIGH_BOOST on this transition — intentional cross-resource pivot.
 	b = append(b, BuildingDef{
 		Name: "Coal Plant", Key: "coal_plant", Category: "production",
 		BaseCost:    map[string]float64{"steel": 22e6, "coal": 8e6, "gold": 12e6},
@@ -156,20 +158,28 @@ func buildingsLineageEnergy() []BuildingDef {
 		WorkerDomain: "energy", WorkerCapacity: 16,
 		EpochKey: "neon_era", OutputResource: "plasma",
 	})
-	// tier 10 — interstellar_age  output=plasma  rate=80
+	// tier 10 — interstellar_age  output=plasma  rate=80  (+ electricity continuation)
+	// Resource pivot: plasma remains primary; electricity secondary continues from solar_collector_array
+	// solar_collector_array: plasma:40 + electricity:2500 → pulsar_tap: plasma:80 + electricity:3200
 	b = append(b, BuildingDef{
 		Name: "Pulsar Tap", Key: "pulsar_tap", Category: "production",
-		BaseCost:    map[string]float64{"dark_matter": 110e12, "titanium": 840e12, "plasma": 520e12},
-		CostScale:   1.35,
-		Effects:     []Effect{{Type: "production", Target: "plasma", Value: 80}},
+		BaseCost: map[string]float64{"dark_matter": 110e12, "titanium": 840e12, "plasma": 520e12},
+		CostScale: 1.35,
+		Effects: []Effect{
+			{Type: "production", Target: "plasma", Value: 80},
+			{Type: "production", Target: "electricity", Value: 3200},
+		},
 		BuildTicks:  2500000,
 		RequiredAge: "interstellar_age",
-		Description: "Taps pulsar radiation for plasma energy. +80 plasma/tick (18 workers).",
+		Description: "Taps pulsar radiation for plasma and electricity. +80 plasma, +3200 electricity/tick (18 workers).",
 		LineageKey:  "energy", LineageTier: 10,
 		WorkerDomain: "energy", WorkerCapacity: 18,
 		EpochKey: "cosmic_era", OutputResource: "plasma",
 	})
 	// tier 11 — galactic_age  output=dark_matter  rate=10
+	// Resource pivot: plasma → dark_matter. Validator shows LOW boost — intentional cross-resource pivot.
+	// dark_matter rate of 10 is deliberately low (dark_matter is a tier-7 resource; starts at 1/tick in metallurgy).
+	// quasar_tap → zero_point_generator jumps 5x (dark_matter:10 → quantum_flux:50) — also an intentional pivot.
 	b = append(b, BuildingDef{
 		Name: "Quasar Tap", Key: "quasar_tap", Category: "production",
 		BaseCost:    map[string]float64{"antimatter": 220e12, "dark_matter": 1.1e15, "titanium": 5.5e15},

--- a/config/buildings_lineage_metallurgy.go
+++ b/config/buildings_lineage_metallurgy.go
@@ -55,6 +55,8 @@ func buildingsLineageMetallurgy() []BuildingDef {
 		EpochKey: "iron_era", OutputResource: "iron",
 	})
 	// tier 3 — renaissance_age  output=steel  rate=0.50
+	// Resource pivot: iron → steel. Validator shows LOW boost (iron:0.40 → steel:0.50) — intentional.
+	// Steel is a higher-tier resource; the rate reset to 0.50 is correct for the new tier.
 	b = append(b, BuildingDef{
 		Name: "Foundry", Key: "foundry", Category: "production",
 		BaseCost:    map[string]float64{"gold": 650000, "steel": 220000, "coal": 80000},
@@ -133,6 +135,8 @@ func buildingsLineageMetallurgy() []BuildingDef {
 		EpochKey: "electric_era", OutputResource: "steel",
 	})
 	// tier 9 — modern_age  output=titanium  rate=0.50 (reset for new metal)
+	// Resource pivot: steel → titanium. Validator shows 0.03x (steel:16 → titanium:0.50) — intentional.
+	// Titanium is a tier-5 resource; starting rate 0.50 matches the iron/steel pivot pattern.
 	b = append(b, BuildingDef{
 		Name: "Titanium Smelter", Key: "titanium_smelter", Category: "production",
 		BaseCost:    map[string]float64{"steel": 34e9, "electricity": 13e9, "data": 1.2e9},
@@ -172,6 +176,8 @@ func buildingsLineageMetallurgy() []BuildingDef {
 		EpochKey: "digital_era", OutputResource: "titanium",
 	})
 	// tier 12 — cyberpunk_age  output=dark_matter  rate=1.0 (new material)
+	// Resource pivot: titanium → dark_matter. Validator shows 0.50x (titanium:2.0 → dark_matter:1.0) — intentional.
+	// dark_matter is a tier-7 resource; starting at 1.0/tick is correct.
 	b = append(b, BuildingDef{
 		Name: "Dark Matter Refinery", Key: "dark_matter_refinery", Category: "production",
 		BaseCost:    map[string]float64{"data": 220e9, "crypto": 1.15e12, "electricity": 2.3e12},
@@ -211,6 +217,8 @@ func buildingsLineageMetallurgy() []BuildingDef {
 		EpochKey: "neon_era", OutputResource: "dark_matter",
 	})
 	// tier 15 — interstellar_age  output=antimatter  rate=2.0 (new material)
+	// Resource pivot: dark_matter → antimatter. Validator shows 0.50x (dark_matter:4.0 → antimatter:2.0) — intentional.
+	// antimatter is a tier-8 resource; starting at 2.0/tick matches cosmic-era rarity.
 	b = append(b, BuildingDef{
 		Name: "Antimatter Forge", Key: "antimatter_forge", Category: "production",
 		BaseCost:    map[string]float64{"dark_matter": 105e12, "titanium": 820e12, "plasma": 510e12},
@@ -237,6 +245,8 @@ func buildingsLineageMetallurgy() []BuildingDef {
 		EpochKey: "cosmic_era", OutputResource: "antimatter",
 	})
 	// tier 17 — quantum_age  output=quantum_flux  rate=4.0
+	// Resource pivot: antimatter → quantum_flux. Validator shows 1.00x (antimatter:4.0 → quantum_flux:4.0) — intentional.
+	// quantum_flux is the terminal resource; matching antimatter rate is the intended cap.
 	b = append(b, BuildingDef{
 		Name: "Quantum Metal Works", Key: "quantum_metal_works", Category: "production",
 		BaseCost:    map[string]float64{"quantum_flux": 225e12, "antimatter": 67e15, "dark_matter": 57e15},


### PR DESCRIPTION
## Summary

- **Real bug fixed**: `pulsar_tap` was missing its electricity secondary output, causing players who upgraded from `solar_collector_array` to lose all 2500 electricity/tick. `pulsar_tap` now produces plasma:80 + electricity:3200, giving a proper ~1.3x upgrade boost instead of 0.03x.
- **Intentional resource pivots documented**: All other low/high validator boost flags in both lineages are cross-resource pivot artifacts — the validator sums all effect values regardless of resource type. Each pivot point now has an explanatory comment in the lineage file.

## Transitions investigated and their resolution

| Transition | Validator showed | Resolution |
|---|---|---|
| `coal_plant → steam_turbine` | HIGH_BOOST 5.5x | Intentional pivot (coal→electricity). Comment added. |
| `nuclear_reactor → oil_refinery` | 1.35x (was 0.60x) | Already fixed; oil_refinery has electricity:250 continuation. |
| `fusion_reactor_array → solar_collector_array` | 1.26x (was 0.02x) | Already fixed. |
| `solar_collector_array → pulsar_tap` | **0.03x → 1.29x** | **Bug fixed**: added electricity:3200 to pulsar_tap. |
| `pulsar_tap → quasar_tap` | 0.12x / 0.00x | Intentional pivot (plasma→dark_matter). Comment added. |
| `augmentation_foundry → fusion_reactor` | 2.00x (was 0.03x) | Already fixed in engineering lineage. |
| Metallurgy pivots (iron→steel, steel→titanium, etc.) | 0.03x–0.50x | All intentional resource tier pivots. Comments added. |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Validator confirms `solar_collector_array → pulsar_tap` now shows 1.29x boost
- [ ] In-game: upgrade `solar_collector_array` to `pulsar_tap` and verify electricity production does not drop

Closes https://trello.com/c/fxeeYVwV

🤖 Generated with [Claude Code](https://claude.com/claude-code)