### PR TITLE
fix: wonder multiplier bonuses now appear in Active Multipliers

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -639,8 +639,9 @@ func (ge *GameEngine) processEvents() {
 // processExpeditions handles military expedition progress
 func (ge *GameEngine) processExpeditions() {
 	prestigeBonuses := ge.Prestige.GetBonuses()
-	militaryBonus := ge.Research.GetBonus("military_power") + ge.permanentBonuses["military_power"] + prestigeBonuses["military_power"]
-	expeditionBonus := ge.Research.GetBonus("expedition_reward") + ge.permanentBonuses["expedition_reward"] + prestigeBonuses["expedition_reward"]
+	wonderBonuses := ge.getWonderBonuses()
+	militaryBonus := ge.Research.GetBonus("military_power") + ge.permanentBonuses["military_power"] + prestigeBonuses["military_power"] + wonderBonuses["military_power"]
+	expeditionBonus := ge.Research.GetBonus("expedition_reward") + ge.permanentBonuses["expedition_reward"] + prestigeBonuses["expedition_reward"] + wonderBonuses["expedition_reward"]
 
 	if ge.Military.active != nil {
 		ge.addLog("debug", fmt.Sprintf("Expedition: %s %d ticks left", ge.Military.active.Name, ge.Military.active.TicksLeft))
@@ -799,6 +800,13 @@ func (ge *GameEngine) recalculateRates() {
 	}
 	// Add prestige bonuses
 	for k, v := range ge.Prestige.GetBonuses() {
+		permanentBonuses[k] += v
+	}
+	// Add wonder bonus effects (Type "bonus" — multipliers such as production_all,
+	// knowledge_rate, expedition_reward). These are computed dynamically from built
+	// wonders each tick rather than stored in permanentBonuses so that save/load
+	// and prestige resets don't require special migration logic.
+	for k, v := range ge.getWonderBonuses() {
 		permanentBonuses[k] += v
 	}
 
@@ -1402,6 +1410,31 @@ func (ge *GameEngine) reapplyLegacyBonuses() {
 			ge.permanentBonuses[res+"_rate"] += mult
 		}
 	}
+}
+
+// getWonderBonuses returns a map of bonus-type effects from all currently built
+// wonders (those with count > 0). Effects with Type "bonus" represent percentage
+// multipliers (e.g. production_all, knowledge_rate, expedition_reward) rather
+// than flat resource production rates. The returned map is keyed by Target and
+// holds the summed Value across all built wonders.
+// Must be called with the engine lock held.
+func (ge *GameEngine) getWonderBonuses() map[string]float64 {
+	out := make(map[string]float64)
+	for key, count := range ge.Buildings.counts {
+		if count == 0 {
+			continue
+		}
+		def, ok := ge.Buildings.defs[key]
+		if !ok || def.Category != "wonder" {
+			continue
+		}
+		for _, eff := range def.Effects {
+			if eff.Type == "bonus" {
+				out[eff.Target] += eff.Value * float64(count)
+			}
+		}
+	}
+	return out
 }
 
 // Endure executes the Endure consequences for the pending catastrophe:
@@ -2304,8 +2337,9 @@ func (ge *GameEngine) GetState() GameState {
 	soldierCount := ge.Workers.GetDomainCount("military")
 	knowledgeCount := ge.Workers.GetDomainCount("knowledge")
 	prestigeBonuses := ge.Prestige.GetBonuses()
-	militaryBonus := ge.Research.GetBonus("military_power") + ge.permanentBonuses["military_power"] + prestigeBonuses["military_power"]
-	expeditionBonus := ge.Research.GetBonus("expedition_reward") + ge.permanentBonuses["expedition_reward"] + prestigeBonuses["expedition_reward"]
+	wonderBonuses := ge.getWonderBonuses()
+	militaryBonus := ge.Research.GetBonus("military_power") + ge.permanentBonuses["military_power"] + prestigeBonuses["military_power"] + wonderBonuses["military_power"]
+	expeditionBonus := ge.Research.GetBonus("expedition_reward") + ge.permanentBonuses["expedition_reward"] + prestigeBonuses["expedition_reward"] + wonderBonuses["expedition_reward"]
 
 	// Prestige snapshot with pending points
 	prestigeSnap := ge.Prestige.Snapshot()

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -276,6 +276,29 @@ func statsProvider(state game.GameState, _ int) string {
 		bonuses["speed_multiplier"].wonders += state.SpeedMultiplier - 1.0
 	}
 
+	// 6. Wonder bonus effects (Type "bonus" — production_all, knowledge_rate, expedition_reward, etc.)
+	// Iterate all built wonders and accumulate their percentage/multiplier bonuses.
+	buildingDefs := config.BaseBuildings()
+	buildingDefsByKey := make(map[string]config.BuildingDef, len(buildingDefs))
+	for _, bd := range buildingDefs {
+		buildingDefsByKey[bd.Key] = bd
+	}
+	for bKey, bState := range state.Buildings {
+		if bState.Count == 0 {
+			continue
+		}
+		def, ok := buildingDefsByKey[bKey]
+		if !ok || def.Category != "wonder" {
+			continue
+		}
+		for _, eff := range def.Effects {
+			if eff.Type == "bonus" {
+				ensureTarget(eff.Target)
+				bonuses[eff.Target].wonders += eff.Value * float64(bState.Count)
+			}
+		}
+	}
+
 	// Collect targets that have any nonzero contribution
 	activeTargets := make([]string, 0, len(bonuses))
 	for target, bc := range bonuses {
@@ -320,7 +343,11 @@ func statsProvider(state game.GameState, _ int) string {
 				fmt.Fprintf(&sb, "  [gray]  legacy         +%.0f%%[-]\n", bc.legacy*100)
 			}
 			if bc.wonders > 0 {
-				fmt.Fprintf(&sb, "  [gray]  wonders        +%.2g[-]\n", bc.wonders)
+				if target == "speed_multiplier" {
+					fmt.Fprintf(&sb, "  [gray]  wonders        +%.1fx[-]\n", bc.wonders)
+				} else {
+					fmt.Fprintf(&sb, "  [gray]  wonders        +%.0f%%[-]\n", bc.wonders*100)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Wonder effects with `Type: "bonus"` (e.g. `production_all`, `knowledge_rate`, `expedition_reward`) were never applied to the game's bonus calculations or displayed in the Stats overlay Active Multipliers section
- Added `getWonderBonuses()` helper to `game/engine.go` that dynamically computes bonus-type effects from all built wonders
- Injected wonder bonuses into `recalculateRates()` local `permanentBonuses` map (so `production_all`, `knowledge_rate`, etc. correctly affect production every tick) and into `processExpeditions()` and `GetState()` (for `expedition_reward` and `military_power`)
- Updated `ui/overlay_stats.go` section 6 to iterate built wonder buildings and attribute their `bonus` effects to `bc.wonders`, making them appear under Active Multipliers with [wonder] attribution
- Fixed wonder breakdown display format to show `+80%` instead of raw `+0.8`

## Affected wonders
Wonders with `Type: "bonus"` effects that now display correctly: Great Library (+30% knowledge rate), Grand Lighthouse (+80% expedition reward), Crystal Palace (+15% production), Hoover Dam (+20% production), Warp Nexus (+80% production), Cosmic Beacon (+50% production), Reality Anchor (+50% production), Singularity Core (+200% production), Global Network (+30% knowledge rate)

## Test plan
- [ ] Build a wonder with a `bonus` effect (e.g. Crystal Palace → +15% production_all)
- [ ] Open Stats overlay — confirm the bonus appears under Active Multipliers with [wonder] attribution
- [ ] Verify the percentage displays correctly (e.g. +15% not +0.15)
- [ ] Verify production rates actually increase after building the wonder
- [ ] `go build ./...` and `go test ./...` pass

Closes https://trello.com/c/dufs0n1f

🤖 Generated with [Claude Code](https://claude.com/claude-code)