### PR TITLE
Load Game browser — save picker with full management

### DIFF
--- a/game/save.go
+++ b/game/save.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/espresso20/ageforge/config"
@@ -633,14 +634,28 @@ func ListSaves() ([]string, error) {
 	return saves, nil
 }
 
-// SaveInfo holds metadata about a save file
+// SaveInfo holds metadata about a save file, parsed from the save's JSON
+// header without loading the full engine state. Fields beyond Name/Timestamp/Age
+// drive the Load Game browser's detail pane.
 type SaveInfo struct {
-	Name      string
-	Timestamp time.Time
-	Age       string
+	Name          string
+	Timestamp     time.Time
+	Age           string
+	Tick          int
+	PrestigeLevel int
+	Morale        float64
+	Modified      bool // save's cheater_badge flag (HMAC mismatch on a prior load)
+	Elite         bool // save's elite_badge flag
+	// Corrupt is set when the file could not be read or JSON-parsed. The entry
+	// is still returned (Name + mtime Timestamp) so the UI can show it as
+	// greyed/unloadable rather than silently dropping it.
+	Corrupt bool
 }
 
-// ListSaveDetails returns metadata for each save file
+// ListSaveDetails returns metadata for each save file. A file that fails to read
+// or parse is not skipped: it is returned with Corrupt=true, its Name, and a
+// Timestamp taken from the file's mtime, so a single bad file never breaks the
+// listing for the rest.
 func ListSaveDetails() ([]SaveInfo, error) {
 	dir := saveDirectory()
 	entries, err := os.ReadDir(dir)
@@ -657,24 +672,51 @@ func ListSaveDetails() ([]SaveInfo, error) {
 		}
 		name := e.Name()[:len(e.Name())-5]
 		path := filepath.Join(dir, e.Name())
-		data, err := os.ReadFile(path)
-		if err != nil {
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			saves = append(saves, corruptInfo(name, e))
 			continue
 		}
+		// Parse only the subset of fields the detail pane needs. The json tags
+		// here must match GameSave / PrestigeSave above.
 		var header struct {
 			Timestamp time.Time `json:"timestamp"`
+			Tick      int       `json:"tick"`
 			Age       string    `json:"age"`
+			Morale    float64   `json:"morale"`
+			Prestige  struct {
+				Level int `json:"level"`
+			} `json:"prestige"`
+			CheaterBadge bool `json:"cheater_badge"`
+			EliteBadge   bool `json:"elite_badge"`
 		}
 		if err := json.Unmarshal(data, &header); err != nil {
+			saves = append(saves, corruptInfo(name, e))
 			continue
 		}
 		saves = append(saves, SaveInfo{
-			Name:      name,
-			Timestamp: header.Timestamp,
-			Age:       header.Age,
+			Name:          name,
+			Timestamp:     header.Timestamp,
+			Age:           header.Age,
+			Tick:          header.Tick,
+			PrestigeLevel: header.Prestige.Level,
+			Morale:        header.Morale,
+			Modified:      header.CheaterBadge,
+			Elite:         header.EliteBadge,
 		})
 	}
 	return saves, nil
+}
+
+// corruptInfo builds a SaveInfo for an unreadable/unparseable save, falling back
+// to the file's mtime for the Timestamp so the UI still has something to sort on.
+func corruptInfo(name string, e os.DirEntry) SaveInfo {
+	info := SaveInfo{Name: name, Corrupt: true}
+	if fi, err := e.Info(); err == nil {
+		info.Timestamp = fi.ModTime()
+	}
+	return info
 }
 
 // WipeAllSaves deletes all save files
@@ -699,4 +741,134 @@ func WipeAllSaves() error {
 func SaveExists(filename string) bool {
 	_, err := os.Stat(savePath(filename))
 	return err == nil
+}
+
+// maxSaveNameLen bounds save base-names. Generous for player-chosen names while
+// keeping us clear of filesystem path limits.
+const maxSaveNameLen = 64
+
+// sanitizeSaveName validates a save base-name that may originate from user input
+// (e.g. the rename dialog) and returns the cleaned name. A trailing ".json" the
+// user may have typed is stripped first. It REJECTS names that are empty/
+// whitespace-only, contain a path separator ('/' or '\'), contain "..", begin
+// with a dot, contain a null byte, or exceed maxSaveNameLen — anything that could
+// escape the saves directory or produce a hidden/awkward file. The returned name
+// is safe to join onto the saves directory.
+func sanitizeSaveName(name string) (string, error) {
+	// Strip a trailing .json the user may have included.
+	if ext := filepath.Ext(name); ext == ".json" {
+		name = name[:len(name)-len(ext)]
+	}
+	name = strings.TrimSpace(name)
+
+	if name == "" {
+		return "", fmt.Errorf("save name cannot be empty")
+	}
+	if len(name) > maxSaveNameLen {
+		return "", fmt.Errorf("save name too long (max %d characters)", maxSaveNameLen)
+	}
+	if strings.ContainsRune(name, 0) {
+		return "", fmt.Errorf("save name contains an invalid character")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("save name cannot contain path separators")
+	}
+	if strings.Contains(name, "..") {
+		return "", fmt.Errorf("save name cannot contain '..'")
+	}
+	if strings.HasPrefix(name, ".") {
+		return "", fmt.Errorf("save name cannot start with a dot")
+	}
+	return name, nil
+}
+
+// DeleteSave removes a save file. The name is sanitized first so a crafted value
+// cannot escape the saves directory. Returns a clear error if the file is absent.
+func DeleteSave(filename string) error {
+	name, err := sanitizeSaveName(filename)
+	if err != nil {
+		return err
+	}
+	if !SaveExists(name) {
+		return fmt.Errorf("save %q does not exist", name)
+	}
+	if err := os.Remove(savePath(name)); err != nil {
+		return fmt.Errorf("failed to delete save: %w", err)
+	}
+	return nil
+}
+
+// RenameSave renames a save file from oldName to newName. Both names are
+// sanitized. Errors if the source does not exist, if newName collides with an
+// existing save, or if either name is invalid. Because only the filename changes
+// (not the bytes), the save's HMAC signature stays valid.
+func RenameSave(oldName, newName string) error {
+	src, err := sanitizeSaveName(oldName)
+	if err != nil {
+		return fmt.Errorf("invalid source name: %w", err)
+	}
+	dst, err := sanitizeSaveName(newName)
+	if err != nil {
+		return fmt.Errorf("invalid new name: %w", err)
+	}
+	if !SaveExists(src) {
+		return fmt.Errorf("save %q does not exist", src)
+	}
+	if src == dst {
+		return fmt.Errorf("new name is the same as the current name")
+	}
+	if SaveExists(dst) {
+		return fmt.Errorf("a save named %q already exists", dst)
+	}
+	srcPath := savePath(src)
+	// Write the renamed file into the same directory the source lives in so a
+	// save in the legacy CWD location isn't orphaned by a canonical-dir write.
+	dstPath := filepath.Join(filepath.Dir(srcPath), dst+".json")
+	if err := os.Rename(srcPath, dstPath); err != nil {
+		return fmt.Errorf("failed to rename save: %w", err)
+	}
+	return nil
+}
+
+// DuplicateSave copies a save to a new name and returns the new base name. The
+// new name is "<filename>-copy", or "<filename>-copy-2", "-copy-3", ... if a
+// prior copy already exists. Bytes are copied verbatim, so the HMAC signature
+// remains valid on the duplicate.
+func DuplicateSave(filename string) (string, error) {
+	src, err := sanitizeSaveName(filename)
+	if err != nil {
+		return "", err
+	}
+	if !SaveExists(src) {
+		return "", fmt.Errorf("save %q does not exist", src)
+	}
+
+	// Find the first free "-copy" variant. The base + suffix must still satisfy
+	// the sanitizer (length bound in particular), so validate before using it.
+	dst := src + "-copy"
+	for n := 2; SaveExists(dst); n++ {
+		dst = fmt.Sprintf("%s-copy-%d", src, n)
+	}
+	if _, err := sanitizeSaveName(dst); err != nil {
+		return "", fmt.Errorf("cannot build a valid copy name: %w", err)
+	}
+
+	srcPath := savePath(src)
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read save: %w", err)
+	}
+	// Place the copy alongside the source (canonical or legacy dir) for the same
+	// reason as RenameSave. Write atomically (temp + rename).
+	dir := filepath.Dir(srcPath)
+	dstPath := filepath.Join(dir, dst+".json")
+	tmpPath := dstPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return "", fmt.Errorf("failed to write copy: %w", err)
+	}
+	if err := os.Rename(tmpPath, dstPath); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to finalize copy: %w", err)
+	}
+	return dst, nil
 }

--- a/game/save.go
+++ b/game/save.go
@@ -216,6 +216,11 @@ func savePath(filename string) string {
 	return primary // default to canonical for new saves
 }
 
