### PR TITLE
Rebalance gather command (yield 10→25, disable past Medieval)

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -1656,10 +1656,39 @@ func (ge *GameEngine) AdvanceAge() error {
 	return nil
 }
 
+// pastMedievalForGather reports whether the given age is strictly later than the
+// Medieval Age in the canonical age order. Used to gate hand-gathering. It is
+// pure (relies only on config.AgeOrder) and acquires no locks, so it is safe to
+// call while the engine write lock is held. Fails safe: if either age key is
+// absent from the order, it returns false (gathering allowed) rather than panic.
+func pastMedievalForGather(age string) bool {
+	order := config.AgeOrder()
+	curIdx, medievalIdx := -1, -1
+	for i, key := range order {
+		switch key {
+		case age:
+			curIdx = i
+		case "medieval_age":
+			medievalIdx = i
+		}
+	}
+	if curIdx == -1 || medievalIdx == -1 {
+		return false
+	}
+	return curIdx > medievalIdx
+}
+
 // GatherResource manually gathers a resource
 func (ge *GameEngine) GatherResource(resource string, amount float64) (float64, error) {
 	ge.mu.Lock()
 	defer ge.mu.Unlock()
+
+	// Hand-gathering is only practical through the Medieval Age. Past it, the
+	// economy is expected to run on buildings and workers. Lock is held here, so
+	// we use the ge.age field and pure config.AgeOrder() — no GetState().
+	if pastMedievalForGather(ge.age) {
+		return 0, fmt.Errorf("gathering by hand is no longer practical past the Medieval Age — your economy runs on buildings and workers now")
+	}
 
 	if !ge.Resources.IsUnlocked(resource) {
 		return 0, fmt.Errorf("resource '%s' is not yet unlocked", resource)

--- a/game/engine_test.go
+++ b/game/engine_test.go
@@ -55,6 +55,50 @@ func TestEngine_GatherLockedResource(t *testing.T) {
 	}
 }
 
+// Gathering in an early age grants the requested amount (up to the per-use cap).
+func TestEngine_GatherYieldEarlyAge(t *testing.T) {
+	ge := NewGameEngine()
+	ge.age = "stone_age"
+
+	startFood := ge.GetState().Resources["food"].Amount
+
+	if _, err := ge.GatherResource("food", 25); err != nil {
+		t.Fatalf("GatherResource in stone_age failed: %v", err)
+	}
+
+	got := ge.GetState().Resources["food"].Amount
+	if got != startFood+25 {
+		t.Errorf("food after gathering 25 = %v, want %v", got, startFood+25)
+	}
+}
+
+// Past the Medieval Age, gathering returns an error and grants nothing.
+func TestEngine_GatherDisabledPastMedieval(t *testing.T) {
+	ge := NewGameEngine()
+	ge.age = "renaissance_age"
+
+	startFood := ge.GetState().Resources["food"].Amount
+
+	if _, err := ge.GatherResource("food", 25); err == nil {
+		t.Error("GatherResource should fail in renaissance_age (post-medieval)")
+	}
+
+	got := ge.GetState().Resources["food"].Amount
+	if got != startFood {
+		t.Errorf("food should be unchanged after blocked gather: got %v, want %v", got, startFood)
+	}
+}
+
+// The Medieval Age itself is the cutoff inclusive — gathering still works there.
+func TestEngine_GatherAllowedInMedieval(t *testing.T) {
+	ge := NewGameEngine()
+	ge.age = "medieval_age"
+
+	if _, err := ge.GatherResource("food", 10); err != nil {
+		t.Errorf("GatherResource should still work in medieval_age, got: %v", err)
+	}
+}
+
 func TestEngine_BuildBuilding(t *testing.T) {
 	ge := NewGameEngine()
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -12,7 +12,7 @@ All commands are typed at the `>` prompt at the bottom of the screen. Press `↑
 | `build cancel` | Cancel the current build in the queue |
 | `sell <building> [count]` | Demolish a building and recover 50% of its build cost. Workers are returned to idle. |
 | `upgrade <building> [count\|all]` | Convert building copies to the next-age tier equivalent, paying only the cost delta (new copy cost minus 50% of the old copy's sell value). Defaults to all copies if no count given. |
-| `gather <resource> [amount]` | Manually gather food, wood, or stone (max 10 per command) |
+| `gather <resource> [amount]` | Manually gather food, wood, or stone (max 25 per command). Disabled from the Renaissance Age onward — works through the Medieval Age only. |
 
 **Example:**
 ```

--- a/site/docs/first-ten-minutes.md
+++ b/site/docs/first-ten-minutes.md
@@ -14,13 +14,15 @@ You're in the **Primitive Age**. The screen shows:
 You have 0 workers and minimal resources. Let's fix that.
 
 ```
-gather wood 10
-gather food 10
+gather wood 25
+gather food 25
 ``` 
 
-Repeat until you have gathered enough wood to build a hut
+Repeat until you have gathered enough wood to build a hut. Each `gather` grants up to **25** of a resource.
 
 *hint* You can use the up arrow to recall previous commands and spam that gathering!
+
+*note* Hand-gathering is an early-game crutch. It works through the **Medieval Age** and is disabled from the **Renaissance Age** onward — by then your buildings and workers should carry the economy.
 
 ---
 

--- a/ui/input.go
+++ b/ui/input.go
@@ -223,7 +223,7 @@ func cmdAdvance(engine *game.GameEngine) CommandResult {
 
 func cmdHelp(args []string) CommandResult {
 	help := `[gold]Commands:[-]
-  [cyan]gather[-] <food|wood|stone> [n] - Hand-gather resources (max 5)
+  [cyan]gather[-] <food|wood|stone> [n] - Hand-gather resources (max 25, until Medieval Age)
   [cyan]build[-] <building> [count|max] - Build structure(s) (default: 1)
   [cyan]sell[-] <building> [count]      - Demolish building(s) and recover 50% of build cost
   [cyan]recruit[-] [count|max]          - Recruit workers from available housing capacity and assign to buildings (default: 1)
@@ -380,9 +380,12 @@ func cmdDump(args []string, engine *game.GameEngine) CommandResult {
 	}
 }
 
+// gatherMaxYield is the per-use cap on hand-gathered resources.
+const gatherMaxYield = 25.0
+
 func cmdGather(args []string, engine *game.GameEngine) CommandResult {
 	if len(args) < 1 {
-		return CommandResult{Message: "Usage: gather <food|wood|stone> [amount] (max 10)", Type: "error"}
+		return CommandResult{Message: "Usage: gather <food|wood|stone> [amount] (max 25)", Type: "error"}
 	}
 	resource := strings.ToLower(args[0])
 	if resource != "food" && resource != "wood" && resource != "stone" {
@@ -394,8 +397,8 @@ func cmdGather(args []string, engine *game.GameEngine) CommandResult {
 			amount = n
 		}
 	}
-	if amount > 10 {
-		amount = 10
+	if amount > gatherMaxYield {
+		amount = gatherMaxYield
 	}
 	actual, err := engine.GatherResource(resource, amount)
 	if err != nil {


### PR DESCRIPTION
Closes `7z5SKoxS` (Gather Command Rebalance).

- **Yield 10 → 25** per command (`gatherMaxYield` const in `ui/input.go`) — a meaningful early-game kickstart now that opening building costs are no longer trivial.
- **Disabled from the Renaissance Age onward** — works through Medieval (inclusive); past it, hand-gathering returns a player-facing error rather than granting resources, since the economy should run on buildings/workers by then.

Gate lives in `GatherResource` under the engine lock, uses only lock-free `config.AgeOrder()` (deadlock-safe), and fails open if age keys are missing. Tests cover the 25 yield, the post-medieval disable, and the inclusive cutoff. Wiki (`commands.md`, `first-ten-minutes.md`) synced.

`go build/vet/test` green.