### PR TITLE
Fix: stash unbuildable (first copy cost exceeded base wood cap)

### DIFF
--- a/config/buildings.go
+++ b/config/buildings.go
@@ -58,7 +58,12 @@ func baseBuildingsRaw() []BuildingDef {
 		// ===== PRIMITIVE AGE (costs: 30-100) =====
 		{
 			Name: "Stash", Key: "stash", Category: "storage",
-			BaseCost:    map[string]float64{"wood": 50},
+			// note: the first copy MUST stay affordable within wood's 50 base storage
+			// cap — stash is the only building that raises that cap, so a first-copy
+			// cost above 50 is an unbuildable deadlock. normalizeCostCurves multiplies
+			// this base by ~1.17 (storage 1.15->1.13, pivot@10), so keep the raw base
+			// well under ~42. 30 -> ~35 normalized, a comfortable margin under 50.
+			BaseCost:    map[string]float64{"wood": 30},
 			CostScale:   1.15,
 			MaxCount:    50,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 300}},

--- a/config/storage_deadlock_test.go
+++ b/config/storage_deadlock_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+// TestStash_FirstCopyAffordableWithinBaseWoodCap guards against the primitive-age
+// deadlock where the first stash costs more wood than the player can store.
+// Stash is the only building that raises the wood storage cap, so if its first
+// copy costs more than the base cap, it can never be built — softlocking the run.
+// (The cost-curve rebalance once pushed it to 59 vs a 50 cap; this test exists so
+// any future re-tune of normalizeCostCurves or the base cap re-surfaces it loudly.)
+func TestStash_FirstCopyAffordableWithinBaseWoodCap(t *testing.T) {
+	stash, ok := BuildingByKey()["stash"]
+	if !ok {
+		t.Fatal("stash building not found")
+	}
+
+	var woodCap float64
+	found := false
+	for _, r := range BaseResources() {
+		if r.Key == "wood" {
+			woodCap = r.BaseStorage
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("wood resource not found")
+	}
+
+	// First copy (count 0) costs exactly the (normalized) base.
+	firstCopy := stash.BaseCost["wood"]
+
+	if firstCopy > woodCap {
+		t.Fatalf("DEADLOCK: stash first copy costs %.0f wood but the base wood cap is %.0f — "+
+			"the only building that raises the cap is unbuildable", firstCopy, woodCap)
+	}
+	// Demand a real margin: a player must be able to gather up to the cost before
+	// hitting the cap, so it shouldn't sit right at the ceiling.
+	if firstCopy > woodCap*0.9 {
+		t.Errorf("stash first copy (%.0f wood) is too close to the wood cap (%.0f) — "+
+			"leave margin so it's reachable", firstCopy, woodCap)
+	}
+}

--- a/site/docs/first-ten-minutes.md
+++ b/site/docs/first-ten-minutes.md
@@ -42,7 +42,7 @@ While those build (8 ticks each), watch the build queue progress bar in the Econ
 
 ## Step 2: Build a stash
 
-Your food and wood caps are tiny (50 each). Storage fills fast and wastes production. Each stash gives **+300 storage** and you can build up to 30 before they're capped out.
+Your food and wood caps are tiny (50 each). Storage fills fast and wastes production. Your first stash costs **35 wood** — gather to that and build it early to break the cap. Each stash gives **+300 storage** and you can build up to 50 before they're capped out.
 
 ```
 build stash


### PR DESCRIPTION
Primitive-age softlock surfaced in playtest. Stash cost **59 wood** but the base wood cap is **50**, and stash is the only building that raises the cap → you could never build the first one.

Root cause: the #38 cost rebalance. Stash's raw base (50 wood, 1.15) gets multiplied ~1.17 by `normalizeCostCurves` (storage→1.13, pivot-around-copy-10) → 59, just over the cap.

**Fix:** lower stash's raw base 50 → 30 (normalized **~35 wood**, a 15-wood margin under the cap). Adds a config regression test (`TestStash_FirstCopyAffordableWithinBaseWoodCap`) asserting the first stash always fits within the base wood cap with margin — so a future cost re-tune can't silently re-deadlock. Invariant documented on the stash def.

Wiki: first-ten-minutes now states the 35-wood cost and fixes a stale 'up to 30' (cap is 50).

`go build/test` green; audit confirms stash@1 = 35. Relates to the open storage-curve card (mnrHFcwa).