+// AutosaveName is the reserved base-name of the automatic save file. The engine
+// writes to it on its autosave cadence; the UI uses it to flag the autosave row
+// in the Load Game browser so it can't be confused with a player-named save.
+const AutosaveName = "autosave"
+
 // SaveGame serialises current engine state to filename.json in the save directory.
 // The save is written atomically (temp file + rename) to prevent corruption if
 // the process is killed mid-write. The payload is HMAC-signed before writing.

--- a/game/save.go
+++ b/game/save.go
@@ -651,6 +651,19 @@ type SaveInfo struct {
 	Morale        float64
 	Modified      bool // save's cheater_badge flag (HMAC mismatch on a prior load)
 	Elite         bool // save's elite_badge flag
+	// Rich detail-pane metadata (all derived from the save header; zero on a
+	// corrupt save).
+	Title              string // current_title — the civ's earned title (may be "")
+	Epoch              string // current_epoch, mapped to its display name
+	Population         int    // sum of worker Count across all domains (assigned + idle)
+	Buildings          int    // total building instances built
+	Wonders            int    // built buildings whose Category == "wonder"
+	Techs              int    // number of researched techs
+	Soldiers           int    // resources["soldiers"], truncated to int
+	PrestigeTotal      int    // prestige.total_earned (lifetime prestige points)
+	PendingCatastrophe string // pending_catastrophe → catastrophe display name ("" if none)
+	MilestonesDone     int    // count of completed milestones
+	MilestonesTotal    int    // total milestones defined in config (0 if unavailable)
 	// Corrupt is set when the file could not be read or JSON-parsed. The entry
 	// is still returned (Name + mtime Timestamp) so the UI can show it as
 	// greyed/unloadable rather than silently dropping it.
@@ -684,15 +697,26 @@ func ListSaveDetails() ([]SaveInfo, error) {
 			continue
 		}
 		// Parse only the subset of fields the detail pane needs. The json tags
-		// here must match GameSave / PrestigeSave above.
+		// here must match GameSave / PrestigeSave / ResearchSave / WorkerInfo above.
 		var header struct {
 			Timestamp time.Time `json:"timestamp"`
 			Tick      int       `json:"tick"`
 			Age       string    `json:"age"`
 			Morale    float64   `json:"morale"`
 			Prestige  struct {
-				Level int `json:"level"`
+				Level       int `json:"level"`
+				TotalEarned int `json:"total_earned"`
 			} `json:"prestige"`
+			CurrentTitle       string                `json:"current_title"`
+			CurrentEpoch       string                `json:"current_epoch"`
+			PendingCatastrophe string                `json:"pending_catastrophe"`
+			Milestones         []string              `json:"milestones"`
+			Resources          map[string]float64    `json:"resources"`
+			Buildings          map[string]int        `json:"buildings"`
+			Workers            map[string]WorkerInfo `json:"workers"`
+			Research           struct {
+				Researched []string `json:"researched"`
+			} `json:"research"`
 			CheaterBadge bool `json:"cheater_badge"`
 			EliteBadge   bool `json:"elite_badge"`
 		}
@@ -700,18 +724,71 @@ func ListSaveDetails() ([]SaveInfo, error) {
 			saves = append(saves, corruptInfo(name, e))
 			continue
 		}
+
+		// Derive aggregates. Ranges over nil maps are no-ops, so a save missing
+		// any of these sections simply yields zero — no panic.
+		population := 0
+		for _, w := range header.Workers {
+			population += w.Count
+		}
+		buildings, wonders := 0, 0
+		buildingDefs := config.BuildingByKey()
+		for key, count := range header.Buildings {
+			if count <= 0 {
+				continue
+			}
+			buildings += count
+			if def, ok := buildingDefs[key]; ok && def.Category == "wonder" {
+				wonders += count
+			}
+		}
+
 		saves = append(saves, SaveInfo{
-			Name:          name,
-			Timestamp:     header.Timestamp,
-			Age:           header.Age,
-			Tick:          header.Tick,
-			PrestigeLevel: header.Prestige.Level,
-			Morale:        header.Morale,
-			Modified:      header.CheaterBadge,
-			Elite:         header.EliteBadge,
+			Name:               name,
+			Timestamp:          header.Timestamp,
+			Age:                header.Age,
+			Tick:               header.Tick,
+			PrestigeLevel:      header.Prestige.Level,
+			Morale:             header.Morale,
+			Modified:           header.CheaterBadge,
+			Elite:              header.EliteBadge,
+			Title:              header.CurrentTitle,
+			Epoch:              epochDisplayName(header.CurrentEpoch),
+			Population:         population,
+			Buildings:          buildings,
+			Wonders:            wonders,
+			Techs:              len(header.Research.Researched),
+			Soldiers:           int(header.Resources["soldiers"]),
+			PrestigeTotal:      header.Prestige.TotalEarned,
+			PendingCatastrophe: catastropheDisplayName(header.PendingCatastrophe),
+			MilestonesDone:     len(header.Milestones),
+			MilestonesTotal:    len(config.Milestones()),
 		})
 	}
 	return saves, nil
+}
+
+// epochDisplayName maps an epoch key to its display name via config, falling
+// back to the raw key. An empty key stays empty.
+func epochDisplayName(key string) string {
+	if key == "" {
+		return ""
+	}
+	if def, ok := config.EpochByKey()[key]; ok && def.Name != "" {
+		return def.Name
+	}
+	return key
+}
+
+// catastropheDisplayName maps a pending-catastrophe key (an epoch key — see
+// GameState.PendingCatastrophe) to the catastrophe's display name. An empty key
+// stays empty so the UI can omit the warning line.
+func catastropheDisplayName(epochKey string) string {
+	if epochKey == "" {
+		return ""
+	}
+	name, _ := config.CatastropheInfo(epochKey)
+	return name
 }
 
 // corruptInfo builds a SaveInfo for an unreadable/unparseable save, falling back

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -1,11 +1,46 @@
 package game
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/espresso20/ageforge/config"
 )
+
+// writeRawSave marshals a GameSave and writes it (unsigned) to the save path for
+// name, overwriting any existing file. ListSaveDetails reads JSON only and never
+// verifies signatures, so an unsigned hand-built save is a valid parse fixture.
+func writeRawSave(t *testing.T, name string, save GameSave) {
+	t.Helper()
+	data, err := json.Marshal(save)
+	if err != nil {
+		t.Fatalf("marshal raw save: %v", err)
+	}
+	if err := os.WriteFile(savePath(name), data, 0644); err != nil {
+		t.Fatalf("write raw save %q: %v", name, err)
+	}
+}
+
+// findDetail runs ListSaveDetails and returns the entry for name, failing if it
+// is absent.
+func findDetail(t *testing.T, name string) SaveInfo {
+	t.Helper()
+	details, err := ListSaveDetails()
+	if err != nil {
+		t.Fatalf("ListSaveDetails failed: %v", err)
+	}
+	for i := range details {
+		if details[i].Name == name {
+			return details[i]
+		}
+	}
+	t.Fatalf("save %q not present in ListSaveDetails output", name)
+	return SaveInfo{}
+}
 
 // writeTestSave creates a real, signed, loadable save under the given base name
 // via the engine, and registers cleanup to remove it (and any "-copy" variants a
@@ -230,6 +265,103 @@ func TestListSaveDetailsPopulatesFields(t *testing.T) {
 	}
 }
 
