### PR TITLE
Multiplier resolver — payoff: fix build_cost + catastrophe debuff (phases 5–6)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,7 @@ minimum: 200ms
 ### Resource Rates (per tick, in order)
 
 1. Base: building production + villager gathering + research effects + event effects
-2. `production_all` multiplier on all positive rates
+2. `production_all` multiplier — `× (1 + Σ production_all)`, applied via the resolver. The sum may be **negative** (e.g. the catastrophe Reconstruction Effort −10% debuff); a former `>0` gate that silently dropped negative pools is gone, so debuffs now apply. Result is floored at 10% of base so production can't be driven below it.
 3. Per-resource multiplier (e.g. `gold_rate` bonus)
 4. Gather rate bonus: additive on villager rates
 5. Diplomacy trade bonuses: multiplicative on positive rates
@@ -343,10 +343,11 @@ minimum: 200ms
 ### Building Costs
 
 ```
-cost = floor(base_cost × cost_scale ^ current_count)
+cost = floor(base_cost × cost_scale ^ current_count) × (1 + Σ build_cost)
 ```
 Example: Hut — 30 wood, scale 1.3: 1st=30, 2nd=39, 3rd=50, 4th=66...
-Upgrades cost `target_base_cost × 0.25` (75% discount).
+
+`build_cost` modifiers are now consumed by `GetCost()`: build-cost-reducing milestone rewards and the Civil Engineering tech (each −3% to −5%) sum into `Σ build_cost` and multiply the scaled cost, floored at 10% of base. Previously these were defined but applied nowhere — `GetCost()` is the consumer the resolver migration wired in (see `design-and-architecture/multiplier-system.md` bug #2). Both the displayed and charged cost reflect the reduction.
 
 ### Food Economy
 

--- a/design-and-architecture/multiplier-system.md
+++ b/design-and-architecture/multiplier-system.md
@@ -1,6 +1,23 @@
 # Multiplier / Bonus System — Investigation & Proposed Redesign
 
-**Status:** Investigation / design proposal (no implementation yet)
+**Status:** **IMPLEMENTED.** The unified Modifier Resolver shipped — phases 1–5 of the
+migration below have landed:
+
+1. resolver core (`game/modifiers.go`) with unit tests for the `Total` combination math;
+2. sources emit `Modifiers()` mapped to canonical targets, gated by a golden equality test;
+3. `recalculateRates` consumes the resolver, with additive pools fed via `AddTotal`;
+4. the UI renders from `Breakdown` (the hand-maintained re-aggregation and dead `epoch` field deleted);
+5. the latent bugs are fixed.
+
+Both HIGH bugs are resolved — active (timed) event bonuses are now visible in the Active
+Multipliers panel (#1), and `build_cost` is finally consumed by `GetCost()` (#2). The related
+negative-debuff bug — the `>0` gate that silently swallowed the catastrophe Reconstruction
+Effort −10% production debuff — is also fixed: negative production modifiers now apply (floored
+so production can't drop below 10% of base). Phase 6 (wiki/docs) is this update.
+
+The design content below is preserved for reference; it now describes the system as built rather
+than as proposed.
+
 **Author:** espresso + Claude
 **Trello:** Refactor — "INVESTIGATION: unified multiplier registry/resolver" (`hJPR8YJX`)
 
@@ -83,17 +100,24 @@ Drift / mismatches:
 
 ## 3. Bug catalog (the "how broken is it" payload)
 
-| # | Severity | Bug | Evidence |
-|---|----------|-----|----------|
-| 1 | **HIGH** | Active (timed) event bonuses **apply but are invisible** in Active Multipliers. They hit production in `recalculateRates` but the UI reads only `state.PermanentBonuses`. Player sees "+20%" in the log; the panel shows 0%. | engine.go `recalculateRates` (production_all incl. active events) vs overlay_stats.go reading `state.PermanentBonuses[target]` |
-| 2 | **HIGH** | `build_cost` bonus target is **defined but never consumed** — `GetCost()` applies no bonuses. Any prestige upgrade targeting `build_cost` does nothing. | config prestige `build_cost` effects; `buildings.go GetCost()` has no bonus lookup |
-| 3 | MED | `bonusAttrib.epoch` field is declared and checked in the UI but **never populated** — epoch permanent bonuses are misattributed (shown as 0 from "epoch"). | overlay_stats.go declares/checks `a.epoch`, nothing increments it |
-| 4 | MED | Morale multiplier is applied **outside** all bonus tracking, with a fragile order-of-operations dependency (`× morale` then `× (1+production_all)`). Not in any breakdown. | engine.go morale applied first, production_all second |
-| 5 | MED | Active-event `tick_speed` boosts (milestone chains) apply but have **no UI attribution** path. | tick speed recalculated from active events; no UI breakdown |
-| 6 | LOW | Split-brain epoch application: some epoch events write `permanentBonuses` directly, others use `InjectEvent` timed effects — same source, two paths. | applyGoodEpochEvent: direct write vs InjectEvent |
+> **All resolved.** Every entry below was fixed by the resolver migration (phases 1–5).
+> The table is retained as a record of what was wrong and how the resolver addressed it.
 
-Items 1 and 2 are genuine, shippable bugs. The rest are attribution/consistency
-debt that guarantees more bugs as sources are added.
+| # | Severity | Status | Bug | Evidence |
+|---|----------|--------|-----|----------|
+| 1 | **HIGH** | ✅ Fixed | Active (timed) event bonuses **applied but were invisible** in Active Multipliers. They hit production in `recalculateRates` but the UI read only `state.PermanentBonuses`. Player saw "+20%" in the log; the panel showed 0%. Now events emit `Modifier`s and the panel renders from `Breakdown`, so they appear. | engine.go `recalculateRates` (production_all incl. active events) vs overlay_stats.go reading `state.PermanentBonuses[target]` |
+| 2 | **HIGH** | ✅ Fixed | `build_cost` bonus target was **defined but never consumed** — `GetCost()` applied no bonuses, so the 5 milestone rewards and 1 tech granting build-cost reductions did nothing. Now `GetCost()` multiplies by `(1 + Σ build_cost)`, floored at 10% of base; the reductions (currently ~−24% stacked) apply to both the displayed and charged cost. | config prestige/milestone/tech `build_cost` effects; `buildings.go GetCost()` had no bonus lookup |
+| 3 | MED | ✅ Fixed | `bonusAttrib.epoch` field was declared and checked in the UI but **never populated** — epoch permanent bonuses were misattributed. The hand-maintained field is deleted; epoch modifiers carry `Source:"epoch:..."` and `Breakdown` attributes them. | overlay_stats.go declared/checked `a.epoch`, nothing incremented it |
+| 4 | MED | ✅ Fixed | Morale multiplier was applied **outside** all bonus tracking, with a fragile order-of-operations dependency. It is now an `OpMul` modifier on `production.all`; combination order is defined once in `Total`. | engine.go morale applied first, production_all second |
+| 5 | MED | ✅ Fixed | Active-event `tick_speed` boosts (milestone chains) applied but had **no UI attribution** path. The same `Breakdown` mechanism now covers `tick_speed`. | tick speed recalculated from active events; no UI breakdown |
+| 6 | LOW | ✅ Fixed | Split-brain epoch application: some epoch events wrote `permanentBonuses` directly, others used `InjectEvent` timed effects. Both now surface as modifiers through one display path. | applyGoodEpochEvent: direct write vs InjectEvent |
+
+A seventh, related defect surfaced and was fixed in the same effort: a `>0` gate on the
+production-bonus pool silently swallowed **negative** `production_all` modifiers, so the
+catastrophe "Reconstruction Effort" −10% debuff only had an effect if the player happened to
+hold ≥10% of positive production bonuses to offset. The gate is gone — negative production
+modifiers now apply, floored so production can't drop below 10% of base — so enduring a
+catastrophe genuinely costs −10% production for its 216-tick window, as designed.
 
 ---
 

--- a/game/buildings.go
+++ b/game/buildings.go
@@ -27,6 +27,15 @@ type BuildingManager struct {
 	legacyBuildings map[string]bool               // buildings superseded by lineage progression; functional but unbuildable
 	ruins           map[string]int                // ruins from Succumb — produce at 50% base rate, no worker scaling
 	pendingUpgrades map[string]string             // oldKey -> newKey: player-driven upgrade awaiting payment
+
+	// costMult is the global build-cost multiplier applied to every computed
+	// building cost (GetCost / BuildBatchCost / UpgradeCost new-copy side). It is
+	// the resolver's build_cost additive pool folded into a factor by the engine:
+	// costMult = clamp(1 + Σ build_cost, 0.10, 1.0). Default 1.0 (no effect) so a
+	// bare BuildingManager with no engine behaves exactly as before. The engine
+	// refreshes it each recalc via SetCostMultiplier so the charged cost and the
+	// displayed cost are computed from the SAME factor and can never disagree.
+	costMult float64
 }
 
 // NewBuildingManager creates a building manager
@@ -39,7 +48,19 @@ func NewBuildingManager() *BuildingManager {
 		legacyBuildings: make(map[string]bool),
 		ruins:           make(map[string]int),
 		pendingUpgrades: make(map[string]string),
+		costMult:        1.0,
 	}
+}
+
+// SetCostMultiplier sets the global build-cost factor applied to all computed
+// costs. The engine derives it from the resolver's build_cost pool each recalc.
+// A non-positive value is ignored (defends GetCost against divide-by-nothing /
+// zero-cost edge cases); the floor/cap clamp is the engine's responsibility.
+func (bm *BuildingManager) SetCostMultiplier(m float64) {
+	if m <= 0 {
+		return
+	}
+	bm.costMult = m
 }
 
 // UnlockBuilding makes a building available
@@ -139,7 +160,9 @@ func (bm *BuildingManager) BuildBatchCost(key string, n int, queue []BuildQueueI
 	for i := 0; i < n; i++ {
 		exp := float64(built + queued + i)
 		for resource, base := range def.BaseCost {
-			total[resource] += math.Floor(base * math.Pow(def.CostScale, exp))
+			// Per-copy floor (matching GetCost) so a batch of n equals the sum of
+			// n single buys — charge and display agree whichever path is used.
+			total[resource] += applyCostMult(base*math.Pow(def.CostScale, exp), bm.costMult)
 		}
 	}
 	return total, true
@@ -194,9 +217,25 @@ func (bm *BuildingManager) GetCost(key string) map[string]float64 {
 	count := bm.counts[key]
 	cost := make(map[string]float64)
 	for res, base := range def.BaseCost {
-		cost[res] = math.Floor(base * math.Pow(def.CostScale, float64(count)))
+		cost[res] = applyCostMult(base*math.Pow(def.CostScale, float64(count)), bm.costMult)
 	}
 	return cost
+}
+
+// applyCostMult folds the global build-cost factor into a single resource's raw
+// curve cost, then floors. A positive raw cost never drops below 1 even after a
+// deep discount — you can always be charged something for a building that costs
+// anything. mult is expected pre-clamped (engine: [0.10, 1.0]); a non-positive
+// mult is treated as a no-op so a misconfigured caller can't zero out costs.
+func applyCostMult(raw, mult float64) float64 {
+	if mult <= 0 {
+		mult = 1.0
+	}
+	c := math.Floor(raw * mult)
+	if raw > 0 && c < 1 {
+		c = 1
+	}
+	return c
 }
 
 // Build constructs a building. Returns false if can't afford or not unlocked.
@@ -499,8 +538,11 @@ func (bm *BuildingManager) UpgradeCost(oldKey, newKey string, upgradeCount int) 
 		// New copy being created: the (newCount+i)th copy
 		newExp := float64(newCount + i)
 		for res, base := range newDef.BaseCost {
-			newCopyCost := math.Floor(base * math.Pow(newDef.CostScale, newExp))
-			// Old sell value for this resource (0 if old building doesn't cost this resource)
+			// New copy gets the build_cost discount (you're paying to build it).
+			newCopyCost := applyCostMult(base*math.Pow(newDef.CostScale, newExp), bm.costMult)
+			// Old sell value for this resource (0 if old building doesn't cost this
+			// resource). Refund is NOT discounted — it reflects what was paid, not
+			// the current build_cost reductions.
 			oldBase := oldDef.BaseCost[res]
 			oldCopyCost := math.Floor(oldBase * math.Pow(oldDef.CostScale, oldExp))
 			oldSellValue := math.Floor(oldCopyCost * 0.5)

--- a/game/buildings_test.go
+++ b/game/buildings_test.go
@@ -162,3 +162,76 @@ func TestBuildingManager_GetQueueCount(t *testing.T) {
 		t.Errorf("GetQueueCount with nil queue = %d, want 0", got)
 	}
 }
+
+// TestBuildingManager_CostMultiplier is the Fix A unit test: the build_cost
+// factor folded into costMult must scale GetCost/BuildBatchCost and never zero
+// out a positive cost. hut: BaseCost={"wood":14}.
+//   - no modifier (default 1.0) → exactly base (14)
+//   - -10% build_cost (costMult 0.90) → floor(14*0.90)=12 (~90% of base)
+//   - extreme stacking clamped to the engine floor (0.10) → floor(14*0.10)=1,
+//     and the per-resource floor keeps it ≥ 1 (never 0) for a positive base.
+func TestBuildingManager_CostMultiplier(t *testing.T) {
+	bm := NewBuildingManager()
+	bm.UnlockBuilding("hut")
+	base := bm.defs["hut"].BaseCost["wood"] // 14
+
+	// Default: no build_cost applied.
+	if got := bm.GetCost("hut")["wood"]; got != base {
+		t.Errorf("default costMult: GetCost wood = %v, want base %v", got, base)
+	}
+
+	// -10% reduction.
+	bm.SetCostMultiplier(0.90)
+	want := math.Floor(base * 0.90) // 12
+	if got := bm.GetCost("hut")["wood"]; got != want {
+		t.Errorf("0.90 costMult: GetCost wood = %v, want %v (~90%% of %v)", got, want, base)
+	}
+	// Batch must agree with the single-buy cost for the first copy (charge==display).
+	if batch, _ := bm.BuildBatchCost("hut", 1, nil); batch["wood"] != want {
+		t.Errorf("0.90 costMult: BuildBatchCost wood = %v, want %v (must match GetCost)", batch["wood"], want)
+	}
+
+	// Extreme stacking — engine clamps to buildCostFloor (0.10) before passing in.
+	bm.SetCostMultiplier(clamp(1.0+(-5.0), buildCostFloor, buildCostCap)) // 1-5 = -4 → floored to 0.10
+	wantFloor := math.Floor(base * buildCostFloor)                        // floor(1.4)=1
+	if got := bm.GetCost("hut")["wood"]; got != wantFloor || got < 1 {
+		t.Errorf("floor clamp: GetCost wood = %v, want %v (>=1, never zeroed)", got, wantFloor)
+	}
+
+	// A non-positive multiplier must be ignored (defensive): cost stays at the
+	// last valid factor's basis, not zero. SetCostMultiplier(0) is a no-op.
+	bm.SetCostMultiplier(0)
+	if got := bm.GetCost("hut")["wood"]; got != wantFloor {
+		t.Errorf("non-positive setter should be ignored: GetCost wood = %v, want %v", got, wantFloor)
+	}
+}
+
+// TestEngine_BuildCostFactorWired is the Fix A integration test: the resolver's
+// build_cost additive pool must flow through recalculateRates into the building
+// manager's costMult, so the CHARGED cost (BuildBatchCost, used by the build
+// path) reflects earned reductions. Pre-Fix-A, build_cost was ignored and this
+// would have charged full base.
+func TestEngine_BuildCostFactorWired(t *testing.T) {
+	ge := NewGameEngine()
+	base := ge.Buildings.defs["hut"].BaseCost["wood"]
+
+	// No build_cost yet → costMult 1.0 → full base.
+	ge.recalculateRates()
+	if got, _ := ge.Buildings.BuildBatchCost("hut", 1, nil); got["wood"] != base {
+		t.Errorf("no build_cost: charged wood = %v, want base %v", got["wood"], base)
+	}
+
+	// Grant a -10% build_cost reduction via permanentBonuses (the same pool
+	// milestones feed) and recalc. costMult = clamp(1-0.10,0.10,1.0)=0.90.
+	ge.permanentBonuses["build_cost"] = -0.10
+	ge.recalculateRates()
+	want := math.Floor(base * 0.90)
+	charged, _ := ge.Buildings.BuildBatchCost("hut", 1, nil)
+	if charged["wood"] != want {
+		t.Errorf("build_cost -0.10: charged wood = %v, want %v", charged["wood"], want)
+	}
+	// Display path (single GetCost) must agree with the charge path.
+	if disp := ge.Buildings.GetCost("hut")["wood"]; disp != charged["wood"] {
+		t.Errorf("charge==display mismatch: GetCost=%v BuildBatchCost=%v", disp, charged["wood"])
+	}
+}

--- a/game/engine.go
+++ b/game/engine.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"strings"
@@ -19,7 +20,33 @@ const (
 	// It prevents the tick loop from spinning faster than the UI can render.
 	MinTickInterval = 200 * time.Millisecond
 	MaxLogSize      = 500
+
+	// productionFloor caps how far a NEGATIVE additive production bonus can drag a
+	// rate down. The additive pools (production_all, <res>_rate, gather_rate) are
+	// applied as rate *= max(productionFloor, 1+Σ), so a -10% catastrophe debuff
+	// (e.g. Reconstruction Effort) actually lands, but stacked penalties can never
+	// push production below 10% of its pre-bonus value or flip it negative.
+	productionFloor = 0.10
+
+	// buildCostFloor / buildCostCap clamp the build-cost factor the engine derives
+	// from the resolver's build_cost pool. build_cost values are negative cost
+	// reductions; the factor is clamp(1+Σ, floor, cap). The 0.10 floor means costs
+	// can never drop below 10% of base no matter how many reductions stack; the
+	// 1.0 cap means a (hypothetical) positive build_cost can't RAISE costs.
+	buildCostFloor = 0.10
+	buildCostCap   = 1.0
 )
+
+// clamp constrains v to [lo, hi].
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
 
 // GameEngine is the central coordinator for all game systems. All subsystems
 // are accessed through their manager fields rather than as globals, so multiple
@@ -456,9 +483,16 @@ func (ge *GameEngine) recalculateTickSpeed() {
 		if mult < 1.0 {
 			mult = 1.0
 		}
-		interval := time.Duration(float64(BaseTickInterval) / ((1.0 + bonus) * mult))
-		if interval < MinTickInterval {
-			interval = MinTickInterval
+		// Mirror getTickInterval's guard: a denominator ≤ 0 (tick_speed ≤ -1.0)
+		// would yield a +Inf/garbage duration in the debug log. The real interval
+		// the loop uses comes from getTickInterval, which guards identically.
+		denom := (1.0 + bonus) * mult
+		interval := MinTickInterval
+		if denom > 0 {
+			interval = time.Duration(float64(BaseTickInterval) / denom)
+			if interval < MinTickInterval {
+				interval = MinTickInterval
+			}
 		}
 		ge.addLog("debug", fmt.Sprintf("Tick speed: +%.0f%% (interval: %dms)", bonus*100, interval.Milliseconds()))
 	}
@@ -921,40 +955,60 @@ func (ge *GameEngine) recalculateRates() {
 	// Phase 3 only moves WHERE the additive sums come from.
 	r := ge.buildResolver()
 
-	// Apply production_all bonus (multiplier on all positive rates)
+	// Build-cost factor (Fix A): fold the resolver's build_cost additive pool
+	// (negative reductions from milestones + a research tech) into a single
+	// multiplier and hand it to the BuildingManager. costMult = clamp(1 + Σ
+	// build_cost, 0.10, 1.0). GetCost/BuildBatchCost/UpgradeCost all read it, so
+	// the charged cost and the displayed cost are computed from the SAME factor.
+	costMult := clamp(1.0+r.AddTotal("build_cost"), buildCostFloor, buildCostCap)
+	ge.Buildings.SetCostMultiplier(costMult)
+
+	// Apply production_all bonus (multiplier on all positive rates).
 	// Pool: research + permanent + prestige + wonders + active-event production_all.
+	// Fix B: UNgated with a floor. Previously gated `if prodAllBonus > 0`, which
+	// silently swallowed negative additive bonuses (e.g. the Reconstruction Effort
+	// catastrophe's -0.10 production_all) whenever the player lacked ≥10% positive
+	// bonuses. Now always applied as ×max(productionFloor, 1+Σ), so the debuff
+	// lands but production can't drop below 10% of its pre-bonus value.
 	prodAllBonus := r.AddTotal("production_all")
-	if prodAllBonus > 0 {
+	prodAllFactor := math.Max(productionFloor, 1.0+prodAllBonus)
+	if prodAllFactor != 1.0 {
 		for _, def := range ge.Resources.defs {
 			r := ge.Resources.resources[def.Key]
 			if r != nil && r.Rate > 0 {
-				r.Rate *= (1.0 + prodAllBonus)
+				r.Rate *= prodAllFactor
 			}
 		}
 	}
 
-	// Apply per-resource rate bonuses (e.g., "gold_rate", "iron_rate")
-	// Includes legacy bonuses (stored in permanentBonuses["wood"] etc. after reapplyLegacyBonuses)
+	// Apply per-resource rate bonuses (e.g., "gold_rate", "iron_rate").
+	// Includes legacy bonuses (stored in permanentBonuses["wood"] etc. after
+	// reapplyLegacyBonuses). Fix B: same ungated+floored treatment as above.
 	for _, def := range ge.Resources.defs {
 		bonusKey := def.Key + "_rate"
 		bonus := r.AddTotal(bonusKey)
-		if bonus > 0 {
+		factor := math.Max(productionFloor, 1.0+bonus)
+		if factor != 1.0 {
 			r := ge.Resources.resources[def.Key]
 			if r != nil && r.Rate > 0 {
-				r.Rate *= (1.0 + bonus)
+				r.Rate *= factor
 			}
 		}
 	}
 
-	// Apply gather_rate bonus to worker-generated rates
+	// Apply gather_rate bonus to worker-generated rates. This is ADDITIVE on the
+	// base worker rates — re-add the bonus portion (the production_all multiply
+	// above has already touched these rates, so we add the gather delta on top of
+	// the base). Fix B: ungated with the same floor. A negative gather_rate now
+	// reduces worker output, but the floored factor max(productionFloor, 1+Σ)
+	// means the effective worker contribution can't drop below 10% of base.
 	gatherBonus := r.AddTotal("gather_rate")
-	if gatherBonus > 0 {
-		// Already applied via multiplier above
-		// This is additive on base worker rates — re-add the bonus portion
+	gatherDelta := math.Max(productionFloor, 1.0+gatherBonus) - 1.0
+	if gatherDelta != 0 {
 		for res, rate := range ge.Workers.GetProductionRates() {
 			r := ge.Resources.resources[res]
 			if r != nil {
-				r.Rate += rate * gatherBonus
+				r.Rate += rate * gatherDelta
 			}
 		}
 	}

--- a/game/modifiers_golden_test.go
+++ b/game/modifiers_golden_test.go
@@ -23,20 +23,26 @@ import (
 const goldenEps = 1e-9
 
 // expectedProductionAll re-derives the net multiplicative factor the engine
-// applies to a positive building production rate, the way recalculateRates does:
+// applies to a positive building production rate, the way recalculateRates does
+// AFTER Fix B (ungated + floored):
 //
 //	prodAllAdd = research[production_all] + permanent[production_all]
 //	           + prestige[production_all] + wonders[production_all]
 //	           + Σ active-event production_all effects
-//	factor     = moraleMultiplier() × (prodAllAdd > 0 ? (1 + prodAllAdd) : 1)
+//	factor     = moraleMultiplier() × max(productionFloor, 1 + prodAllAdd)
 //
 // The morale factor is the BANDED multiplier moraleMultiplier(), applied
 // unconditionally to the building rate (recalculateRates hoists it as
 // `mMult := ge.moraleMultiplier()`, then `rate × mMult`). It is NOT the raw
 // ge.morale field: post-rework morale is a managed resource (neutral 0.50)
 // whose production effect is the banded curve — 1.0 across [0.25,0.75], a bonus
-// to +20% above, a penalty toward ×0.5 below. The production_all additive
-// multiply is still gated on prodAllAdd > 0.
+// to +20% above, a penalty toward ×0.5 below.
+//
+// Fix B removed the old `prodAllAdd > 0` gate: a negative additive bonus (e.g.
+// the Reconstruction Effort catastrophe's -0.10) now applies. The productionFloor
+// floor only binds when 1+add < 0.10; for every fixture here it does not, so this
+// expected factor equals the resolver's UNfloored Total (1+add)×morale — the
+// resolver carries the additive pool and morale, the floor is engine-side only.
 func expectedProductionAll(ge *GameEngine) float64 {
 	research := ge.Research.GetBonuses()
 	prestige := ge.Prestige.GetBonuses()
@@ -50,20 +56,19 @@ func expectedProductionAll(ge *GameEngine) float64 {
 		}
 	}
 
-	factor := ge.moraleMultiplier()
-	if add > 0 {
-		factor *= 1.0 + add
-	}
-	return factor
+	return ge.moraleMultiplier() * math.Max(productionFloor, 1.0+add)
 }
 
-// expectedResRate re-derives the per-resource rate multiplier:
+// expectedResRate re-derives the per-resource rate multiplier (Fix B: ungated +
+// floored):
 //
 //	add    = research[<res>_rate] + permanent[<res>_rate] + prestige[<res>_rate] + wonders[<res>_rate]
-//	factor = add > 0 ? (1 + add) : 1
+//	factor = max(productionFloor, 1 + add)
 //
 // (permanentBonuses already absorbs milestone/legacy/epoch; prestige and wonders
-// are merged into the same effective per-resource pool in recalculateRates.)
+// are merged into the same effective per-resource pool in recalculateRates.) As
+// with production_all the floor only binds when 1+add < 0.10; fixtures here are
+// non-binding, so this equals the resolver's unfloored Total.
 func expectedResRate(ge *GameEngine, res string) float64 {
 	key := res + "_rate"
 	research := ge.Research.GetBonuses()
@@ -71,13 +76,10 @@ func expectedResRate(ge *GameEngine, res string) float64 {
 	wonders := ge.getWonderBonuses()
 
 	add := research[key] + ge.permanentBonuses[key] + prestige[key] + wonders[key]
-	if add > 0 {
-		return 1.0 + add
-	}
-	return 1.0
+	return math.Max(productionFloor, 1.0+add)
 }
 
-// expectedGatherRate re-derives the gather_rate multiplier the same way.
+// expectedGatherRate re-derives the gather_rate multiplier the same way (Fix B).
 func expectedGatherRate(ge *GameEngine) float64 {
 	research := ge.Research.GetBonuses()
 	prestige := ge.Prestige.GetBonuses()
@@ -85,10 +87,7 @@ func expectedGatherRate(ge *GameEngine) float64 {
 
 	add := research["gather_rate"] + ge.permanentBonuses["gather_rate"] +
 		prestige["gather_rate"] + wonders["gather_rate"]
-	if add > 0 {
-		return 1.0 + add
-	}
-	return 1.0
+	return math.Max(productionFloor, 1.0+add)
 }
 
 // expectedTickSpeed re-derives the (1 + Σ tick_speed) factor recalculateTickSpeed
@@ -112,7 +111,10 @@ func expectedTickSpeed(ge *GameEngine) float64 {
 // the independently-derived expected value. Note: production_all is the special
 // case — the resolver's Total folds the OpMul morale factor in, so it equals the
 // engine's net (moraleMultiplier() × prodall) factor, which is what we compare
-// against. The other targets are gated-additive on both sides.
+// against. Post-Fix-B the expected helpers are ungated + floored (max(0.10, 1+Σ));
+// the resolver's Total is unfloored (1+Σ)[×morale], so the two agree exactly for
+// every non-floor-binding fixture in this file (all of them — including the new
+// negative production_all case, where 1-0.10 = 0.90 > 0.10).
 func assertResolverGolden(t *testing.T, ge *GameEngine, resCheck string, gather bool) {
 	t.Helper()
 	r := ge.buildResolver()
@@ -187,6 +189,31 @@ func TestResolverGolden_ActiveEventProdAll(t *testing.T) {
 		Effects:   []config.Effect{{Type: "production_all", Value: 0.50}},
 	})
 	assertResolverGolden(t, ge, "stone", true)
+}
+
+// TestResolverGolden_NegativeProdAll is the Fix B fixture: a Reconstruction-like
+// catastrophe debuff (active event with production_all -0.10) must actually apply
+// now that the >0 gate is gone. Morale is pinned neutral (×1.0), so both the
+// engine's now-ungated factor and the resolver's Total are exactly ×0.90 — the
+// debuff lands. Pre-Fix-B the gate would have made expectedProductionAll return
+// 1.0 (swallowing the debuff) and this assertion would have FAILED, which is the
+// point: it pins the new behavior.
+func TestResolverGolden_NegativeProdAll(t *testing.T) {
+	ge := NewGameEngine()
+	ge.morale = moraleNeutral // 0.50 → moraleMultiplier() == 1.0, isolates the debuff
+	ge.Events.InjectEvent(ActiveEvent{
+		Key:       "endure_reconstruction",
+		Name:      "Reconstruction Effort",
+		TicksLeft: 216,
+		Effects:   []config.Effect{{Type: "production_all", Value: -0.10}},
+	})
+
+	// Sanity: the factor must be exactly 0.90 (1 - 0.10), and the floor must NOT
+	// bind (0.90 > productionFloor). If this drifts to 1.0 the gate has crept back.
+	if got, want := ge.buildResolver().Total("production_all"), 0.90; math.Abs(got-want) > goldenEps {
+		t.Fatalf("negative production_all: resolver Total=%.12f want %.12f (debuff must apply)", got, want)
+	}
+	assertResolverGolden(t, ge, "wood", true)
 }
 
 func TestResolverGolden_ActiveEventTickSpeed(t *testing.T) {

--- a/site/docs/buildings.md
+++ b/site/docs/buildings.md
@@ -136,6 +136,10 @@ This means bulk-buying is always more expensive per unit than buying one at a ti
 
 Costs were rebalanced to flatter curves. Production, military, research, and trade buildings use `CostScale = 1.15`. Storage and housing buildings use the gentler `CostScale = 1.13`. Wonders are flat (`CostScale = 1.0`) — every copy costs the same, but they're capped to one each. Costs still grow exponentially for the scaling lineages, so plan your resource production before bulk-buying.
 
+### Build-cost reductions
+
+A handful of **milestone rewards** (Master Builder, Grand Architect, and others) and one **research tech** (Civil Engineering) grant build-cost reductions of −3% to −5% each. These now apply to your cumulative scaled cost: the cost above is multiplied by `(1 + Σ build_cost)`, floored so the cost never drops below 10% of base. Stacked, the currently available reductions reach roughly **−24%**. The discount is reflected in the cost the build menu shows you and in what you're actually charged — there's no hidden mismatch between display and charge. You don't need to do anything to opt in; earning the milestone or completing the tech is enough.
+
 **Example:** Gathering Camp, BaseCost=16 wood, CostScale=1.15, none built or queued:
 - 1st: 16 wood
 - 2nd: 18 wood

--- a/site/docs/catastrophe.md
+++ b/site/docs/catastrophe.md
@@ -48,7 +48,7 @@ Pay a cost and keep your civilization intact.
 - **Production debuff −10% for 216 ticks** — a timed `Reconstruction Effort` event applies −10% to all production for the recovery period
 - **Survived marker** recorded in your civilization history for that epoch
 
-Endure is painful but survivable. A well-developed civilization with many buildings loses only a fraction of its output — the production penalty is temporary, buildings grow back, and workers can be re-recruited.
+Endure is painful but survivable, but it is no longer cheap on production. The −10% reconstruction debuff genuinely applies for its full 216-tick window: **every** building — even the ones that survived — produces at 90% until the timer expires. (Earlier builds effectively ignored this penalty unless you happened to hold enough positive production bonuses to offset it; it now bites as designed.) Budget for the building loss, the worker loss, *and* a flat −10% on everything for the reconstruction period. The hit is temporary — buildings grow back, workers can be re-recruited, and the debuff expires on its own — but a large civilization should plan around running below capacity for the full window rather than assuming the penalty is negligible.
 
 **Morale impact:** Enduring also costs morale on top of the building destruction — a hit that drags the civilization-wide morale percentage down. If morale was already low heading into a catastrophe, this can push it into the low band (toward the 10% floor), where worker output is penalised and recovery slows. Once you stabilise, morale drifts back toward the 50% neutral baseline on its own; prioritise food surplus after Enduring to speed that recovery.
 
@@ -121,7 +121,7 @@ After destruction, the production debuff event (`endure_reconstruction`) is inje
 Effect: production_all -10% for 216 ticks
 ```
 
-This is separate from the building loss. Even buildings that survived are producing at 90% for the reconstruction period. Plan for both effects simultaneously.
+This is separate from the building loss. Even buildings that survived are producing at 90% for the reconstruction period, and this now applies in full — negative production modifiers are floored so production can't drop below 10% of base, but a single −10% debuff lands cleanly off the top regardless of what other bonuses you hold. Plan for both effects simultaneously.
 
 **Recovery checklist after Endure:**
 1. Check which buildings were destroyed (the log lists every lost building by name)

--- a/site/docs/milestones.md
+++ b/site/docs/milestones.md
@@ -76,6 +76,8 @@ If no chain is completed, fallback titles apply:
 | Grand Architect *(hidden)* | Build 1,000 structures | -5% build cost, +5% production |
 | Wonder Collector *(hidden)* | Construct 3 Wonders | +10% all production |
 
+The `-5% build cost` rewards here (Master Builder, Grand Architect) are functional, not flavor: they reduce the actual cumulative cost of every building you queue, and the saving shows up in the cost the build menu displays. Stacked with the other build-cost rewards across the game (and the Civil Engineering tech), the reductions currently reach roughly −24%, floored at 10% of base. See [Buildings](buildings.md#build-cost-reductions).
+
 **Chain reward:** Title: "The Architects" · Speed boost ×1.5 for 90 ticks
 
 ---

--- a/site/docs/technologies.md
+++ b/site/docs/technologies.md
@@ -467,7 +467,7 @@ Only one tech reduces build cost:
 |---|---|
 | Civil Engineering | −5% |
 
-Small but permanent; useful when you're building dozens of structures.
+This reduction is live: it multiplies your cumulative build cost by `(1 + Σ build_cost)` (floored at 10% of base) alongside the build-cost milestone rewards, and the saving is reflected in the cost the build menu shows. Small but permanent, it stacks with those milestones toward the current ceiling of roughly −24%, so it's worth taking when you're building dozens of structures. See [Buildings](buildings.md#build-cost-reductions).
 
 ---
 


### PR DESCRIPTION
Third and final PR of the multiplier-resolver migration (design: #46). The resolver surfaced two real shipping bugs — this fixes them. **Intentional behavior changes** (approved).

## Fix 1 — `build_cost` reductions now work
5 milestone rewards + 1 research tech grant build-cost reductions (−3% to −5%) that **nothing consumed** — they were dead. Now `BuildingManager` carries a cost multiplier (`1 + Σ build_cost`, clamped to `[0.10, 1.0]`) that the engine sets each recalc; `GetCost`/`BuildBatchCost`/`UpgradeCost` apply it, so **charged and displayed cost agree**. Earned reductions (up to ~−24% stacked) finally cut costs.

## Fix 2 — catastrophe Reconstruction −10% now bites
The `production_all`/`<res>_rate`/`gather_rate` additive pools were gated on `>0`, silently **swallowing negative modifiers** — including the post-catastrophe Reconstruction Effort `−10%`, which often did nothing. Replaced the gate with a floored apply (`max(0.10, 1+x)`), so the debuff now applies for its 216-tick window as designed. Golden test updated to the ungated formula **plus a negative-`production_all` fixture** pinning the −10% at ×0.90.

## Docs
catastrophe / buildings / milestones / technologies / CONTRIBUTING updated; the design doc (`multiplier-system.md`) marked **implemented** with the bug catalog resolved.

## Migration complete
With #46 (design), #47 (groundwork), #48 (cutover), and this — the engine and UI both read one resolver, the two HIGH bugs are fixed, and ~210 lines of UI re-aggregation are gone. `go build/vet/test` green; golden test guards the economy.

⚠️ Worth a playtest of the two feel changes (cheaper builds; enduring a catastrophe now actually costs production) before merge.