### PR TITLE
Help command opens a Help panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ go.work
 *.swp
 *.swo
 
-# Ignore game saves
+# Ignore game saves and runtime logs
 data/saves/
+data/logs/
 
 # Build output
 dist/

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -198,7 +198,7 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 | `saves` | List all save files |
 | `Esc` | Quick-save (autosave slot) |
 | `dump` | Export logs to a file for debugging |
-| `help` | Show a quick command summary |
+| `help` | Open the Help panel — full command reference and list of available panels |
 
 ---
 

--- a/site/docs/how-to-play.md
+++ b/site/docs/how-to-play.md
@@ -42,7 +42,8 @@ Build → Recruit → Assign → Research → Advance → Repeat
 
 ## Navigation
 
-- overlay commands (type `research`, `army`, `trade`, `map`, etc.) — open panels
+- overlay commands (type `research`, `army`, `trade`, `map`, `help`, etc.) — open panels
+- `help` opens the Help panel: a full command reference plus the list of every panel you can open
 - **PgUp / PgDn** — scroll the active tab
 - **↑ / ↓** — navigate command history
 - **Esc** — save game

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -38,23 +38,23 @@ type Dashboard struct {
 	economyTab *EconomyTab
 
 	// Sidebar
-	sidebar       *tview.TextView
-	workerMiniTV  *tview.TextView
+	sidebar      *tview.TextView
+	workerMiniTV *tview.TextView
 
 	// Shared UI
-	logTV    *tview.TextView
-	statusTV *tview.TextView
-	ageTV      *tview.TextView
-	inputField *tview.InputField
+	logTV               *tview.TextView
+	statusTV            *tview.TextView
+	ageTV               *tview.TextView
+	inputField          *tview.InputField
 	lastAge             string
 	pendingAgeSplash    string // set by bus handler, consumed by refresh()
 	pendingEpochChanged bool   // whether the pending age advance also crossed an epoch boundary
 	toastMgr            *ToastManager
-	toastTV     *tview.TextView
-	contentArea *tview.Flex
+	toastTV             *tview.TextView
+	contentArea         *tview.Flex
 
 	// Shame badge — set once on first load when CheaterBadge is true
-	cheaterTV       *tview.TextView
+	cheaterTV        *tview.TextView
 	activeShameBadge string
 
 	// catModalShown tracks the pending catastrophe key we have already shown a modal for,
@@ -79,10 +79,10 @@ type Dashboard struct {
 // NewDashboard creates the gameplay dashboard
 func NewDashboard(app *tview.Application, engine *game.GameEngine, pages *tview.Pages) *Dashboard {
 	d := &Dashboard{
-		app:    app,
-		engine: engine,
-		pages:  pages,
-		stopCh: make(chan struct{}),
+		app:     app,
+		engine:  engine,
+		pages:   pages,
+		stopCh:  make(chan struct{}),
 		histIdx: -1,
 	}
 	d.build()
@@ -101,6 +101,7 @@ func NewDashboard(app *tview.Application, engine *game.GameEngine, pages *tview.
 	d.overlayMgr.Register("epoch", "Epoch", epochProvider)
 	d.overlayMgr.Register("history", "Civilization History", historyProvider)
 	d.overlayMgr.Register("buildings", "Buildings", buildingsProvider)
+	d.overlayMgr.Register("help", "Help", helpProvider)
 
 	mv4 := NewMapV4()
 	d.overlayMgr.RegisterWidget("map", "City Map", mv4.Build, mv4.Refresh, true)
@@ -376,7 +377,7 @@ func (d *Dashboard) updateSidebar(activeOverlay string) {
 }
 
 func buildSidebarText(active string) string {
-	commands := []string{"milestones", "research", "army", "trade", "stats", "wonders", "workers", "logs", "epoch", "history", "map"}
+	commands := []string{"milestones", "research", "army", "trade", "stats", "wonders", "workers", "logs", "epoch", "history", "map", "help"}
 	var sb strings.Builder
 	sb.WriteString("\n")
 	for _, cmd := range commands {
@@ -644,7 +645,6 @@ func (d *Dashboard) refreshLog(state game.GameState) {
 	d.logTV.ScrollToEnd()
 }
 
-
 // showDevUnlockModal opens an unlabelled passphrase input modal.
 // No hint text is shown — the existence of this modal is not advertised.
 func (d *Dashboard) showDevUnlockModal() {
@@ -695,4 +695,3 @@ func (d *Dashboard) showDevUnlockModal() {
 	d.pages.AddPage(devUnlockPage, centered, true, true)
 	d.app.SetFocus(field)
 }
-

--- a/ui/input.go
+++ b/ui/input.go
@@ -36,7 +36,7 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 
 	switch cmd {
 	case "help", "h", "?":
-		return cmdHelp(args)
+		return CommandResult{OverlayName: "help"}
 	case "gather", "g":
 		return cmdGather(args, engine)
 	case "build", "b":
@@ -219,54 +219,6 @@ func cmdAdvance(engine *game.GameEngine) CommandResult {
 		Message: fmt.Sprintf("Your civilization enters the [gold]%s[-]!", state.AgeName),
 		Type:    "success",
 	}
-}
-
-func cmdHelp(args []string) CommandResult {
-	help := `[gold]Commands:[-]
-  [cyan]gather[-] <food|wood|stone> [n] - Hand-gather resources (max 25, until Medieval Age)
-  [cyan]build[-] <building> [count|max] - Build structure(s) (default: 1)
-  [cyan]sell[-] <building> [count]      - Demolish building(s) and recover 50% of build cost
-  [cyan]recruit[-] [count|max]          - Recruit workers from available housing capacity and assign to buildings (default: 1)
-  [cyan]assign[-] <building> [n|all]   - Assign workers to a building
-  [cyan]unassign[-] <building> [n|all] - Unassign workers from a building
-  [cyan]dismiss[-] <building> [n|all]  - Fire workers from a building (removes from pool)
-  [cyan]advance[-]                     - Advance to the next age (when ready)
-  [cyan]research[-] <tech_key>         - Research a technology
-  [cyan]research[-] cancel             - Cancel current research
-  [cyan]research[-] list               - List available techs
-  [cyan]expedition[-] <key>            - Launch a military expedition
-  [cyan]expedition[-] list             - List available expeditions
-  [cyan]trade[-] <from> <to> <amount>  - Exchange resources
-  [cyan]trade[-] list                  - Show exchange rates
-  [cyan]trade[-] route list            - List trade routes
-  [cyan]trade[-] route start <key>     - Start a trade route
-  [cyan]trade[-] route stop <key>      - Stop a trade route
-  [cyan]diplomacy[-]                   - Show faction status
-  [cyan]diplomacy[-] ally <faction>    - Ally with faction (costs gold)
-  [cyan]diplomacy[-] rival <faction>   - Declare rivalry
-  [cyan]diplomacy[-] embargo <faction> - Embargo faction
-  [cyan]diplomacy[-] gift <faction>    - Send gift (+15 opinion)
-  [cyan]diplomacy[-] neutral <faction> - Reset to neutral
-  [cyan]prestige[-]                    - View prestige status
-  [cyan]prestige[-] confirm yes        - Reset game with prestige bonus
-  [cyan]prestige[-] shop               - View prestige upgrades
-  [cyan]prestige[-] buy <key>          - Buy a prestige upgrade
-  [cyan]rates[-]                       - Show resource rate breakdown
-  [cyan]status[-]                      - Show detailed status
-  [cyan]upgrade[-]                     - List available building upgrades
-  [cyan]upgrade[-] <building> [n|all]  - Upgrade building to next age tier (pays cost delta)
-  [cyan]dump[-]                        - Export logs to file for debugging
-  [cyan]save[-] [name]                 - Save game (default: autosave)
-  [cyan]load[-] [name]                 - Load game (default: autosave)
-  [cyan]saves[-]                       - List all save files
-  [cyan]wonder[-]                      - Show current wonder bank status
-  [cyan]wonder collect[-] <res> <amt|all> - Bank resources into current wonder
-  [cyan]speed[-] [1.0|1.5|2.0|...]     - Set game speed (unlocks per wonder built)
-  [cyan]catastrophe invoke[-]           - Voluntarily trigger the epoch catastrophe
-  [cyan]help[-]                        - Show this help
-
-[gold]Shortcuts:[-] g=gather, b=build, r=recruit, a=assign, u=unassign, s=status, res=research, exp=expedition, t=trade, dip=diplomacy`
-	return CommandResult{Message: help, Type: "info"}
 }
 
 func cmdUpgrade(args []string, engine *game.GameEngine) CommandResult {

--- a/ui/overlay_help.go
+++ b/ui/overlay_help.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// helpProvider renders the Help overlay: a categorised command reference and a
+// list of the panels the player can open. It is intentionally static (it does
+// not read game state) so the same reference is available at any point in play.
+func helpProvider(_ game.GameState, _ int) string {
+	var sb strings.Builder
+
+	sb.WriteString("[gold]═══ Actions ═══[-]\n")
+	sb.WriteString("  [cyan]gather[-] <food|wood|stone> [n] - Hand-gather resources (max 25, until Medieval Age)\n")
+	sb.WriteString("  [cyan]build[-] <building> [count|max] - Build structure(s) (default: 1)\n")
+	sb.WriteString("  [cyan]sell[-] <building> [count]      - Demolish building(s), recover 50% of build cost\n")
+	sb.WriteString("  [cyan]advance[-]                       - Advance to the next age (when ready)\n")
+	sb.WriteString("  [cyan]upgrade[-]                       - List available building upgrades\n")
+	sb.WriteString("  [cyan]upgrade[-] <building> [n|all]    - Upgrade building to next age tier (pays cost delta)\n")
+
+	sb.WriteString("\n[gold]═══ Workers ═══[-]\n")
+	sb.WriteString("  [cyan]recruit[-] [count|max]           - Recruit workers from available housing (default: 1)\n")
+	sb.WriteString("  [cyan]assign[-] <building> [n|all]     - Assign workers to a building\n")
+	sb.WriteString("  [cyan]unassign[-] <building> [n|all]   - Unassign workers from a building\n")
+	sb.WriteString("  [cyan]dismiss[-] <building> [n|all]    - Fire workers from a building (removes from pool)\n")
+
+	sb.WriteString("\n[gold]═══ Research & Military ═══[-]\n")
+	sb.WriteString("  [cyan]research[-] <tech_key>          - Research a technology\n")
+	sb.WriteString("  [cyan]research[-] cancel             - Cancel current research\n")
+	sb.WriteString("  [cyan]research[-] list               - List available techs\n")
+	sb.WriteString("  [cyan]expedition[-] <key>            - Launch a military expedition\n")
+	sb.WriteString("  [cyan]expedition[-] list             - List available expeditions\n")
+
+	sb.WriteString("\n[gold]═══ Trade & Diplomacy ═══[-]\n")
+	sb.WriteString("  [cyan]trade[-] <from> <to> <amount>  - Exchange resources\n")
+	sb.WriteString("  [cyan]trade[-] list                  - Show exchange rates\n")
+	sb.WriteString("  [cyan]trade[-] route list            - List trade routes\n")
+	sb.WriteString("  [cyan]trade[-] route start <key>     - Start a trade route\n")
+	sb.WriteString("  [cyan]trade[-] route stop <key>      - Stop a trade route\n")
+	sb.WriteString("  [cyan]diplomacy[-]                   - Show faction status\n")
+	sb.WriteString("  [cyan]diplomacy[-] ally <faction>    - Ally with faction (costs gold)\n")
+	sb.WriteString("  [cyan]diplomacy[-] rival <faction>   - Declare rivalry\n")
+	sb.WriteString("  [cyan]diplomacy[-] embargo <faction> - Embargo faction\n")
+	sb.WriteString("  [cyan]diplomacy[-] gift <faction>    - Send gift (+15 opinion)\n")
+	sb.WriteString("  [cyan]diplomacy[-] neutral <faction> - Reset to neutral\n")
+
+	sb.WriteString("\n[gold]═══ Wonders & Prestige ═══[-]\n")
+	sb.WriteString("  [cyan]wonder[-]                          - Show current wonder bank status\n")
+	sb.WriteString("  [cyan]wonder collect[-] <res> <amt|all> - Bank resources into current wonder\n")
+	sb.WriteString("  [cyan]prestige[-]                        - View prestige status\n")
+	sb.WriteString("  [cyan]prestige[-] confirm yes            - Reset game with prestige bonus\n")
+	sb.WriteString("  [cyan]prestige[-] shop                   - View prestige upgrades\n")
+	sb.WriteString("  [cyan]prestige[-] buy <key>              - Buy a prestige upgrade\n")
+	sb.WriteString("  [cyan]catastrophe invoke[-]              - Voluntarily trigger the epoch catastrophe\n")
+
+	sb.WriteString("\n[gold]═══ Game ═══[-]\n")
+	sb.WriteString("  [cyan]rates[-]                       - Show resource rate breakdown\n")
+	sb.WriteString("  [cyan]status[-]                      - Show detailed status\n")
+	sb.WriteString("  [cyan]speed[-] [1.0|1.5|2.0|...]     - Set game speed (unlocks per wonder built)\n")
+	sb.WriteString("  [cyan]save[-] [name]                 - Save game (default: autosave)\n")
+	sb.WriteString("  [cyan]load[-] [name]                 - Load game (default: autosave)\n")
+	sb.WriteString("  [cyan]saves[-]                       - List all save files\n")
+	sb.WriteString("  [cyan]dump[-]                        - Export logs to file for debugging\n")
+	sb.WriteString("  [cyan]help[-]                        - Open this Help panel\n")
+
+	sb.WriteString("\n[gold]═══ Panels ═══[-]\n")
+	sb.WriteString("[gray]Type the command to open the panel.[-]\n")
+	for _, p := range []struct{ cmd, desc string }{
+		{"milestones", "Milestone goals & rewards"},
+		{"research", "Technology tree & progress"},
+		{"army", "Military overview & expeditions"},
+		{"trade", "Exchange rates & trade routes"},
+		{"stats", "Empire statistics"},
+		{"wonders", "Wonder bank & built wonders"},
+		{"workers", "Worker domains & assignments"},
+		{"logs", "Recent game log entries"},
+		{"epoch", "Epoch progress & catastrophe"},
+		{"history", "Civilization history timeline"},
+		{"buildings", "Built structures by lineage"},
+		{"map", "City map view"},
+		{"help", "This Help panel"},
+	} {
+		sb.WriteString("  [cyan]" + padRight(p.cmd, 12) + "[-] — " + p.desc + "\n")
+	}
+
+	sb.WriteString("\n[gold]═══ Shortcuts ═══[-]\n")
+	sb.WriteString("[gray]g=gather, b=build, r=recruit, a=assign, u=unassign, s=status, res=research, exp=expedition, t=trade, dip=diplomacy[-]\n")
+
+	return sb.String()
+}
+
+// padRight pads s with spaces on the right to width w (no truncation).
+func padRight(s string, w int) string {
+	if len(s) >= w {
+		return s
+	}
+	return s + strings.Repeat(" ", w-len(s))
+}


### PR DESCRIPTION
Typing `help` / `h` / `?` now opens a proper **Help overlay panel** instead of dumping inline text — consistent with every other panel (stats, workers, army…).

The panel has two sections: a full **command reference** (regrouped by category; all of the old `cmdHelp` content preserved) and a **Panels** list showing every overlay and how to open it — including `help` itself, which is now also in the panel switcher list.

Wired through the standard `CommandResult{OverlayName:"help"}` path and registered via `overlayMgr`; `cmdHelp` ignored its args (no topic-help to keep) so it's removed. Wiki (`commands.md`, `how-to-play.md`) updated. Also gitignores `data/logs/` (runtime noise, sibling of the already-ignored `data/saves/`).

`go build/vet/test` green, gofmt clean.