+// pickBuildingKeys returns a real wonder key and a real non-wonder building key
+// from config, so the rich-fields test stays valid as the building set evolves.
+func pickBuildingKeys(t *testing.T) (wonder, other string) {
+	t.Helper()
+	for k, d := range config.BuildingByKey() {
+		if d.Category == "wonder" && wonder == "" {
+			wonder = k
+		}
+		if d.Category != "wonder" && other == "" {
+			other = k
+		}
+	}
+	if wonder == "" || other == "" {
+		t.Fatalf("could not find a wonder (%q) and non-wonder (%q) building in config", wonder, other)
+	}
+	return wonder, other
+}
+
+// TestListSaveDetailsRichFields writes a real save, then rewrites it with a
+// hand-built header carrying buildings/workers/resources/title/epoch/prestige so
+// the derivation + parse logic in ListSaveDetails is exercised directly. The save
+// is rewritten unsigned, which is fine: ListSaveDetails never verifies signatures.
+func TestListSaveDetailsRichFields(t *testing.T) {
+	name := "test_rich_details"
+	writeTestSave(t, name) // ensures the dir exists and registers cleanup
+
+	wonderKey, prodKey := pickBuildingKeys(t)
+
+	// 5 production + 1 wonder = 6 building instances (the count-0 key is excluded
+	// from both totals). 4 + 6 = 10 workers.
+	save := GameSave{
+		Timestamp:          time.Now(),
+		Tick:               4242,
+		Age:                "iron_age",
+		Morale:             0.75,
+		CurrentTitle:       "The Eternal",
+		CurrentEpoch:       "iron_era",
+		PendingCatastrophe: "iron_era", // pending_catastrophe holds an epoch key
+		Milestones:         []string{"m1", "m2", "m3"},
+		Resources:          map[string]float64{"soldiers": 137.9, "wood": 50},
+		Buildings:          map[string]int{prodKey: 5, wonderKey: 1, "ghost_key_zero": 0},
+		Workers: map[string]WorkerInfo{
+			"food":     {Count: 4},
+			"military": {Count: 6},
+		},
+		Research: ResearchSave{Researched: []string{"t1", "t2", "t3", "t4"}},
+		Prestige: PrestigeSave{Level: 2, TotalEarned: 1500},
+	}
+
+	writeRawSave(t, name, save)
+
+	found := findDetail(t, name)
+	if found.Corrupt {
+		t.Fatalf("rich save %q flagged Corrupt", name)
+	}
+	if found.Title != "The Eternal" {
+		t.Errorf("Title = %q, want %q", found.Title, "The Eternal")
+	}
+	// Epoch should be the display name, not the raw key.
+	if found.Epoch == "" || found.Epoch == "iron_era" {
+		t.Errorf("Epoch = %q, want a display name resolved from %q", found.Epoch, "iron_era")
+	}
+	if found.Population != 10 {
+		t.Errorf("Population = %d, want 10 (4 food + 6 military)", found.Population)
+	}
+	if found.Buildings != 6 { // 5 prod + 1 wonder; the count-0 key is excluded
+		t.Errorf("Buildings = %d, want 6", found.Buildings)
+	}
+	if found.Wonders != 1 {
+		t.Errorf("Wonders = %d, want 1", found.Wonders)
+	}
+	if found.Techs != 4 {
+		t.Errorf("Techs = %d, want 4", found.Techs)
+	}
+	if found.Soldiers != 137 { // int() truncation of 137.9
+		t.Errorf("Soldiers = %d, want 137", found.Soldiers)
+	}
+	if found.PrestigeLevel != 2 {
+		t.Errorf("PrestigeLevel = %d, want 2", found.PrestigeLevel)
+	}
+	if found.PrestigeTotal != 1500 {
+		t.Errorf("PrestigeTotal = %d, want 1500", found.PrestigeTotal)
+	}
+	if found.MilestonesDone != 3 {
+		t.Errorf("MilestonesDone = %d, want 3", found.MilestonesDone)
+	}
+	if found.MilestonesTotal != len(config.Milestones()) {
+		t.Errorf("MilestonesTotal = %d, want %d", found.MilestonesTotal, len(config.Milestones()))
+	}
+	if found.PendingCatastrophe == "" || found.PendingCatastrophe == "iron_era" {
+		t.Errorf("PendingCatastrophe = %q, want a catastrophe display name resolved from %q", found.PendingCatastrophe, "iron_era")
+	}
+	if found.Tick != 4242 {
+		t.Errorf("Tick = %d, want 4242", found.Tick)
+	}
+}
+
 func TestListSaveDetailsFlagsCorrupt(t *testing.T) {
 	// Ensure the dir exists, then drop a non-JSON .json file into it.
 	good := "test_corrupt_neighbor"
@@ -265,6 +397,14 @@ func TestListSaveDetailsFlagsCorrupt(t *testing.T) {
 	}
 	if corrupt.Timestamp.IsZero() {
 		t.Errorf("corrupt save Timestamp is zero, want file mtime fallback")
+	}
+	// New rich fields must all default to zero on a corrupt save (no panic, no
+	// partial parse leaking through).
+	if corrupt.Title != "" || corrupt.Epoch != "" || corrupt.PendingCatastrophe != "" ||
+		corrupt.Population != 0 || corrupt.Buildings != 0 || corrupt.Wonders != 0 ||
+		corrupt.Techs != 0 || corrupt.Soldiers != 0 || corrupt.PrestigeTotal != 0 ||
+		corrupt.MilestonesDone != 0 || corrupt.MilestonesTotal != 0 {
+		t.Errorf("corrupt save has non-zero rich fields: %+v", *corrupt)
 	}
 	// The healthy neighbour must still be listed and parsed fine — one bad file
 	// must not poison the rest.

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -1,0 +1,276 @@
+package game
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestSave creates a real, signed, loadable save under the given base name
+// via the engine, and registers cleanup to remove it (and any "-copy" variants a
+// test may produce). It returns the engine so callers can reuse it for loads.
+func writeTestSave(t *testing.T, name string) *GameEngine {
+	t.Helper()
+	ge := NewGameEngine()
+	if err := ge.SaveGame(name); err != nil {
+		t.Fatalf("SaveGame(%q) failed: %v", name, err)
+	}
+	if !SaveExists(name) {
+		t.Fatalf("save %q not found after SaveGame", name)
+	}
+	t.Cleanup(func() {
+		// Best-effort cleanup; ignore errors (file may already be gone/renamed).
+		_ = os.Remove(savePath(name))
+		_ = os.Remove(savePath(name + "-copy"))
+		_ = os.Remove(savePath(name + "-copy-2"))
+	})
+	return ge
+}
+
+func TestSanitizeSaveName(t *testing.T) {
+	ok := []struct{ in, want string }{
+		{"my_save", "my_save"},
+		{"  spaced  ", "spaced"},
+		{"game.json", "game"}, // trailing .json stripped
+		{"save-copy-2", "save-copy-2"},
+	}
+	for _, tc := range ok {
+		got, err := sanitizeSaveName(tc.in)
+		if err != nil {
+			t.Errorf("sanitizeSaveName(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("sanitizeSaveName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+
+	bad := []string{
+		"",
+		"   ",
+		"../escape",
+		"foo/bar",
+		`foo\bar`,
+		"..",
+		"a..b",
+		".hidden",
+		string([]byte{'a', 0, 'b'}),
+		strings.Repeat("x", maxSaveNameLen+1),
+	}
+	for _, in := range bad {
+		if _, err := sanitizeSaveName(in); err == nil {
+			t.Errorf("sanitizeSaveName(%q) = nil error, want rejection", in)
+		}
+	}
+}
+
+func TestDeleteSave(t *testing.T) {
+	name := "test_delete_save"
+	writeTestSave(t, name)
+
+	if err := DeleteSave(name); err != nil {
+		t.Fatalf("DeleteSave(%q) failed: %v", name, err)
+	}
+	if SaveExists(name) {
+		t.Errorf("save %q still exists after DeleteSave", name)
+	}
+
+	// Missing file → clear error.
+	if err := DeleteSave("test_delete_does_not_exist"); err == nil {
+		t.Error("DeleteSave on missing file = nil error, want error")
+	}
+}
+
+func TestDeleteSaveRejectsTraversal(t *testing.T) {
+	// Sentinel file in a temp dir that a traversal name could target. It must
+	// survive a DeleteSave call with a crafted path-traversal name.
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "passwd")
+	if err := os.WriteFile(sentinel, []byte("do-not-delete"), 0644); err != nil {
+		t.Fatalf("failed to write sentinel: %v", err)
+	}
+
+	traversal := "../../../../../../../../" + tmp + "/passwd"
+	if err := DeleteSave(traversal); err == nil {
+		t.Errorf("DeleteSave(%q) = nil error, want rejection", traversal)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("sentinel file was touched/removed by traversal name: %v", err)
+	}
+
+	// A couple more crafted names for good measure.
+	for _, bad := range []string{"../../etc/passwd", `..\..\secrets`} {
+		if err := DeleteSave(bad); err == nil {
+			t.Errorf("DeleteSave(%q) = nil error, want rejection", bad)
+		}
+	}
+}
+
+func TestRenameSave(t *testing.T) {
+	oldName := "test_rename_old"
+	newName := "test_rename_new"
+	writeTestSave(t, oldName)
+	t.Cleanup(func() { _ = os.Remove(savePath(newName)) })
+
+	if err := RenameSave(oldName, newName); err != nil {
+		t.Fatalf("RenameSave(%q,%q) failed: %v", oldName, newName, err)
+	}
+	if SaveExists(oldName) {
+		t.Errorf("old save %q still exists after rename", oldName)
+	}
+	if !SaveExists(newName) {
+		t.Fatalf("new save %q missing after rename", newName)
+	}
+	// Renamed file must still load (signature preserved — bytes unchanged).
+	if err := NewGameEngine().LoadGame(newName); err != nil {
+		t.Errorf("LoadGame(%q) after rename failed: %v", newName, err)
+	}
+
+	// Collision: renaming onto an existing save must be rejected.
+	other := "test_rename_other"
+	writeTestSave(t, other)
+	if err := RenameSave(other, newName); err == nil {
+		t.Errorf("RenameSave onto existing %q = nil error, want rejection", newName)
+	}
+	if !SaveExists(other) {
+		t.Errorf("source %q should be untouched after a rejected collision", other)
+	}
+
+	// Invalid target name.
+	if err := RenameSave(newName, "../escape"); err == nil {
+		t.Error("RenameSave to invalid name = nil error, want rejection")
+	}
+	// Missing source.
+	if err := RenameSave("test_rename_missing", "whatever"); err == nil {
+		t.Error("RenameSave with missing source = nil error, want error")
+	}
+}
+
+func TestDuplicateSave(t *testing.T) {
+	name := "test_dup_save"
+	writeTestSave(t, name)
+
+	first, err := DuplicateSave(name)
+	if err != nil {
+		t.Fatalf("DuplicateSave(%q) failed: %v", name, err)
+	}
+	if first != name+"-copy" {
+		t.Errorf("first duplicate name = %q, want %q", first, name+"-copy")
+	}
+	if !SaveExists(first) {
+		t.Fatalf("first duplicate %q missing", first)
+	}
+	// Both original and copy must load.
+	if err := NewGameEngine().LoadGame(name); err != nil {
+		t.Errorf("LoadGame(original %q) failed: %v", name, err)
+	}
+	if err := NewGameEngine().LoadGame(first); err != nil {
+		t.Errorf("LoadGame(copy %q) failed: %v", first, err)
+	}
+
+	// Second duplicate must bump to "-copy-2".
+	second, err := DuplicateSave(name)
+	if err != nil {
+		t.Fatalf("second DuplicateSave(%q) failed: %v", name, err)
+	}
+	if second != name+"-copy-2" {
+		t.Errorf("second duplicate name = %q, want %q", second, name+"-copy-2")
+	}
+	if !SaveExists(second) {
+		t.Errorf("second duplicate %q missing", second)
+	}
+
+	// Missing source.
+	if _, err := DuplicateSave("test_dup_missing"); err == nil {
+		t.Error("DuplicateSave on missing source = nil error, want error")
+	}
+}
+
+func TestListSaveDetailsPopulatesFields(t *testing.T) {
+	name := "test_details_save"
+	ge := writeTestSave(t, name)
+	// Give the save a non-trivial tick so we can assert it round-trips.
+	ge.mu.Lock()
+	ge.tick = 1234
+	ge.mu.Unlock()
+	if err := ge.SaveGame(name); err != nil {
+		t.Fatalf("re-SaveGame failed: %v", err)
+	}
+
+	details, err := ListSaveDetails()
+	if err != nil {
+		t.Fatalf("ListSaveDetails failed: %v", err)
+	}
+	var found *SaveInfo
+	for i := range details {
+		if details[i].Name == name {
+			found = &details[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("save %q not present in ListSaveDetails output", name)
+	}
+	if found.Corrupt {
+		t.Errorf("freshly written save %q flagged Corrupt", name)
+	}
+	if found.Tick != 1234 {
+		t.Errorf("Tick = %d, want 1234", found.Tick)
+	}
+	if found.Age == "" {
+		t.Errorf("Age is empty, want the engine's starting age")
+	}
+	if found.Timestamp.IsZero() {
+		t.Errorf("Timestamp is zero, want the save's timestamp")
+	}
+	// A fresh engine has full morale; ensure the field was parsed (non-zero).
+	if found.Morale <= 0 {
+		t.Errorf("Morale = %v, want > 0", found.Morale)
+	}
+}
+
+func TestListSaveDetailsFlagsCorrupt(t *testing.T) {
+	// Ensure the dir exists, then drop a non-JSON .json file into it.
+	good := "test_corrupt_neighbor"
+	writeTestSave(t, good) // guarantees the save dir exists
+
+	dir := saveDirectory()
+	corruptName := "test_corrupt_file"
+	corruptPath := filepath.Join(dir, corruptName+".json")
+	if err := os.WriteFile(corruptPath, []byte("this is not json {{{"), 0644); err != nil {
+		t.Fatalf("failed to write corrupt save: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(corruptPath) })
+
+	details, err := ListSaveDetails()
+	if err != nil {
+		t.Fatalf("ListSaveDetails failed (should not error on a corrupt file): %v", err)
+	}
+
+	var corrupt, healthy *SaveInfo
+	for i := range details {
+		switch details[i].Name {
+		case corruptName:
+			corrupt = &details[i]
+		case good:
+			healthy = &details[i]
+		}
+	}
+	if corrupt == nil {
+		t.Fatalf("corrupt save %q not present in output (should be included, not dropped)", corruptName)
+	}
+	if !corrupt.Corrupt {
+		t.Errorf("corrupt save %q not flagged Corrupt", corruptName)
+	}
+	if corrupt.Timestamp.IsZero() {
+		t.Errorf("corrupt save Timestamp is zero, want file mtime fallback")
+	}
+	// The healthy neighbour must still be listed and parsed fine — one bad file
+	// must not poison the rest.
+	if healthy == nil {
+		t.Errorf("healthy save %q dropped from listing alongside a corrupt file", good)
+	} else if healthy.Corrupt {
+		t.Errorf("healthy save %q wrongly flagged Corrupt", good)
+	}
+}

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -210,7 +210,7 @@ Save files live in `./data/saves/*.json`, relative to the directory you launch t
 
 From the main menu, choosing **Load Game** opens a save browser that lists every save in `./data/saves/` (most-recent first). Load Game is always available — if you have no saves yet, the browser shows a "No saved games found — start a new game" message instead of an empty list.
 
-Highlighting a save updates a **detail pane** on the side, showing that save's age, progress (tick count), prestige level, morale, and exact save time.
+Highlighting a save updates a **detail pane** on the side with everything you need to size up that save before loading it: its earned title, age and epoch, civilization scale (population, buildings, wonders, milestones, techs, soldiers), prestige level and points, morale, a ⚠ warning if a catastrophe is pending, and the exact save time.
 
 **Keys inside the browser:**
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -200,6 +200,38 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 | `dump` | Export logs to a file for debugging |
 | `help` | Show a quick command summary |
 
+Save files live in `./data/saves/*.json`, relative to the directory you launch the game from. The `save <name>` and `load <name>` commands above work with the same files as the **Load Game** browser below.
+
+---
+
+## Saving & Loading
+
+### The Load Game browser
+
+From the main menu, choosing **Load Game** opens a save browser that lists every save in `./data/saves/` (most-recent first). Load Game is always available — if you have no saves yet, the browser shows a "No saved games found — start a new game" message instead of an empty list.
+
+Highlighting a save updates a **detail pane** on the side, showing that save's age, progress (tick count), prestige level, morale, and exact save time.
+
+**Keys inside the browser:**
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move the highlight between saves |
+| `Enter` | Load the highlighted save |
+| `d` | Delete the highlighted save (asks you to confirm first) |
+| `r` | Rename the highlighted save (type a new name; names that collide with an existing save or contain path characters are rejected) |
+| `c` | Duplicate the highlighted save (creates `<name>-copy`) |
+| `Esc` | Return to the main menu |
+
+**Row tags:**
+
+| Tag | Meaning |
+|---|---|
+| ★ auto | The autosave slot |
+| ⭐ elite | An elite save |
+| ⚠ modified | The save file was edited outside the game (cheater badge) |
+| ⚠ corrupt | The file could not be read. It is still listed but dimmed, and cannot be loaded |
+
 ---
 
 ## Tab shortcuts

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -85,8 +85,8 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 	b.root = tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(title, 1, 0, false).
 		AddItem(b.subtitle, 1, 0, false).
-		AddItem(b.list, 0, 1, true). // weighted — takes remaining space
-		AddItem(b.detail, 8, 0, false).
+		AddItem(b.list, 0, 1, true).     // weighted — takes remaining space
+		AddItem(b.detail, 10, 0, false). // fits 6 content lines + optional badge + border
 		AddItem(footer, 1, 0, false)
 
 	b.list.SetInputCapture(b.handleKey)
@@ -427,8 +427,13 @@ func rowTag(s game.SaveInfo) string {
 	return ""
 }
 
-// detailText renders the detail pane for a save. Healthy saves show the full
-// stat block; corrupt saves show only the unloadable notice + file time.
+// detailSep is the gold middle-dot separator between detail-pane segments.
+const detailSep = " [gold]·[-] "
+
+// detailText renders the detail pane for a save. Healthy saves show a rich stat
+// block (identity, population/structures, progress, prestige/morale, an optional
+// catastrophe warning, and save metadata); corrupt saves show only the
+// unloadable notice + file time.
 func detailText(s game.SaveInfo) string {
 	if s.Corrupt {
 		return fmt.Sprintf(
@@ -437,18 +442,61 @@ func detailText(s game.SaveInfo) string {
 		)
 	}
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "[white]%s[-]\n", s.Name)
-	fmt.Fprintf(&sb, "[#8b949e]Age:[-] %s   ", ageDisplay(s.Age))
-	fmt.Fprintf(&sb, "[#8b949e]Progress:[-] %s ticks   ", commafy(s.Tick))
-	fmt.Fprintf(&sb, "[#8b949e]Prestige:[-] %d\n", s.PrestigeLevel)
-	fmt.Fprintf(&sb, "[#8b949e]Morale:[-] %.0f%%   ", s.Morale*100)
-	fmt.Fprintf(&sb, "[#8b949e]Saved:[-] %s", s.Timestamp.Format("Jan 2, 2006 3:04 PM"))
+	var lines []string
 
-	if badges := detailBadges(s); badges != "" {
-		fmt.Fprintf(&sb, "\n%s", badges)
+	// Line 1 — identity: "Title" · Age · Epoch. Drop the quoted title when empty
+	// so the line starts cleanly with the Age (no empty quotes).
+	var id []string
+	if s.Title != "" {
+		id = append(id, fmt.Sprintf("[gold]\"%s\"[-]", s.Title))
 	}
-	return sb.String()
+	id = append(id, fmt.Sprintf("[white]%s[-]", ageDisplay(s.Age)))
+	if s.Epoch != "" {
+		id = append(id, fmt.Sprintf("[#8b949e]%s[-]", s.Epoch))
+	}
+	lines = append(lines, strings.Join(id, detailSep))
+
+	// Line 2 — civilisation footprint.
+	lines = append(lines, strings.Join([]string{
+		fmt.Sprintf("[#8b949e]Population[-] [white]%s[-]", commafy(s.Population)),
+		fmt.Sprintf("[#8b949e]Buildings[-] [white]%s[-]", commafy(s.Buildings)),
+		fmt.Sprintf("[#8b949e]Wonders[-] [white]%s[-]", commafy(s.Wonders)),
+	}, detailSep))
+
+	// Line 3 — progress markers. Milestones show "done/total" only when the total
+	// is known (config accessor available).
+	milestones := commafy(s.MilestonesDone)
+	if s.MilestonesTotal > 0 {
+		milestones = fmt.Sprintf("%s/%s", commafy(s.MilestonesDone), commafy(s.MilestonesTotal))
+	}
+	lines = append(lines, strings.Join([]string{
+		fmt.Sprintf("[#8b949e]Milestones[-] [white]%s[-]", milestones),
+		fmt.Sprintf("[#8b949e]Techs[-] [white]%s[-]", commafy(s.Techs)),
+		fmt.Sprintf("[#8b949e]Soldiers[-] [white]%s[-]", commafy(s.Soldiers)),
+	}, detailSep))
+
+	// Line 4 — prestige + morale.
+	lines = append(lines, strings.Join([]string{
+		fmt.Sprintf("[#8b949e]Prestige[-] [white]Lv %s[-] [#8b949e](%s pts)[-]", commafy(s.PrestigeLevel), commafy(s.PrestigeTotal)),
+		fmt.Sprintf("[#8b949e]Morale[-] [white]%.0f%%[-]", s.Morale*100),
+	}, detailSep))
+
+	// Line 5 — looming catastrophe warning (omitted entirely when none pending).
+	if s.PendingCatastrophe != "" {
+		lines = append(lines, fmt.Sprintf("[red]⚠ Pending: %s[-]", s.PendingCatastrophe))
+	}
+
+	// Line 6 — save metadata.
+	lines = append(lines, fmt.Sprintf(
+		"[#8b949e]Saved[-] %s [gold]·[-] [#8b949e]%s ticks[-]",
+		s.Timestamp.Format("Jan 2, 2006 3:04 PM"), commafy(s.Tick),
+	))
+
+	out := strings.Join(lines, "\n")
+	if badges := detailBadges(s); badges != "" {
+		out += "\n" + badges
+	}
+	return out
 }
 
 // detailBadges returns the badge line for the detail pane, or "".

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -79,7 +79,7 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 	footer := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
-		SetText("[#8b949e][↑↓] Navigate   [Enter] Load   [d] Delete   [r] Rename   [c] Duplicate   [Esc] Back[-]")
+		SetText(footerBar())
 
 	// ── Layout ───────────────────────────────────────────────────────────────
 	b.root = tview.NewFlex().SetDirection(tview.FlexRow).
@@ -395,6 +395,25 @@ func rowLabel(s game.SaveInfo) string {
 
 // rowTag returns the trailing status tag for a (non-corrupt) save row, or "".
 // Precedence: autosave first, then modified, then elite.
+// footerButton renders one keycap-style action button: the hotkey on a gold
+// cap fused to its label on a dark chip — e.g. a gold "Enter" beside "Load".
+func footerButton(key, label string) string {
+	return fmt.Sprintf("[black:gold:b] %s [white:#30363d:b] %s [-:-:-]", key, label)
+}
+
+// footerBar is the Load Game action bar: a keycap button per action so the
+// player can see at a glance which key triggers what.
+func footerBar() string {
+	return "  " + strings.Join([]string{
+		footerButton("↑↓", "Navigate"),
+		footerButton("Enter", "Load"),
+		footerButton("D", "Delete"),
+		footerButton("R", "Rename"),
+		footerButton("C", "Duplicate"),
+		footerButton("Esc", "Back"),
+	}, "  ") + "  "
+}
+
 func rowTag(s game.SaveInfo) string {
 	if s.Name == game.AutosaveName {
 		return "[gold]★ auto[-]"

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -1,0 +1,555 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/espresso20/ageforge/config"
+	"github.com/espresso20/ageforge/game"
+)
+
+// loadGamePage is the page name under which the Load Game browser is registered
+// on the root Pages. It is added on demand (from the splash handler) and removed
+// on Back/Load so the save list is always rebuilt fresh.
+const loadGamePage = "load_game"
+
+// loadGameBrowser holds the widgets and live state for the Load Game screen.
+// Everything the input handlers and refresh logic touch hangs off this struct so
+// the page can be rebuilt cheaply and selection restored after delete/rename/dup.
+type loadGameBrowser struct {
+	app    *tview.Application
+	pages  *tview.Pages
+	engine *game.GameEngine
+
+	root     *tview.Flex
+	list     *tview.List
+	detail   *tview.TextView
+	subtitle *tview.TextView
+
+	saves []game.SaveInfo // current rows, sorted most-recent first
+}
+
+// CreateLoadGamePage builds the full-screen Load Game browser and returns its
+// root primitive. The caller registers it (e.g. pages.AddPage(loadGamePage, ...))
+// and sets focus to the returned primitive's list — call SetFocus on the value
+// returned by FocusTarget, or just rely on AddPage's focus when it is the only
+// page shown. The screen is self-contained: all key handling lives on the list.
+func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game.GameEngine) tview.Primitive {
+	b := &loadGameBrowser{
+		app:    app,
+		pages:  pages,
+		engine: engine,
+	}
+
+	// ── Title ────────────────────────────────────────────────────────────────
+	title := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("[gold]═══ Load Game ═══[-]")
+
+	b.subtitle = tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter)
+
+	// ── Save list ────────────────────────────────────────────────────────────
+	b.list = tview.NewList()
+	b.list.SetBorder(false)
+	b.list.SetSelectedBackgroundColor(tcell.ColorGold)
+	b.list.SetSelectedTextColor(tcell.ColorBlack)
+	b.list.ShowSecondaryText(false)
+	b.list.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
+		b.updateDetail(index)
+	})
+
+	// ── Detail pane ──────────────────────────────────────────────────────────
+	b.detail = tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(true)
+	b.detail.SetBorder(true).
+		SetBorderColor(tcell.ColorGold).
+		SetTitle(" Details ").
+		SetTitleColor(tcell.ColorGold)
+
+	// ── Footer ───────────────────────────────────────────────────────────────
+	footer := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("[#8b949e][↑↓] Navigate   [Enter] Load   [d] Delete   [r] Rename   [c] Duplicate   [Esc] Back[-]")
+
+	// ── Layout ───────────────────────────────────────────────────────────────
+	b.root = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(title, 1, 0, false).
+		AddItem(b.subtitle, 1, 0, false).
+		AddItem(b.list, 0, 1, true). // weighted — takes remaining space
+		AddItem(b.detail, 8, 0, false).
+		AddItem(footer, 1, 0, false)
+
+	b.list.SetInputCapture(b.handleKey)
+
+	b.refresh(0)
+	return b.root
+}
+
+// refresh re-reads the save listing, re-sorts most-recent first, rebuilds the
+// list rows, and restores a clamped selection. wantIdx is the index to select
+// after the rebuild (clamped to range); pass the current index to keep position.
+func (b *loadGameBrowser) refresh(wantIdx int) {
+	saves, err := game.ListSaveDetails()
+	if err != nil {
+		// A listing error is rare (the saves dir not existing returns nil,nil).
+		// Surface it in the detail pane rather than crashing, and show an empty list.
+		b.saves = nil
+		b.list.Clear()
+		b.subtitle.SetText("[#8b949e]" + savesDirLabel() + " — could not read saves[-]")
+		b.detail.SetText(fmt.Sprintf("[red]Could not read saves: %v[-]", err))
+		return
+	}
+
+	// Sort most-recent first by Timestamp.
+	sort.SliceStable(saves, func(i, j int) bool {
+		return saves[i].Timestamp.After(saves[j].Timestamp)
+	})
+	b.saves = saves
+
+	b.subtitle.SetText(fmt.Sprintf("[#8b949e]%s — %s[-]", savesDirLabel(), pluralSaves(len(saves))))
+
+	b.list.Clear()
+	if len(saves) == 0 {
+		// Empty state — the action keys become no-ops (handleKey guards on len).
+		b.detail.SetText("[#8b949e]No saved games found in " + savesDir() + ".\n\nStart a new game to create one.[-]")
+		return
+	}
+
+	for _, s := range saves {
+		b.list.AddItem(rowLabel(s), "", 0, nil)
+	}
+
+	// Restore a sensible selection (clamp to range).
+	if wantIdx < 0 {
+		wantIdx = 0
+	}
+	if wantIdx >= len(saves) {
+		wantIdx = len(saves) - 1
+	}
+	b.list.SetCurrentItem(wantIdx)
+	// SetCurrentItem fires SetChangedFunc only when the index actually changes;
+	// force the detail pane to reflect the (possibly unchanged) selection.
+	b.updateDetail(wantIdx)
+}
+
+// updateDetail renders the detail pane for the save at index. Out-of-range or
+// empty selections render nothing harmful.
+func (b *loadGameBrowser) updateDetail(index int) {
+	if index < 0 || index >= len(b.saves) {
+		return
+	}
+	b.detail.SetText(detailText(b.saves[index]))
+}
+
+// selected returns the currently selected SaveInfo and true, or a zero value and
+// false when the list is empty / selection is out of range.
+func (b *loadGameBrowser) selected() (game.SaveInfo, bool) {
+	idx := b.list.GetCurrentItem()
+	if idx < 0 || idx >= len(b.saves) {
+		return game.SaveInfo{}, false
+	}
+	return b.saves[idx], true
+}
+
+// handleKey routes the action keys for the browser. tview.List handles ↑/↓
+// natively; we intercept Enter/d/r/c/Esc/q.
+func (b *loadGameBrowser) handleKey(event *tcell.EventKey) *tcell.EventKey {
+	switch event.Key() {
+	case tcell.KeyEnter:
+		b.doLoad()
+		return nil
+	case tcell.KeyEsc:
+		b.back()
+		return nil
+	case tcell.KeyRune:
+		switch event.Rune() {
+		case 'd', 'D':
+			b.doDelete()
+			return nil
+		case 'r', 'R':
+			b.doRename()
+			return nil
+		case 'c', 'C':
+			b.doDuplicate()
+			return nil
+		case 'q', 'Q':
+			b.back()
+			return nil
+		}
+	}
+	return event
+}
+
+// back removes the load_game page and returns to the splash.
+func (b *loadGameBrowser) back() {
+	b.pages.RemovePage(loadGamePage)
+	b.pages.SwitchToPage("splash")
+}
+
+// doLoad loads the selected save and transitions to the dashboard. Corrupt saves
+// are refused with an inline message. Load errors are shown inline and stay.
+func (b *loadGameBrowser) doLoad() {
+	s, ok := b.selected()
+	if !ok {
+		return
+	}
+	if s.Corrupt {
+		b.detail.SetText(detailText(s) + "\n\n[red]Can't load a corrupt save.[-]")
+		return
+	}
+	if err := b.engine.LoadGame(s.Name); err != nil {
+		b.engine.AddLog("error", fmt.Sprintf("Load failed: %v", err))
+		b.detail.SetText(detailText(s) + fmt.Sprintf("\n\n[red]Load failed: %v[-]", err))
+		return
+	}
+	b.engine.AddLog("success", "Game loaded!")
+	// Mirror splash.go's post-load transition exactly.
+	b.pages.RemovePage(loadGamePage)
+	b.pages.SwitchToPage("dashboard")
+	go b.engine.Start()
+}
+
+// doDelete shows a red confirm modal, then deletes on confirm and refreshes.
+func (b *loadGameBrowser) doDelete() {
+	s, ok := b.selected()
+	if !ok {
+		return
+	}
+	curIdx := b.list.GetCurrentItem()
+
+	const page = "load_game_delete"
+	modal := tview.NewModal().
+		SetText(fmt.Sprintf("Delete '%s'?\n\nThis can't be undone.", s.Name)).
+		AddButtons([]string{"Cancel", "Delete"}).
+		SetDoneFunc(func(_ int, label string) {
+			b.pages.RemovePage(page)
+			b.app.SetFocus(b.list)
+			if label != "Delete" {
+				return
+			}
+			if err := game.DeleteSave(s.Name); err != nil {
+				b.engine.AddLog("error", fmt.Sprintf("Delete failed: %v", err))
+				b.detail.SetText(fmt.Sprintf("[red]Delete failed: %v[-]", err))
+				return
+			}
+			// Keep the selection near where it was; clamp happens in refresh.
+			b.refresh(curIdx)
+		})
+	modal.SetBackgroundColor(tcell.ColorDarkRed)
+	b.pages.AddPage(page, modal, true, true)
+}
+
+// doRename shows an input modal prefilled with the current name. Errors from
+// RenameSave (collision/invalid) surface inline in the dialog and let the player
+// retry. On success the dialog closes, the list refreshes, and the renamed item
+// stays selected.
+func (b *loadGameBrowser) doRename() {
+	s, ok := b.selected()
+	if !ok {
+		return
+	}
+	if s.Corrupt {
+		// A corrupt file can still be renamed at the FS level, but there's no
+		// healthy use for it; keep behaviour simple and allow it — RenameSave
+		// only touches the filename, not the bytes.
+	}
+
+	const page = "load_game_rename"
+
+	errTV := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter)
+
+	input := tview.NewInputField().
+		SetLabel("Name: ").
+		SetText(s.Name).
+		SetFieldWidth(40)
+
+	close := func() {
+		b.pages.RemovePage(page)
+		b.app.SetFocus(b.list)
+	}
+
+	submit := func() {
+		newName := strings.TrimSpace(input.GetText())
+		if err := game.RenameSave(s.Name, newName); err != nil {
+			errTV.SetText(fmt.Sprintf("[red]%v[-]", err))
+			b.app.SetFocus(input)
+			return
+		}
+		b.pages.RemovePage(page)
+		b.app.SetFocus(b.list)
+		// Refresh, then re-select the renamed item by its new name.
+		b.refresh(0)
+		b.selectByName(newName)
+	}
+
+	okBtn := tview.NewButton("[ OK ]").SetSelectedFunc(submit)
+	okBtn.SetBackgroundColor(tcell.ColorGold)
+	okBtn.SetLabelColor(tcell.ColorBlack)
+	cancelBtn := tview.NewButton("[ Cancel ]").SetSelectedFunc(close)
+
+	// Enter in the input field submits.
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			submit()
+		}
+	})
+
+	btnRow := tview.NewFlex().SetDirection(tview.FlexColumn).
+		AddItem(tview.NewBox(), 0, 1, false).
+		AddItem(okBtn, 8, 0, false).
+		AddItem(tview.NewBox(), 2, 0, false).
+		AddItem(cancelBtn, 12, 0, false).
+		AddItem(tview.NewBox(), 0, 1, false)
+
+	inner := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(input, 1, 0, true).
+		AddItem(tview.NewBox(), 1, 0, false).
+		AddItem(errTV, 1, 0, false).
+		AddItem(tview.NewBox(), 1, 0, false).
+		AddItem(btnRow, 1, 0, false)
+	inner.SetBorder(true).
+		SetTitle(" Rename Save ").
+		SetTitleColor(tcell.ColorGold).
+		SetBorderColor(tcell.ColorGold)
+
+	// Tab cycles input → OK → Cancel; Esc cancels from anywhere on the modal.
+	focusOrder := []tview.Primitive{input, okBtn, cancelBtn}
+	focusIdx := 0
+	modal := centeredModal(inner, 50, 9)
+	modal.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
+		switch ev.Key() {
+		case tcell.KeyEsc:
+			close()
+			return nil
+		case tcell.KeyTab:
+			focusIdx = (focusIdx + 1) % len(focusOrder)
+			b.app.SetFocus(focusOrder[focusIdx])
+			return nil
+		case tcell.KeyBacktab:
+			focusIdx = (focusIdx - 1 + len(focusOrder)) % len(focusOrder)
+			b.app.SetFocus(focusOrder[focusIdx])
+			return nil
+		}
+		return ev
+	})
+
+	b.pages.AddPage(page, modal, true, true)
+	b.app.SetFocus(input)
+}
+
+// doDuplicate duplicates the selected save with no prompt, refreshes, and selects
+// the new copy.
+func (b *loadGameBrowser) doDuplicate() {
+	s, ok := b.selected()
+	if !ok {
+		return
+	}
+	newName, err := game.DuplicateSave(s.Name)
+	if err != nil {
+		b.engine.AddLog("error", fmt.Sprintf("Duplicate failed: %v", err))
+		b.detail.SetText(fmt.Sprintf("[red]Duplicate failed: %v[-]", err))
+		return
+	}
+	b.refresh(0)
+	b.selectByName(newName)
+}
+
+// selectByName moves the selection to the row whose save name matches, if present.
+func (b *loadGameBrowser) selectByName(name string) {
+	for i, s := range b.saves {
+		if s.Name == name {
+			b.list.SetCurrentItem(i)
+			b.updateDetail(i)
+			return
+		}
+	}
+}
+
+// ── Pure helpers (formatting) ───────────────────────────────────────────────
+
+// rowLabel renders one list row: name, age, relative time, and a trailing tag.
+// Corrupt rows are dimmed grey.
+func rowLabel(s game.SaveInfo) string {
+	if s.Corrupt {
+		return fmt.Sprintf("[gray]%s   —   %s   ⚠ corrupt[-]", s.Name, relativeTime(s.Timestamp))
+	}
+	age := ageDisplay(s.Age)
+	tag := rowTag(s)
+	if tag != "" {
+		tag = "   " + tag
+	}
+	return fmt.Sprintf("%s   [#8b949e]%s   %s[-]%s", s.Name, age, relativeTime(s.Timestamp), tag)
+}
+
+// rowTag returns the trailing status tag for a (non-corrupt) save row, or "".
+// Precedence: autosave first, then modified, then elite.
+func rowTag(s game.SaveInfo) string {
+	if s.Name == game.AutosaveName {
+		return "[gold]★ auto[-]"
+	}
+	if s.Modified {
+		return "[red]⚠ modified[-]"
+	}
+	if s.Elite {
+		return "[gold]⭐ elite[-]"
+	}
+	return ""
+}
+
+// detailText renders the detail pane for a save. Healthy saves show the full
+// stat block; corrupt saves show only the unloadable notice + file time.
+func detailText(s game.SaveInfo) string {
+	if s.Corrupt {
+		return fmt.Sprintf(
+			"[red]⚠ Corrupt save — cannot be loaded[-]\n[#8b949e]File time: %s[-]",
+			s.Timestamp.Format("Jan 2, 2006 3:04 PM"),
+		)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[white]%s[-]\n", s.Name)
+	fmt.Fprintf(&sb, "[#8b949e]Age:[-] %s   ", ageDisplay(s.Age))
+	fmt.Fprintf(&sb, "[#8b949e]Progress:[-] %s ticks   ", commafy(s.Tick))
+	fmt.Fprintf(&sb, "[#8b949e]Prestige:[-] %d\n", s.PrestigeLevel)
+	fmt.Fprintf(&sb, "[#8b949e]Morale:[-] %.0f%%   ", s.Morale*100)
+	fmt.Fprintf(&sb, "[#8b949e]Saved:[-] %s", s.Timestamp.Format("Jan 2, 2006 3:04 PM"))
+
+	if badges := detailBadges(s); badges != "" {
+		fmt.Fprintf(&sb, "\n%s", badges)
+	}
+	return sb.String()
+}
+
+// detailBadges returns the badge line for the detail pane, or "".
+func detailBadges(s game.SaveInfo) string {
+	var parts []string
+	if s.Name == game.AutosaveName {
+		parts = append(parts, "[gold]★ autosave[-]")
+	}
+	if s.Elite {
+		parts = append(parts, "[gold]⭐ elite[-]")
+	}
+	if s.Modified {
+		parts = append(parts, "[red]⚠ modified[-]")
+	}
+	return strings.Join(parts, "   ")
+}
+
+// ageDisplay maps an age key to its display name (e.g. "stone_age" → "Stone Age").
+// Falls back to the raw key, or an em-dash when empty.
+func ageDisplay(key string) string {
+	if key == "" {
+		return "—"
+	}
+	if def, ok := config.AgeByKey()[key]; ok {
+		return def.Name
+	}
+	return key
+}
+
+// relativeTime renders a coarse human-friendly age for a timestamp, e.g.
+// "just now", "5m ago", "2h ago", "yesterday", "3 days ago". A zero timestamp
+// (possible on a corrupt file with no readable mtime) renders "unknown".
+func relativeTime(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	d := time.Since(t)
+	switch {
+	case d < 0:
+		// Clock skew / future-stamped save — treat as just now.
+		return "just now"
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		m := int(d / time.Minute)
+		return fmt.Sprintf("%dm ago", m)
+	case d < 24*time.Hour:
+		h := int(d / time.Hour)
+		return fmt.Sprintf("%dh ago", h)
+	case d < 48*time.Hour:
+		return "yesterday"
+	default:
+		days := int(d / (24 * time.Hour))
+		return fmt.Sprintf("%d days ago", days)
+	}
+}
+
+// commafy formats a non-negative int with thousands separators (e.g. 12400 →
+// "12,400"). Negative inputs are formatted with a leading minus.
+func commafy(n int) string {
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		if neg {
+			return "-" + s
+		}
+		return s
+	}
+	var out strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		out.WriteString(s[:pre])
+		if len(s) > pre {
+			out.WriteByte(',')
+		}
+	}
+	for i := pre; i < len(s); i += 3 {
+		out.WriteString(s[i : i+3])
+		if i+3 < len(s) {
+			out.WriteByte(',')
+		}
+	}
+	if neg {
+		return "-" + out.String()
+	}
+	return out.String()
+}
+
+// pluralSaves renders the save-count label ("1 save" / "N saves").
+func pluralSaves(n int) string {
+	if n == 1 {
+		return "1 save"
+	}
+	return fmt.Sprintf("%d saves", n)
+}
+
+// savesDir returns the player-facing saves folder label used in messages.
+func savesDir() string {
+	return "./data/saves/"
+}
+
+// savesDirLabel is the subtitle prefix (same folder, kept as its own helper so
+// the call sites read clearly).
+func savesDirLabel() string {
+	return savesDir()
+}
+
+// centeredModal wraps an inner primitive in nested Flex spacers so it floats at a
+// fixed width×height in the centre of the screen — the same idiom as
+// catastrophe_modal.go. width/height are fixed cell counts.
+func centeredModal(inner tview.Primitive, width, height int) *tview.Flex {
+	return tview.NewFlex().
+		AddItem(tview.NewBox(), 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(tview.NewBox(), 0, 1, false).
+			AddItem(inner, height, 0, true).
+			AddItem(tview.NewBox(), 0, 1, false),
+			width, 0, true).
+		AddItem(tview.NewBox(), 0, 1, false)
+}

