### PR TITLE
fix: city map only renders buildings from the current age

### DIFF
--- a/ui/map.go
+++ b/ui/map.go
@@ -1666,10 +1666,16 @@ func v4GetBuildings(state game.GameState, params v4DensityParams) []v4Building {
 		}
 		isWonder := false
 		isStorage := false
-		if def, ok := config.BuildingByKey()[key]; ok && def.Category == "wonder" {
+		def, defOk := config.BuildingByKey()[key]
+		if defOk && def.Category == "wonder" {
 			isWonder = true
 		} else if len(key) >= 6 && key[len(key)-6:] == "wonder" {
 			isWonder = true
+		}
+		// Only render buildings that belong to the current age.
+		// If RequiredAge is empty (untagged building), include it as a fallback.
+		if defOk && def.RequiredAge != "" && def.RequiredAge != state.Age {
+			continue
 		}
 		// Wonders are rendered separately in the bottom strip — exclude from city slots.
 		if isWonder {


### PR DESCRIPTION
## Summary
- `v4GetBuildings` in `ui/map.go` was iterating all accumulated `state.Buildings` counts, causing buildings from previous ages (e.g. `gathering_camp`, `hut` from `primitive_age`) to continue rendering on the city map after advancing to a new age.
- Added a `def.RequiredAge == state.Age` guard after the existing `bs.Count == 0` check. Buildings without a `RequiredAge` tag (empty string) are included as a safe fallback rather than silently dropped.
- Refactored the inline `def, ok := config.BuildingByKey()[key]` from within the wonder-category if-condition into a standalone lookup so it can be reused for the age filter.

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./...`
- [ ] Start game in `primitive_age` — only primitive_age buildings appear on the map
- [ ] Advance to `stone_age` — map shows only stone_age buildings; primitive ones are gone
- [ ] Wonders continue to render only in the wonder strip (unchanged behavior)

Closes https://trello.com/c/xqHcTxTo

🤖 Generated with [Claude Code](https://claude.com/claude-code)