### PR TITLE
Multiplier resolver — cutover (phases 3–4)

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -2733,6 +2733,12 @@ func (ge *GameEngine) GetState() GameState {
 			}
 			return out
 		}(),
+		// Snapshot the resolver's aggregated modifiers for the UI's Active
+		// Multipliers panel. buildResolver reads only already-held state and
+		// pure config.*, so it's safe under the RLock held here (it never
+		// re-acquires a lock). All() returns a fresh copy — no shared mutable
+		// state escapes.
+		Modifiers: ge.buildResolver().All(),
 	}
 }
 

--- a/game/engine.go
+++ b/game/engine.go
@@ -444,15 +444,11 @@ func (ge *GameEngine) getTickInterval() time.Duration {
 // The result is cached in ge.tickSpeedBonus; getTickInterval reads it.
 func (ge *GameEngine) recalculateTickSpeed() {
 	oldBonus := ge.tickSpeedBonus
-	bonus := ge.Research.GetBonus("tick_speed") +
-		ge.permanentBonuses["tick_speed"] +
-		ge.Prestige.GetBonuses()["tick_speed"]
-	// Add active event tick_speed effects (e.g., milestone chain boosts)
-	for _, eff := range ge.Events.GetActiveEffects() {
-		if eff.Type == "tick_speed" {
-			bonus += eff.Value
-		}
-	}
+	// tick_speed additive pool from the resolver (research + permanent + prestige
+	// + active-event tick_speed). buildResolver reads only write-lock-held state
+	// + pure config; recalculateTickSpeed runs under the write lock. UNgated, as
+	// before — the (1 + bonus) below applies regardless of sign.
+	bonus := ge.buildResolver().AddTotal("tick_speed")
 	ge.tickSpeedBonus = bonus
 
 	if bonus != oldBonus {
@@ -918,14 +914,16 @@ func (ge *GameEngine) recalculateRates() {
 		permanentBonuses[k] += v
 	}
 
+	// Additive bonus pools now come from the resolver — the single source of
+	// truth shared with Breakdown/UI. buildResolver reads only already-held
+	// state + pure config, so it is lock-safe on this write-locked recalc path.
+	// Application logic below (the >0 gates, morale via mMult) is unchanged:
+	// Phase 3 only moves WHERE the additive sums come from.
+	r := ge.buildResolver()
+
 	// Apply production_all bonus (multiplier on all positive rates)
-	// Accumulated from: research bonuses, permanent bonuses, prestige, and active event effects
-	prodAllBonus := researchBonuses["production_all"] + permanentBonuses["production_all"]
-	for _, eff := range ge.Events.GetActiveEffects() {
-		if eff.Type == "production_all" {
-			prodAllBonus += eff.Value
-		}
-	}
+	// Pool: research + permanent + prestige + wonders + active-event production_all.
+	prodAllBonus := r.AddTotal("production_all")
 	if prodAllBonus > 0 {
 		for _, def := range ge.Resources.defs {
 			r := ge.Resources.resources[def.Key]
@@ -939,7 +937,7 @@ func (ge *GameEngine) recalculateRates() {
 	// Includes legacy bonuses (stored in permanentBonuses["wood"] etc. after reapplyLegacyBonuses)
 	for _, def := range ge.Resources.defs {
 		bonusKey := def.Key + "_rate"
-		bonus := researchBonuses[bonusKey] + permanentBonuses[bonusKey]
+		bonus := r.AddTotal(bonusKey)
 		if bonus > 0 {
 			r := ge.Resources.resources[def.Key]
 			if r != nil && r.Rate > 0 {
@@ -949,7 +947,7 @@ func (ge *GameEngine) recalculateRates() {
 	}
 
 	// Apply gather_rate bonus to worker-generated rates
-	gatherBonus := researchBonuses["gather_rate"] + permanentBonuses["gather_rate"]
+	gatherBonus := r.AddTotal("gather_rate")
 	if gatherBonus > 0 {
 		// Already applied via multiplier above
 		// This is additive on base worker rates — re-add the bonus portion

--- a/game/modifiers.go
+++ b/game/modifiers.go
@@ -114,6 +114,20 @@ func (r *Resolver) Breakdown(target string) []Modifier {
 	return out
 }
 
+// All returns a flat copy of every modifier the resolver holds, across all
+// targets, in target-sorted order (and insertion order within a target). It is
+// the natural inverse of AddAll: snapshot a resolver's contents out, hand them
+// across a boundary (e.g. into a GameState for the UI), and rebuild an
+// equivalent resolver with NewResolver + AddAll. The returned slice is a copy,
+// so mutating it cannot corrupt the resolver.
+func (r *Resolver) All() []Modifier {
+	out := make([]Modifier, 0)
+	for _, target := range r.Targets() {
+		out = append(out, r.mods[target]...)
+	}
+	return out
+}
+
 // Targets returns the sorted, de-duplicated list of targets that currently have
 // at least one modifier. Handy for UI that wants to enumerate every multiplier
 // bucket. (Map keys are inherently unique, so this is sorted-only; the "deduped"

--- a/game/modifiers.go
+++ b/game/modifiers.go
@@ -87,6 +87,21 @@ func (r *Resolver) Total(target string) float64 {
 	return (1 + addSum) * mulProd
 }
 
+// AddTotal returns the additive bonus pool for target: the sum of every OpAdd
+// Value, ignoring OpMul factors entirely. This is the raw Σ that Total turns
+// into a (1 + Σ) factor — engine code that historically hand-summed these
+// additive contributions reads it here instead, so the pool has a single
+// source of truth. An empty or unknown target returns 0.
+func (r *Resolver) AddTotal(target string) float64 {
+	sum := 0.0
+	for _, m := range r.mods[target] {
+		if m.Op == OpAdd {
+			sum += m.Value
+		}
+	}
+	return sum
+}
+
 // Breakdown returns the modifiers contributing to target, in insertion order.
 //
 // The returned slice is a copy, so mutating it (or its backing array) cannot

--- a/game/modifiers_test.go
+++ b/game/modifiers_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/espresso20/ageforge/config"
 )
 
 // floatEq compares with a small epsilon for cases where binary floating point
@@ -165,5 +167,73 @@ func TestAddAll(t *testing.T) {
 	}
 	if got := r.Total("tick_speed"); !floatEq(got, 1.5) {
 		t.Fatalf("AddAll tick_speed total = %v, want 1.5", got)
+	}
+}
+
+// TestAddTotal_SumsOpAddIgnoresOpMul verifies AddTotal pools only OpAdd values
+// and never folds in an OpMul factor, and that an unknown target is 0.
+func TestAddTotal_SumsOpAddIgnoresOpMul(t *testing.T) {
+	r := NewResolver()
+	r.Add(Modifier{Source: "research", Target: "production_all", Op: OpAdd, Value: 0.25})
+	r.Add(Modifier{Source: "prestige", Target: "production_all", Op: OpAdd, Value: 0.10})
+	r.Add(Modifier{Source: "morale", Target: "production_all", Op: OpMul, Value: 1.18})
+	r.Add(Modifier{Source: "wonders", Target: "gold_rate", Op: OpAdd, Value: 0.40})
+
+	if got, want := r.AddTotal("production_all"), 0.35; math.Abs(got-want) > 1e-9 {
+		t.Errorf("production_all AddTotal = %.12f, want %.12f (OpMul must be ignored)", got, want)
+	}
+	if got, want := r.AddTotal("gold_rate"), 0.40; math.Abs(got-want) > 1e-9 {
+		t.Errorf("gold_rate AddTotal = %.12f, want %.12f", got, want)
+	}
+	if got := r.AddTotal("nonexistent_target"); got != 0 {
+		t.Errorf("unknown target AddTotal = %.12f, want 0", got)
+	}
+}
+
+// TestAddTotal_EqualsOldHandSum proves the resolver's additive pool is value-
+// identical to the OLD scattered hand-sum recalculateRates/recalculateTickSpeed
+// used: research[t] + permanent[t] + prestige[t] + wonders[t] + Σ active-event[t].
+// A representative state contributes to production_all (research+prestige+wonder+
+// event) and a <res>_rate (research+permanent+wonder), so an equal result means
+// the Phase-3 swap is a faithful drop-in.
+func TestAddTotal_EqualsOldHandSum(t *testing.T) {
+	ge := NewGameEngine()
+	ge.Research.bonuses["production_all"] = 0.10
+	ge.Research.bonuses["iron_rate"] = 0.20
+	ge.Prestige.level = 3 // passive +6% production_all
+	addWonder(ge, "test_addtotal_prodall", "production_all", 0.15, 1)
+	addWonder(ge, "test_addtotal_iron", "iron_rate", 0.10, 1)
+	ge.permanentBonuses["iron_rate"] = 0.07
+	ge.Events.InjectEvent(ActiveEvent{
+		Key:       "boom",
+		Name:      "Economic Boom",
+		TicksLeft: 40,
+		Effects:   []config.Effect{{Type: "production_all", Value: 0.20}},
+	})
+
+	r := ge.buildResolver()
+
+	// OLD hand-sum for production_all: research + (perm+prestige+wonders) + Σ events.
+	research := ge.Research.GetBonuses()
+	prestige := ge.Prestige.GetBonuses()
+	wonders := ge.getWonderBonuses()
+
+	oldProdAll := research["production_all"] + ge.permanentBonuses["production_all"] +
+		prestige["production_all"] + wonders["production_all"]
+	for _, eff := range ge.Events.GetActiveEffects() {
+		if eff.Type == "production_all" {
+			oldProdAll += eff.Value
+		}
+	}
+	if got := r.AddTotal("production_all"); math.Abs(got-oldProdAll) > 1e-9 {
+		t.Errorf("production_all: AddTotal=%.12f old hand-sum=%.12f", got, oldProdAll)
+	}
+
+	// OLD hand-sum for iron_rate: research + (perm+prestige+wonders). Events emit
+	// nothing for <res>_rate, so there is no event term here.
+	oldIron := research["iron_rate"] + ge.permanentBonuses["iron_rate"] +
+		prestige["iron_rate"] + wonders["iron_rate"]
+	if got := r.AddTotal("iron_rate"); math.Abs(got-oldIron) > 1e-9 {
+		t.Errorf("iron_rate: AddTotal=%.12f old hand-sum=%.12f", got, oldIron)
 	}
 }

--- a/game/modifiers_test.go
+++ b/game/modifiers_test.go
@@ -170,6 +170,38 @@ func TestAddAll(t *testing.T) {
 	}
 }
 
+// TestAll_RoundTrips verifies All() is the inverse of AddAll: flattening a
+// resolver and rebuilding from the dump reproduces every Total. This is the
+// path GetState → GameState.Modifiers → UI relies on.
+func TestAll_RoundTrips(t *testing.T) {
+	src := []Modifier{
+		{Source: "research", Target: "production_all", Op: OpAdd, Value: 0.10},
+		{Source: "morale", Target: "production_all", Op: OpMul, Value: 1.18},
+		{Source: "prestige", Target: "tick_speed", Op: OpAdd, Value: 0.05},
+		{Source: "event:peace", Target: "tick_speed", Op: OpAdd, Value: 0.01},
+	}
+	orig := NewResolver()
+	orig.AddAll(src)
+
+	flat := orig.All()
+	if len(flat) != len(src) {
+		t.Fatalf("All() len = %d, want %d", len(flat), len(src))
+	}
+
+	rebuilt := NewResolver()
+	rebuilt.AddAll(flat)
+	for _, target := range orig.Targets() {
+		if a, b := orig.Total(target), rebuilt.Total(target); !floatEq(a, b) {
+			t.Errorf("Total(%q): orig %v != rebuilt %v", target, a, b)
+		}
+	}
+
+	// Empty resolver yields a non-nil, zero-length slice (safe for AddAll).
+	if got := NewResolver().All(); got == nil || len(got) != 0 {
+		t.Errorf("empty All() = %v, want non-nil empty slice", got)
+	}
+}
+
 // TestAddTotal_SumsOpAddIgnoresOpMul verifies AddTotal pools only OpAdd values
 // and never folds in an OpMul factor, and that an unknown target is 0.
 func TestAddTotal_SumsOpAddIgnoresOpMul(t *testing.T) {

--- a/game/types.go
+++ b/game/types.go
@@ -60,6 +60,13 @@ type GameState struct {
 	// permanent bonuses (epoch events, legacy, milestones, etc.).
 	// Populated in GetState(); not stored in save JSON.
 	PermanentBonuses map[string]float64 `json:"-"`
+	// Modifiers is a flat snapshot of every modifier the engine's resolver
+	// aggregated this tick (research, prestige, wonders, permanent, morale,
+	// active events). The UI rebuilds a Resolver from it (NewResolver +
+	// AddAll) to render the Active Multipliers panel — same source of truth
+	// the engine uses for its rates, so the panel can never drift from the
+	// math. Populated in GetState(); not stored in save JSON.
+	Modifiers []Modifier `json:"-"`
 }
 
 // AgeAdvanceSummary holds data about what changed during an age advance transition.

--- a/site/docs/morale.md
+++ b/site/docs/morale.md
@@ -88,7 +88,7 @@ Stack enough of them and their per-tick lift outpaces the drift-to-neutral, park
 - **Workers panel** (`workers`) — a coloured morale bar.
 - **Villager sidebar** — the same coloured bar, always visible at a glance.
 - **Status bar** — the headline `Morale: NN%`, coloured by band, with a `+NN%` / `-NN%` tag when it is actively boosting or penalising production.
-- **Stats panel** (`stats`) — when morale is off-neutral it appears under **Active Multipliers** as a `+NN%` / `-NN%` line on all production, alongside your wonder, epoch, and prestige bonuses.
+- **Stats panel** (`stats`) — when morale is off-neutral it appears under **Active Multipliers** in the **All Production** breakdown as a `Morale ×N.NN` factor, shown alongside your research, wonder, prestige, and active-event bonuses on that line.
 - **Load Game browser** — each save's detail pane shows its morale, so you can size up a civilization before loading it.
 
 The bar is **green when morale is boosting production** (high band), **neutral in the middle**, and **red when it is penalising production** (low band).

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -183,216 +183,155 @@ func statsProvider(state game.GameState, _ int) string {
 
 	// ─── Active Multipliers ───
 	sb.WriteString("\n[gold]═══ Active Multipliers ═══[-]\n\n")
-
-	// Build attribution maps so we can label each bonus by source.
-	// These are re-derived from config definitions purely for display;
-	// the canonical totals always come from state.PermanentBonuses.
-	type bonusAttrib struct {
-		milestones float64
-		research   float64
-		prestige   float64
-		legacy     float64
-		wonders    float64
-		epoch      float64
-	}
-	attrib := map[string]*bonusAttrib{}
-
-	ensureTarget := func(target string) {
-		if attrib[target] == nil {
-			attrib[target] = &bonusAttrib{}
-		}
-	}
-
-	// 1. Milestone permanent_bonus effects
-	msDefs := config.MilestoneByKey()
-	for msKey, msInfo := range state.Milestones.Milestones {
-		if !msInfo.Completed {
-			continue
-		}
-		def, ok := msDefs[msKey]
-		if !ok {
-			continue
-		}
-		for _, eff := range def.Rewards {
-			if eff.Type == "permanent_bonus" {
-				ensureTarget(eff.Target)
-				attrib[eff.Target].milestones += eff.Value
-			}
-		}
-	}
-
-	// 2. Research bonus effects
-	techDefs := config.TechByKey()
-	for techKey, techState := range state.Research.Techs {
-		if !techState.Researched {
-			continue
-		}
-		def, ok := techDefs[techKey]
-		if !ok {
-			continue
-		}
-		for _, eff := range def.Effects {
-			if eff.Type == "bonus" {
-				ensureTarget(eff.Target)
-				attrib[eff.Target].research += eff.Value
-			}
-		}
-	}
-
-	// 3. Prestige — passive production_all bonus
-	if state.Prestige.PassiveBonus > 0 {
-		ensureTarget("production_all")
-		attrib["production_all"].prestige += state.Prestige.PassiveBonus
-	}
-	// Prestige — upgrade rate bonuses
-	prestigeDefs := config.PrestigeUpgradeByKey()
-	for key, uState := range state.Prestige.Upgrades {
-		if uState.Tier <= 0 {
-			continue
-		}
-		def, ok := prestigeDefs[key]
-		if !ok {
-			continue
-		}
-		if def.EffectType == "rate_bonus" {
-			ensureTarget(def.EffectKey)
-			attrib[def.EffectKey].prestige += def.PerTier * float64(uState.Tier)
-		}
-	}
-
-	// 4. Legacy bonuses
-	for epochKey, active := range state.LegacyBonuses {
-		if !active {
-			continue
-		}
-		legBonuses := config.LegacyBonusForEpoch(epochKey)
-		for target, mult := range legBonuses {
-			ensureTarget(target)
-			attrib[target].legacy += mult
-		}
-	}
-
-	// 5. Speed multiplier (from wonders)
-	if state.SpeedMultiplier > 1.0 {
-		ensureTarget("speed_multiplier")
-		attrib["speed_multiplier"].wonders += state.SpeedMultiplier - 1.0
-	}
-
-	// 6. Wonder bonus effects (Type "bonus" — production_all, knowledge_rate, expedition_reward, etc.)
-	// Iterate all built wonders and accumulate their percentage/multiplier bonuses.
-	buildingDefs := config.BaseBuildings()
-	buildingDefsByKey := make(map[string]config.BuildingDef, len(buildingDefs))
-	for _, bd := range buildingDefs {
-		buildingDefsByKey[bd.Key] = bd
-	}
-	for bKey, bState := range state.Buildings {
-		if bState.Count == 0 {
-			continue
-		}
-		def, ok := buildingDefsByKey[bKey]
-		if !ok || def.Category != "wonder" {
-			continue
-		}
-		for _, eff := range def.Effects {
-			if eff.Type == "bonus" {
-				ensureTarget(eff.Target)
-				attrib[eff.Target].wonders += eff.Value * float64(bState.Count)
-			}
-		}
-	}
-
-	// Collect targets that have any nonzero contribution
-	activeTargets := make([]string, 0, len(attrib))
-	for target, bc := range attrib {
-		total := bc.milestones + bc.research + bc.prestige + bc.legacy + bc.wonders
-		if total > 0 {
-			activeTargets = append(activeTargets, target)
-		}
-	}
-	if state.SpeedMultiplier > 1.0 {
-		if attrib["speed_multiplier"] == nil {
-			activeTargets = append(activeTargets, "speed_multiplier")
-		}
-	}
-
-	// Morale is an all-production multiplier when it's off neutral (1.0). It's
-	// not attributed by source like the others — it's a single banded factor —
-	// so it's rendered as a standalone line but must still count toward "is
-	// anything active" so the empty branch below doesn't fire on morale alone.
-	moraleActive := absFloat(state.MoraleMultiplier-1.0) > 0.0005
-
-	if len(activeTargets) == 0 && !moraleActive {
-		sb.WriteString(" [gray]No active multipliers[-]\n")
-	} else {
-		// Sort: production_all first, then alphabetical
-		sort.Slice(activeTargets, func(i, j int) bool {
-			if activeTargets[i] == "production_all" {
-				return true
-			}
-			if activeTargets[j] == "production_all" {
-				return false
-			}
-			return activeTargets[i] < activeTargets[j]
-		})
-
-		// Morale is an all-production factor — group it with the all-production
-		// entries at the top. Sign drives the colour (green bonus / red penalty);
-		// reuse computeMoraleBand so this matches the workers panel exactly.
-		if moraleActive {
-			band := computeMoraleBand(state.Morale, state.MoraleMultiplier)
-			moraleColor := "green"
-			sign := "+"
-			if band.DeltaPct < 0 {
-				moraleColor = "red"
-				sign = "" // %d already carries the minus sign for negatives
-			}
-			fmt.Fprintf(&sb, "  [cyan]%-20s[-] [%s]%s%d%%[-]  [gray](all production)[-]\n",
-				"Morale", moraleColor, sign, band.DeltaPct)
-		}
-
-		for _, target := range activeTargets {
-			var total float64
-			if target == "speed_multiplier" {
-				total = state.SpeedMultiplier - 1.0
-			} else {
-				total = state.PermanentBonuses[target]
-			}
-			a := attrib[target]
-			if a == nil {
-				a = &bonusAttrib{}
-			}
-
-			if target == "speed_multiplier" {
-				fmt.Fprintf(&sb, "  [cyan]%-20s[-] [yellow]+%.1fx[-]\n", target, total)
-			} else {
-				fmt.Fprintf(&sb, "  [cyan]%-20s[-] [yellow]+%.0f%%[-]\n", target, total*100)
-			}
-			if a.milestones > 0 {
-				fmt.Fprintf(&sb, "  [gray]  milestones     +%.0f%%[-]\n", a.milestones*100)
-			}
-			if a.research > 0 {
-				fmt.Fprintf(&sb, "  [gray]  research       +%.0f%%[-]\n", a.research*100)
-			}
-			if a.prestige > 0 {
-				fmt.Fprintf(&sb, "  [gray]  prestige       +%.0f%%[-]\n", a.prestige*100)
-			}
-			if a.legacy > 0 {
-				fmt.Fprintf(&sb, "  [gray]  legacy         +%.0f%%[-]\n", a.legacy*100)
-			}
-			if a.epoch > 0 {
-				fmt.Fprintf(&sb, "  [gray]  epoch events   +%.0f%%[-]\n", a.epoch*100)
-			}
-			if a.wonders > 0 {
-				if target == "speed_multiplier" {
-					fmt.Fprintf(&sb, "  [gray]  wonders        +%.1fx[-]\n", a.wonders)
-				} else {
-					fmt.Fprintf(&sb, "  [gray]  wonders        +%.0f%%[-]\n", a.wonders*100)
-				}
-			}
-		}
-	}
+	sb.WriteString(renderActiveMultipliers(state))
 
 	return sb.String()
+}
+
+// renderActiveMultipliers renders the Active Multipliers section from the
+// resolver snapshot carried on the state (state.Modifiers), the single source
+// of truth the engine also uses to compute its rates. We rebuild a Resolver
+// here rather than re-deriving bonuses from config: Total drives each headline,
+// Breakdown drives the per-source attribution, and the two can never disagree
+// because they read the same contributions.
+//
+// SpeedMultiplier is intentionally NOT a resolver modifier — it's a wonder-gate
+// concept layered on top of tick speed — so it gets its own line, as before.
+func renderActiveMultipliers(state game.GameState) string {
+	var sb strings.Builder
+
+	r := game.NewResolver()
+	r.AddAll(state.Modifiers) // nil/empty slice is fine — yields no targets
+
+	wrote := false
+	for _, target := range r.Targets() {
+		total := r.Total(target)
+		if absFloat(total-1.0) <= multEpsilon {
+			continue // no net effect — skip
+		}
+		breakdown := summarizeBreakdown(r.Breakdown(target))
+		if breakdown == "" {
+			continue // every contribution was a no-op
+		}
+		pct := (total - 1.0) * 100
+		fmt.Fprintf(&sb, "  [cyan]%-20s[-] [yellow]%+.0f%%[-]   [gray]%s[-]\n",
+			multiplierTargetLabel(target), pct, breakdown)
+		wrote = true
+	}
+
+	// SpeedMultiplier: a wonder gate, not a resolver modifier. Render it on its
+	// own line so it stays visible.
+	if state.SpeedMultiplier > 1.0 {
+		fmt.Fprintf(&sb, "  [cyan]%-20s[-] [yellow]×%.2f[-]   [gray]wonders[-]\n",
+			"Game Speed", state.SpeedMultiplier)
+		wrote = true
+	}
+
+	if !wrote {
+		return " [gray]No active multipliers[-]\n"
+	}
+	return sb.String()
+}
+
+// multEpsilon is the tolerance below which a target's Total is treated as a
+// no-op (×1.0) and omitted from the panel.
+const multEpsilon = 0.0005
+
+// summarizeBreakdown collapses a target's per-modifier contributions into a
+// compact, source-labelled string like
+// "Morale ×1.18 · Research +10% · Wonders +5%". Modifiers from the same source
+// are merged (additive points summed, multipliers producted) so a source shows
+// once. No-op contributions (OpAdd 0, OpMul 1) are dropped. Returns "" if every
+// contribution is a no-op.
+func summarizeBreakdown(mods []game.Modifier) string {
+	type agg struct {
+		addSum  float64
+		mulProd float64
+		hasMul  bool
+		order   int
+	}
+	bySource := map[string]*agg{}
+	order := 0
+	for _, m := range mods {
+		a := bySource[m.Source]
+		if a == nil {
+			a = &agg{mulProd: 1.0, order: order}
+			bySource[m.Source] = a
+			order++
+		}
+		if m.Op == game.OpMul {
+			a.mulProd *= m.Value
+			a.hasMul = true
+		} else {
+			a.addSum += m.Value
+		}
+	}
+
+	// Stable order: first-seen (matches resolver insertion order).
+	sources := make([]string, 0, len(bySource))
+	for src := range bySource {
+		sources = append(sources, src)
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		return bySource[sources[i]].order < bySource[sources[j]].order
+	})
+
+	parts := make([]string, 0, len(sources))
+	for _, src := range sources {
+		a := bySource[src]
+		label := multiplierSourceLabel(src)
+		// Prefer a multiplicative display only when the source contributed a
+		// genuine OpMul (e.g. morale ×1.18) and no additive points alongside.
+		if a.hasMul && absFloat(a.addSum) <= multEpsilon {
+			if absFloat(a.mulProd-1.0) <= multEpsilon {
+				continue // ×1.00 — no-op
+			}
+			parts = append(parts, fmt.Sprintf("%s ×%.2f", label, a.mulProd))
+			continue
+		}
+		// Additive (the common case). Fold any stray OpMul into the percent so
+		// nothing is silently dropped.
+		eff := (1+a.addSum)*a.mulProd - 1.0
+		if absFloat(eff) <= multEpsilon {
+			continue // +0% — no-op
+		}
+		parts = append(parts, fmt.Sprintf("%s %+.0f%%", label, eff*100))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// multiplierTargetLabel maps a resolver target id to a friendly panel label.
+// Reuses formatBonusName (overlay_research.go) which already handles
+// production_all, gather_rate, <res>_rate, military_power, etc.
+func multiplierTargetLabel(target string) string {
+	switch target {
+	case "tick_speed":
+		return "Tick Speed"
+	}
+	return formatBonusName(target)
+}
+
+// multiplierSourceLabel maps a modifier Source id to a friendly label.
+// Known sources are title-cased; "event:<name>" becomes "Event: <name>".
+func multiplierSourceLabel(src string) string {
+	if name, ok := strings.CutPrefix(src, "event:"); ok {
+		return "Event: " + name
+	}
+	switch src {
+	case "research":
+		return "Research"
+	case "prestige":
+		return "Prestige"
+	case "wonders":
+		return "Wonders"
+	case "permanent":
+		return "Permanent"
+	case "morale":
+		return "Morale"
+	case "event":
+		return "Event"
+	}
+	return capitalize(src)
 }
 
 // absFloat is a tiny abs helper for epsilon comparisons (avoids importing math

--- a/ui/overlay_stats_multipliers_test.go
+++ b/ui/overlay_stats_multipliers_test.go
@@ -1,0 +1,138 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+func TestMultiplierSourceLabel(t *testing.T) {
+	cases := map[string]string{
+		"research":               "Research",
+		"prestige":               "Prestige",
+		"wonders":                "Wonders",
+		"permanent":              "Permanent",
+		"morale":                 "Morale",
+		"event":                  "Event",
+		"event:Peaceful Century": "Event: Peaceful Century",
+		"mystery_source":         "Mystery_source", // capitalize fallback
+	}
+	for in, want := range cases {
+		if got := multiplierSourceLabel(in); got != want {
+			t.Errorf("multiplierSourceLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMultiplierTargetLabel(t *testing.T) {
+	cases := map[string]string{
+		"production_all": "All Production",
+		"tick_speed":     "Tick Speed",
+		"gather_rate":    "Gather Rate",
+		"food_rate":      "Food Rate", // <res>_rate via formatBonusName
+	}
+	for in, want := range cases {
+		if got := multiplierTargetLabel(in); got != want {
+			t.Errorf("multiplierTargetLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSummarizeBreakdown_AdditiveAndMul(t *testing.T) {
+	// production_all: research +10%, wonders +5%, morale ×1.18.
+	mods := []game.Modifier{
+		{Source: "research", Target: "production_all", Op: game.OpAdd, Value: 0.10},
+		{Source: "wonders", Target: "production_all", Op: game.OpAdd, Value: 0.05},
+		{Source: "morale", Target: "production_all", Op: game.OpMul, Value: 1.18},
+	}
+	got := summarizeBreakdown(mods)
+	want := "Research +10% · Wonders +5% · Morale ×1.18"
+	if got != want {
+		t.Errorf("summarizeBreakdown = %q, want %q", got, want)
+	}
+}
+
+func TestSummarizeBreakdown_MergesSameSource(t *testing.T) {
+	// Two research contributions on one target should merge into one entry.
+	mods := []game.Modifier{
+		{Source: "research", Target: "food_rate", Op: game.OpAdd, Value: 0.12},
+		{Source: "research", Target: "food_rate", Op: game.OpAdd, Value: 0.08},
+	}
+	if got := summarizeBreakdown(mods); got != "Research +20%" {
+		t.Errorf("summarizeBreakdown = %q, want %q", got, "Research +20%")
+	}
+}
+
+func TestSummarizeBreakdown_DropsNoops(t *testing.T) {
+	mods := []game.Modifier{
+		{Source: "research", Target: "gather_rate", Op: game.OpAdd, Value: 0.0},
+		{Source: "morale", Target: "gather_rate", Op: game.OpMul, Value: 1.0},
+	}
+	if got := summarizeBreakdown(mods); got != "" {
+		t.Errorf("summarizeBreakdown of no-ops = %q, want empty", got)
+	}
+}
+
+// TestRenderActiveMultipliers_ActiveEvent proves the bug fix: a timed event's
+// production_all/tick_speed contributions now surface in the panel (they used
+// to be invisible because the old hand-aggregation never read events).
+func TestRenderActiveMultipliers_ActiveEvent(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 1.0,
+		Modifiers: []game.Modifier{
+			{Source: "research", Target: "production_all", Op: game.OpAdd, Value: 0.10},
+			{Source: "wonders", Target: "production_all", Op: game.OpAdd, Value: 0.05},
+			{Source: "morale", Target: "production_all", Op: game.OpMul, Value: 1.18},
+			{Source: "prestige", Target: "tick_speed", Op: game.OpAdd, Value: 0.05},
+			{Source: "event:Peaceful Century", Target: "tick_speed", Op: game.OpAdd, Value: 0.01},
+		},
+	}
+	out := renderActiveMultipliers(state)
+
+	if !strings.Contains(out, "Event: Peaceful Century +1%") {
+		t.Errorf("active event bonus missing from panel:\n%s", out)
+	}
+	if !strings.Contains(out, "All Production") || !strings.Contains(out, "Morale ×1.18") {
+		t.Errorf("production_all line malformed:\n%s", out)
+	}
+	if !strings.Contains(out, "Tick Speed") || !strings.Contains(out, "Prestige +5%") {
+		t.Errorf("tick_speed line malformed:\n%s", out)
+	}
+}
+
+func TestRenderActiveMultipliers_SpeedMultiplierLine(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 2.0,
+		Modifiers:       nil,
+	}
+	out := renderActiveMultipliers(state)
+	if !strings.Contains(out, "Game Speed") || !strings.Contains(out, "×2.00") {
+		t.Errorf("speed multiplier line missing:\n%s", out)
+	}
+}
+
+// TestRenderActiveMultipliers_Empty guards nil-safety on a fresh game: no
+// modifiers, no speed multiplier → the "No active multipliers" line, no panic.
+func TestRenderActiveMultipliers_Empty(t *testing.T) {
+	state := game.GameState{SpeedMultiplier: 1.0, Modifiers: nil}
+	out := renderActiveMultipliers(state)
+	if !strings.Contains(out, "No active multipliers") {
+		t.Errorf("empty state should report no multipliers, got:\n%s", out)
+	}
+}
+
+// TestRenderActiveMultipliers_NoopTargetsHidden ensures a target whose net
+// effect is ×1.0 (e.g. only no-op contributions) does not render a line.
+func TestRenderActiveMultipliers_NoopTargetsHidden(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 1.0,
+		Modifiers: []game.Modifier{
+			{Source: "morale", Target: "production_all", Op: game.OpMul, Value: 1.0},
+		},
+	}
+	out := renderActiveMultipliers(state)
+	if !strings.Contains(out, "No active multipliers") {
+		t.Errorf("no-op target should be hidden, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Second of three PRs. Switches the engine and the UI to actually consume the resolver. **Behavior-preserving** (golden test + full suite green), and fixes one HIGH bug as a natural consequence.

## Phase 3 — engine sources additive pools from the resolver (`48a742e`)
Adds `Resolver.AddTotal(target)` and replaces `recalculateRates`' scattered hand-summing (`research + permanent + prestige + wonders + Σevents`) for `production_all` / `<res>_rate` / `gather_rate` / `tick_speed` with `r.AddTotal(t)`. The `>0` gates and the inline morale application are preserved **byte-for-byte** — same numbers, one source. A new test pins `AddTotal == the old hand-sum`.

## Phase 4 — UI renders from Breakdown; active-events bug fixed (`326d583`)
Deletes ~210 lines of config re-derivation in the Active Multipliers panel (the third aggregation path) and the dead `epoch` field. `GetState` exposes the flat modifier list; the panel rebuilds a resolver and renders `Total` + per-source `Breakdown`. **Active timed-event bonuses now appear** (they apply in the tick but were invisible before — regression test included). Morale folds into the All Production breakdown; `SpeedMultiplier` stays its own wonder-gate line.

Engine and UI now read **one source of truth** — they can't disagree. `go build/vet/test` green; golden test still pins the economy to its prior numbers.

## Still deferred to PR 3 (payoff)
- `build_cost` bonus has no consumer (prestige upgrades that target it do nothing) — wire it up.
- The `>0` gate swallows negative additive debuffs — decide drop-vs-preserve and lock it with a golden fixture.