--- a/ui/load_game_test.go
+++ b/ui/load_game_test.go
@@ -80,6 +80,72 @@ func TestDetailTextCorrupt(t *testing.T) {
 	}
 }
 
+func TestDetailTextPopulated(t *testing.T) {
+	s := game.SaveInfo{
+		Name:               "hero",
+		Timestamp:          time.Now(),
+		Age:                "iron_age",
+		Tick:               4242,
+		PrestigeLevel:      2,
+		PrestigeTotal:      1500,
+		Morale:             0.75,
+		Title:              "The Eternal",
+		Epoch:              "Iron Era",
+		Population:         10,
+		Buildings:          120,
+		Wonders:            3,
+		Techs:              4,
+		Soldiers:           137,
+		PendingCatastrophe: "The Great Plague",
+		MilestonesDone:     7,
+		MilestonesTotal:    33,
+	}
+	got := detailText(s)
+
+	// Every stat label and the title must render.
+	for _, want := range []string{
+		"The Eternal", "Iron Era",
+		"Population", "Buildings", "Wonders",
+		"Milestones", "7/33", "Techs", "Soldiers",
+		"Prestige", "Lv 2", "1,500 pts", "Morale", "75%",
+		"Pending", "The Great Plague",
+	} {
+		if !contains(got, want) {
+			t.Errorf("detailText(populated) missing %q\ngot: %q", want, got)
+		}
+	}
+}
+
+func TestDetailTextOmitsEmptyTitleAndCatastrophe(t *testing.T) {
+	s := game.SaveInfo{
+		Name:       "hero",
+		Timestamp:  time.Now(),
+		Age:        "stone_age",
+		Population: 5,
+		Buildings:  3,
+		// No Title, no PendingCatastrophe, no MilestonesTotal.
+		MilestonesDone: 1,
+	}
+	got := detailText(s)
+
+	// Empty title → no quoted segment leaking through.
+	if contains(got, "\"\"") {
+		t.Errorf("detailText with empty Title rendered empty quotes\ngot: %q", got)
+	}
+	// No looming catastrophe → the whole warning line is omitted.
+	if contains(got, "Pending") {
+		t.Errorf("detailText with empty PendingCatastrophe still shows a Pending line\ngot: %q", got)
+	}
+	// With no total known, Milestones shows a bare count (no slash).
+	if contains(got, "Milestones") && contains(got, "1/") {
+		t.Errorf("detailText showed Milestones with a total when none was set\ngot: %q", got)
+	}
+	// The age must still anchor line 1.
+	if !contains(got, ageDisplay("stone_age")) {
+		t.Errorf("detailText missing the age display for an untitled save\ngot: %q", got)
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/ui/load_game_test.go
+++ b/ui/load_game_test.go
@@ -1,0 +1,90 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+func TestCommafy(t *testing.T) {
+	cases := map[int]string{
+		0:       "0",
+		7:       "7",
+		42:      "42",
+		999:     "999",
+		1000:    "1,000",
+		12400:   "12,400",
+		100000:  "100,000",
+		1234567: "1,234,567",
+		-1500:   "-1,500",
+		-12:     "-12",
+	}
+	for in, want := range cases {
+		if got := commafy(in); got != want {
+			t.Errorf("commafy(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRelativeTime(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"zero", time.Time{}, "unknown"},
+		{"just now", now.Add(-10 * time.Second), "just now"},
+		{"minutes", now.Add(-5 * time.Minute), "5m ago"},
+		{"hours", now.Add(-2 * time.Hour), "2h ago"},
+		{"yesterday", now.Add(-30 * time.Hour), "yesterday"},
+		{"days", now.Add(-72 * time.Hour), "3 days ago"},
+		{"future", now.Add(10 * time.Minute), "just now"},
+	}
+	for _, c := range cases {
+		if got := relativeTime(c.t); got != c.want {
+			t.Errorf("relativeTime(%s) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRowTagPrecedence(t *testing.T) {
+	// Autosave wins even if modified/elite flags are also set.
+	auto := game.SaveInfo{Name: game.AutosaveName, Modified: true, Elite: true}
+	if got := rowTag(auto); got != "[gold]★ auto[-]" {
+		t.Errorf("rowTag(autosave) = %q, want auto tag", got)
+	}
+	// Modified outranks elite for a player-named save.
+	mod := game.SaveInfo{Name: "hero", Modified: true, Elite: true}
+	if got := rowTag(mod); got != "[red]⚠ modified[-]" {
+		t.Errorf("rowTag(modified) = %q, want modified tag", got)
+	}
+	// Elite when neither auto nor modified.
+	elite := game.SaveInfo{Name: "hero", Elite: true}
+	if got := rowTag(elite); got != "[gold]⭐ elite[-]" {
+		t.Errorf("rowTag(elite) = %q, want elite tag", got)
+	}
+	// Plain save → no tag.
+	plain := game.SaveInfo{Name: "hero"}
+	if got := rowTag(plain); got != "" {
+		t.Errorf("rowTag(plain) = %q, want empty", got)
+	}
+}
+
+func TestDetailTextCorrupt(t *testing.T) {
+	s := game.SaveInfo{Name: "broken", Corrupt: true, Timestamp: time.Now()}
+	got := detailText(s)
+	if want := "Corrupt save"; !contains(got, want) {
+		t.Errorf("detailText(corrupt) = %q, should mention %q", got, want)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/ui/load_game_test.go
+++ b/ui/load_game_test.go
@@ -88,3 +88,30 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+func TestFooterBarShowsHotkeyButtons(t *testing.T) {
+	bar := footerBar()
+	// Every action label must be present.
+	for _, label := range []string{"Navigate", "Load", "Delete", "Rename", "Duplicate", "Back"} {
+		if !contains(bar, label) {
+			t.Errorf("footerBar() missing action label %q", label)
+		}
+	}
+	// Every hotkey must render as a keycap (between the gold cap tag and the label tag).
+	for _, cap := range []string{"] ↑↓ [", "] Enter [", "] D [", "] R [", "] C [", "] Esc ["} {
+		if !contains(bar, cap) {
+			t.Errorf("footerBar() missing keycap %q", cap)
+		}
+	}
+	// Buttons must be styled with a real color tag, not plain text.
+	if !contains(bar, "[black:gold:b]") {
+		t.Errorf("footerBar() should style keycaps with a color tag, got %q", bar)
+	}
+	// Regression guard: the old footer used bare [Enter]/[d]/[r]/[c]/[Esc], which
+	// tview parses as color tags and SWALLOWS — the hotkeys vanished on screen.
+	for _, naked := range []string{"[Enter]", "[Esc]", "[d]", "[r]", "[c]"} {
+		if contains(bar, naked) {
+			t.Errorf("footerBar() contains swallowable tag %q — keys will vanish in tview", naked)
+		}
+	}
+}

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -22,8 +22,8 @@ var eliteMessages = []string{
 
 // CreateSplashPage creates the main menu splash screen.
 func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.GameEngine, currentVersion string) tview.Primitive {
-	saveExists := game.SaveExists("autosave")
-	_, eliteBadge := game.PeekSaveBadges("autosave")
+	saveExists := game.SaveExists(game.AutosaveName)
+	_, eliteBadge := game.PeekSaveBadges(game.AutosaveName)
 	prestigeLevel := engine.Prestige.GetLevel()
 
 	// Animated starfield + title canvas (takes the upper portion of the screen)
@@ -43,22 +43,18 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 	mainList.SetSelectedTextColor(tcell.ColorBlack)
 	mainList.ShowSecondaryText(false)
 
-	loadLabel := "  ⚔  Load Game"
-	if !saveExists {
-		loadLabel = "  ⚔  Load Game  [no save]"
-	}
-	mainList.AddItem(loadLabel, "", 'l', func() {
-		nav(func() {
-			if saveExists {
-				if err := engine.LoadGame("autosave"); err != nil {
-					engine.AddLog("error", fmt.Sprintf("Load failed: %v", err))
-				} else {
-					engine.AddLog("success", "Game loaded!")
-				}
-			}
-			pages.SwitchToPage("dashboard")
-			go engine.Start()
-		})
+	// The Load Game browser lists every save (player-named + autosave) and handles
+	// its own empty state, so the menu item is always enabled — gating it on the
+	// autosave alone would hide the browser even when player-named saves exist.
+	mainList.AddItem("  ⚔  Load Game", "", 'l', func() {
+		// Build the page fresh each time so the save list is always current,
+		// then add + focus it (mirrors the modal add/remove lifecycle). We do NOT
+		// halt the canvas here: the browser is an opaque full-screen page, so the
+		// animation runs harmlessly underneath and is still live when the player
+		// returns via Back (no need to rebuild the splash).
+		page := CreateLoadGamePage(app, pages, engine)
+		pages.AddPage(loadGamePage, page, true, true)
+		app.SetFocus(page)
 	})
 	mainList.AddItem("  ✦  New Game", "", 'n', func() {
 		nav(func() {


### PR DESCRIPTION
Closes `N1JBFxvZ`. The splash "Load Game" option now opens a real **save browser** instead of hard-loading `autosave`.

## What you get
A full-screen browser listing every save in `./data/saves/` (most-recent first) with a live **detail pane** (age, progress, prestige, morale, save time). Full management from the screen:

- `[Enter]` load · `[d]` delete (confirm) · `[r]` rename (inline-validated) · `[c]` duplicate · `[Esc]` back
- Row tags: ★ auto · ⚠ modified (cheater badge) · ⭐ elite · ⚠ corrupt (listed, dimmed, unloadable)
- Empty state guides you to start a new game; Load Game is now always available (no more "[no save]" gate)

## Stages
1. `dd240bd` — save layer: `DeleteSave`/`RenameSave`/`DuplicateSave` (path-traversal-safe via `sanitizeSaveName`) + extended `SaveInfo` metadata (tick/prestige/morale/corrupt)
2. `afd5969` — the screen: list + detail pane + the four actions + their modals + splash wiring (`game.AutosaveName` added)
3. `4839014` — wiki: "Saving & Loading" section in commands.md

## Testing
`go build/vet/test` green, gofmt clean. Save-layer logic is unit-tested (traversal rejection, rename collisions, duplicate suffixing, corrupt-file flagging); UI pure-helpers tested.

⚠️ **Wants a hands-on pass before merge** — the interactive bits (list nav, the delete/rename modals operating on real save files) are the part automated tests can't cover. Build is a clean runnable binary. Suggest: make a couple of saves, open Load Game, and exercise rename/duplicate/delete on a throwaway save.