### PR TITLE
feat: continuous morale curve + morale history graph

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -189,64 +189,60 @@ func (ge *GameEngine) applyMorale(delta float64) {
 	ge.clampMorale()
 }
 
-// Morale tuning constants. Morale is a managed two-way dial: a neutral band in
-// the middle leaves production untouched (preserving the historic economy
-// baseline), a high band you must EARN grants up to +moraleMaxBonus, and a low
-// band you must AVOID drags production down to moraleMinMult.
+// Morale tuning constants. Morale is a managed two-way dial on a continuous
+// curve pivoted at moraleNeutral: at the pivot production is untouched
+// (preserving the historic economy baseline), above it the bonus you must EARN
+// ramps up to +moraleMaxBonus at the cap, and below it the penalty you must
+// AVOID ramps down to moraleMinMult at the 0.10 floor.
 const (
-	moraleNeutral     = 0.50   // starting/settling point; neutral-band centre
-	moraleNeutralLow  = 0.25   // below this, production penalty ramps in
-	moraleNeutralHigh = 0.75   // above this, production bonus ramps in
-	moraleMaxBonus    = 0.20   // max production bonus at moraleCap()
-	moraleMinMult     = 0.50   // production multiplier at the 0.10 morale floor
-	moraleDrift       = 0.0008 // per-tick gentle pull back toward moraleNeutral
+	moraleNeutral  = 0.50   // starting/settling point; continuous-curve pivot
+	moraleMaxBonus = 0.20   // max production bonus at moraleCap()
+	moraleMinMult  = 0.50   // production multiplier at the 0.10 morale floor
+	moraleDrift    = 0.0008 // per-tick gentle pull back toward moraleNeutral
 )
 
-// moraleMultiplier converts the current morale into a production multiplier.
+// moraleMultiplier converts the current morale into a production multiplier
+// using a CONTINUOUS curve pivoted at the neutral point (moraleNeutral = 0.50):
 //
-//   - Neutral band [moraleNeutralLow, moraleNeutralHigh]  → exactly 1.0
-//   - High band (morale > moraleNeutralHigh)              → 1.0 .. 1.0+moraleMaxBonus,
-//     ramping linearly up to moraleCap()
-//   - Low band (morale < moraleNeutralLow)                → moraleMinMult .. 1.0,
-//     ramping linearly down to the 0.10 floor
+//   - At 0.50 the multiplier is exactly 1.0 (economy baseline preserved).
+//   - Above 0.50 it ramps linearly to 1.0+moraleMaxBonus at moraleCap().
+//   - Below 0.50 it ramps linearly down to moraleMinMult at the 0.10 floor.
 //
-// At neutral morale (moraleNeutral = 0.50) this returns exactly 1.0, so the
-// economy baseline is unchanged from before the morale-as-managed-resource
-// rework.
+// There is no neutral dead zone any more: any deviation from 0.50 produces a
+// small, honest effect that grows with distance. Near the pivot the effect is
+// tiny (e.g. 52% -> ~+0.8%); at the extremes it reaches the tuned endpoints
+// (+20% at cap, x0.50 at the floor). The downside ramps steeper than the
+// upside because the 0.10 floor is closer to the pivot than the cap is.
 func (ge *GameEngine) moraleMultiplier() float64 {
+	const moraleFloor = 0.10
 	m := ge.morale
 
-	// Neutral band — no production effect.
-	if m >= moraleNeutralLow && m <= moraleNeutralHigh {
-		return 1.0
-	}
-
-	// High band — ramp from 1.0 (at moraleNeutralHigh) to 1.0+moraleMaxBonus (at cap).
-	if m > moraleNeutralHigh {
+	if m > moraleNeutral {
 		cap := ge.moraleCap()
-		span := cap - moraleNeutralHigh
+		span := cap - moraleNeutral
 		if span <= 0 {
-			// Cap at/below the neutral-high edge (shouldn't happen: cap ≥ 1.0).
 			return 1.0
 		}
-		frac := (m - moraleNeutralHigh) / span
+		frac := (m - moraleNeutral) / span
 		if frac > 1.0 {
 			frac = 1.0
 		}
 		return 1.0 + frac*moraleMaxBonus
 	}
 
-	// Low band — ramp from 1.0 (at moraleNeutralLow) down to moraleMinMult (at 0.10).
-	const moraleFloor = 0.10
-	span := moraleNeutralLow - moraleFloor
-	if span <= 0 {
-		return moraleMinMult
+	if m < moraleNeutral {
+		span := moraleNeutral - moraleFloor
+		if span <= 0 {
+			return moraleMinMult
+		}
+		frac := (moraleNeutral - m) / span
+		if frac > 1.0 {
+			frac = 1.0
+		}
+		return 1.0 - frac*(1.0-moraleMinMult)
 	}
-	frac := (moraleNeutralLow - m) / span
-	if frac > 1.0 {
-		frac = 1.0
-	}
-	return 1.0 - frac*(1.0-moraleMinMult)
+
+	return 1.0 // exactly neutral
 }
 
 // updateMoraleTick applies per-tick morale changes: starvation penalty,
@@ -656,6 +652,7 @@ func (ge *GameEngine) doTick() {
 			Faith:      faith,
 			ProdAll:    ge.permanentBonuses["production_all"],
 			TickSpeed:  ge.tickSpeedBonus,
+			Morale:     ge.morale,
 			AgeOrder:   ageOrder,
 		})
 	}

--- a/game/history.go
+++ b/game/history.go
@@ -12,6 +12,7 @@ type HistorySample struct {
 	Faith      float64 `json:"faith"`
 	ProdAll    float64 `json:"prod_all"`
 	TickSpeed  float64 `json:"tick_speed"`
+	Morale     float64 `json:"morale"`
 	AgeOrder   int     `json:"age_order"`
 }
 

--- a/game/modifiers_golden_test.go
+++ b/game/modifiers_golden_test.go
@@ -30,13 +30,13 @@ const goldenEps = 1e-9
 //	           + Σ active-event production_all effects
 //	factor     = moraleMultiplier() × (prodAllAdd > 0 ? (1 + prodAllAdd) : 1)
 //
-// The morale factor is the BANDED multiplier moraleMultiplier(), applied
-// unconditionally to the building rate (recalculateRates hoists it as
-// `mMult := ge.moraleMultiplier()`, then `rate × mMult`). It is NOT the raw
-// ge.morale field: post-rework morale is a managed resource (neutral 0.50)
-// whose production effect is the banded curve — 1.0 across [0.25,0.75], a bonus
-// to +20% above, a penalty toward ×0.5 below. The production_all additive
-// multiply is still gated on prodAllAdd > 0.
+// The morale factor is moraleMultiplier(), applied unconditionally to the
+// building rate (recalculateRates hoists it as `mMult := ge.moraleMultiplier()`,
+// then `rate × mMult`). It is NOT the raw ge.morale field: post-rework morale is
+// a managed resource (neutral 0.50) whose production effect is a continuous curve
+// pivoted at 0.50 — exactly 1.0 at the pivot, ramping to +20% at the cap above
+// and toward ×0.5 at the 0.10 floor below. The production_all additive multiply
+// is still gated on prodAllAdd > 0.
 func expectedProductionAll(ge *GameEngine) float64 {
 	research := ge.Research.GetBonuses()
 	prestige := ge.Prestige.GetBonuses()
@@ -206,9 +206,9 @@ func TestResolverGolden_ActiveEventTickSpeed(t *testing.T) {
 func TestResolverGolden_MoraleHigh(t *testing.T) {
 	ge := NewGameEngine()
 	ge.Research.bonuses["production_all"] = 0.20
-	// High band: morale > moraleNeutralHigh (0.75) → moraleMultiplier ramps the
-	// bonus in. At cap 1.0 this saturates to ×1.20; production_all Total must
-	// include the banded bonus factor, not the raw 0.90 morale field.
+	// Above the 0.50 pivot → moraleMultiplier ramps the bonus in. At/above cap 1.0
+	// this saturates to ×1.20; production_all Total must include the curve's bonus
+	// factor, not the raw 0.90 morale field.
 	ge.morale = 0.90
 	assertResolverGolden(t, ge, "wood", true)
 }
@@ -216,7 +216,7 @@ func TestResolverGolden_MoraleHigh(t *testing.T) {
 func TestResolverGolden_MoraleNeutral(t *testing.T) {
 	ge := NewGameEngine()
 	ge.Research.bonuses["production_all"] = 0.20
-	// Neutral band [0.25, 0.75] → moraleMultiplier exactly 1.0.
+	// Exactly at the 0.50 pivot → moraleMultiplier exactly 1.0.
 	ge.morale = moraleNeutral // 0.50
 	assertResolverGolden(t, ge, "wood", true)
 }
@@ -224,8 +224,8 @@ func TestResolverGolden_MoraleNeutral(t *testing.T) {
 func TestResolverGolden_MoraleLow(t *testing.T) {
 	ge := NewGameEngine()
 	ge.Research.bonuses["production_all"] = 0.20
-	// Low band: morale < moraleNeutralLow (0.25) → moraleMultiplier penalty.
-	// production_all Total must drop to moraleMultiplier()×(1+adds), well below 1.
+	// Below the 0.50 pivot → moraleMultiplier penalty. production_all Total must
+	// drop to moraleMultiplier()×(1+adds), well below 1.
 	ge.morale = 0.15
 	assertResolverGolden(t, ge, "wood", true)
 }

--- a/game/morale_test.go
+++ b/game/morale_test.go
@@ -8,18 +8,25 @@ import (
 const moraleEps = 1e-9
 
 // ---------------------------------------------------------------------------
-// moraleMultiplier — banded production curve
+// moraleMultiplier — continuous production curve pivoted at 0.50
 // ---------------------------------------------------------------------------
 
-func TestMorale_MultiplierNeutralBandIsOne(t *testing.T) {
-	ge := NewGameEngine()
-	// Across the whole neutral band the multiplier must be exactly 1.0 so the
-	// historic economy baseline is preserved.
-	for _, m := range []float64{moraleNeutralLow, 0.30, moraleNeutral, 0.60, moraleNeutralHigh} {
-		ge.morale = m
-		if got := ge.moraleMultiplier(); math.Abs(got-1.0) > moraleEps {
-			t.Errorf("moraleMultiplier(%.3f) = %.6f, want 1.0", m, got)
-		}
+func TestMorale_MultiplierNeutralOnlyAtPivot(t *testing.T) {
+	ge := NewGameEngine() // fresh: cap = 1.0, no wonders
+	// Exactly at the pivot → 1.0 (baseline preserved).
+	ge.morale = moraleNeutral
+	if got := ge.moraleMultiplier(); math.Abs(got-1.0) > moraleEps {
+		t.Errorf("moraleMultiplier(%.2f) = %.6f, want exactly 1.0", moraleNeutral, got)
+	}
+	// Just above 50% → a small bonus (the old dead zone is gone).
+	ge.morale = 0.52
+	if got := ge.moraleMultiplier(); !(got > 1.0) {
+		t.Errorf("moraleMultiplier(0.52) = %.6f, want > 1.0 (no neutral dead zone)", got)
+	}
+	// Just below 50% → a small penalty.
+	ge.morale = 0.48
+	if got := ge.moraleMultiplier(); !(got < 1.0) {
+		t.Errorf("moraleMultiplier(0.48) = %.6f, want < 1.0 (no neutral dead zone)", got)
 	}
 }
 
@@ -32,28 +39,20 @@ func TestMorale_MultiplierBaselineAtNeutral(t *testing.T) {
 	}
 }
 
-func TestMorale_MultiplierHighBandRampsToMaxBonus(t *testing.T) {
+func TestMorale_MultiplierRampsToMaxBonusAtCap(t *testing.T) {
 	ge := NewGameEngine()
-	// No wonders → cap is 1.0, which equals the high-band ceiling. At cap the
-	// multiplier is the full bonus.
+	// Fresh engine: cap = 1.0. At cap → full bonus.
 	cap := ge.moraleCap()
-	if math.Abs(cap-1.0) > moraleEps {
-		t.Fatalf("precondition: fresh engine moraleCap = %.3f, want 1.0", cap)
-	}
 	ge.morale = cap
 	want := 1.0 + moraleMaxBonus
 	if got := ge.moraleMultiplier(); math.Abs(got-want) > moraleEps {
 		t.Errorf("moraleMultiplier(cap=%.3f) = %.6f, want %.6f", cap, got, want)
 	}
-
-	// Midway between neutral-high and cap → half the bonus. Give the engine a
-	// wonder so the high band has width to ramp across.
+	// Midway between pivot (0.50) and cap → half the bonus. Add a wonder so the
+	// upper half-range has width.
 	ge.Buildings.counts["sacred_grove"] = 1 // a wonder → cap = 1.05
 	cap = ge.moraleCap()
-	if cap <= moraleNeutralHigh {
-		t.Fatalf("precondition: cap %.3f must exceed neutralHigh %.3f", cap, moraleNeutralHigh)
-	}
-	mid := moraleNeutralHigh + (cap-moraleNeutralHigh)/2
+	mid := moraleNeutral + (cap-moraleNeutral)/2
 	ge.morale = mid
 	want = 1.0 + 0.5*moraleMaxBonus
 	if got := ge.moraleMultiplier(); math.Abs(got-want) > 1e-6 {
@@ -61,20 +60,18 @@ func TestMorale_MultiplierHighBandRampsToMaxBonus(t *testing.T) {
 	}
 }
 
-func TestMorale_MultiplierLowBandRampsToMinMult(t *testing.T) {
+func TestMorale_MultiplierRampsToMinMultAtFloor(t *testing.T) {
 	ge := NewGameEngine()
-	// At the 0.10 floor the multiplier is moraleMinMult.
+	// At the 0.10 floor → moraleMinMult.
 	ge.morale = 0.10
 	if got := ge.moraleMultiplier(); math.Abs(got-moraleMinMult) > moraleEps {
 		t.Errorf("moraleMultiplier(0.10) = %.6f, want %.6f", got, moraleMinMult)
 	}
-
-	// Halfway between the floor (0.10) and neutral-low (0.25) → half the penalty.
-	mid := 0.10 + (moraleNeutralLow-0.10)/2
-	ge.morale = mid
+	// Midway between pivot (0.50) and floor (0.10) = 0.30 → half the penalty.
+	ge.morale = 0.30
 	want := 1.0 - 0.5*(1.0-moraleMinMult)
 	if got := ge.moraleMultiplier(); math.Abs(got-want) > 1e-6 {
-		t.Errorf("moraleMultiplier(%.4f) = %.6f, want %.6f", mid, got, want)
+		t.Errorf("moraleMultiplier(0.30) = %.6f, want %.6f", got, want)
 	}
 }
 

--- a/game/types.go
+++ b/game/types.go
@@ -51,10 +51,10 @@ type GameState struct {
 	// Morale system
 	Morale    float64 // current morale 0.10–cap
 	MoraleCap float64 // current cap (1.0 + 0.05 per wonder)
-	// MoraleMultiplier is the production multiplier the banded morale curve
-	// currently yields (moraleMultiplier()). 1.0 across the neutral band, up to
-	// 1.0+moraleMaxBonus in the high band, down to moraleMinMult in the low band.
-	// Exposed so the UI renders the banded model without re-deriving the formula.
+	// MoraleMultiplier is the production multiplier the continuous morale curve
+	// currently yields (moraleMultiplier()). Exactly 1.0 at the 0.50 pivot, up to
+	// 1.0+moraleMaxBonus at the cap, down to moraleMinMult at the 0.10 floor.
+	// Exposed so the UI renders the model without re-deriving the formula.
 	MoraleMultiplier float64
 	// PermanentBonuses is the authoritative runtime map of all cumulative
 	// permanent bonuses (epoch events, legacy, milestones, etc.).

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -173,7 +173,7 @@ Available upgrades and costs are shown in **Stats** overlay (`stats`).
 |---|---|
 | `history` | Open the Civilization History overlay — braille line graphs of key metrics over time |
 
-The History overlay shows 6 live graphs: **Population**, **Food Rate**, **Knowledge Rate**, **Faith**, **Production Bonus**, and **Tick Speed**. Each graph covers up to ~1 hour of rolling history (300 samples, one every 10 ticks). Age advances appear as `│` markers across all graphs so you can correlate events with metric changes.
+The History overlay shows 7 live graphs: **Population**, **Food Rate**, **Knowledge Rate**, **Faith**, **Morale**, **Production Bonus**, and **Tick Speed**. Each graph covers up to ~1 hour of rolling history (300 samples, one every 10 ticks). Age advances appear as `│` markers across all graphs so you can correlate events with metric changes.
 
 Graphs appear after ~30 seconds of play. History is saved and restored automatically. See [History](history.md) for details.
 

--- a/site/docs/history.md
+++ b/site/docs/history.md
@@ -6,7 +6,7 @@ The Civilization History overlay gives you a live graphical view of how your civ
 
 ## What it shows
 
-Six metrics are tracked and graphed continuously:
+Seven metrics are tracked and graphed continuously:
 
 | Metric | What it measures |
 |---|---|
@@ -14,6 +14,7 @@ Six metrics are tracked and graphed continuously:
 | **Food Rate** | Net food per tick (positive = surplus, negative = deficit) |
 | **Knowledge Rate** | Knowledge production per tick |
 | **Faith** | Total faith accumulated |
+| **Morale** | Civilization morale as a percentage (the production multiplier's input) |
 | **Prod Bonus** | Your current `production_all` permanent bonus percentage |
 | **Tick Speed** | Current tick speed multiplier |
 
@@ -33,7 +34,7 @@ Population     ↑ 163workers  min:10.0    max:198.0
 ```
 
 - **Y-axis labels** on the left show max, midpoint, and min values for the visible window
-- **`│` vertical markers** show where age advances occurred — all 6 graphs share the same markers so you can see how each metric responded to an age transition
+- **`│` vertical markers** show where age advances occurred — all 7 graphs share the same markers so you can see how each metric responded to an age transition
 - **X-axis** represents cumulative ticks from oldest to newest sample (left = oldest, right = now)
 
 ---
@@ -54,4 +55,4 @@ Population     ↑ 163workers  min:10.0    max:198.0
 - **Food Rate dipping below zero** shows up clearly as the line crossing the midpoint — useful for catching worker starvation before it becomes critical
 - **Prod Bonus flat-lining** means no new milestones or prestige upgrades have fired recently
 - **Tick Speed** shows the effect of wonders — each wonder built adds a visible step up in the graph
-- Scroll up/down in the overlay with arrow keys if all 6 graphs don't fit on screen
+- Scroll up/down in the overlay with arrow keys if all 7 graphs don't fit on screen

--- a/site/docs/morale.md
+++ b/site/docs/morale.md
@@ -29,19 +29,21 @@ So a civilization with 4 wonders built can push morale as high as **120%**, whil
 
 ---
 
-## The Three Bands
+## The Production Curve
 
-Morale is centred on 50%. What it does depends on which band it sits in:
+Morale's effect on production is a **continuous curve pivoted at 50%** — there is no neutral "dead zone". The multiplier moves the moment morale leaves 50%:
 
-| Band | Morale Range | Effect on All Production |
-|------|--------------|--------------------------|
-| **Low** | below 25% | **Penalty** — ramps down to **×0.50** (half production) at the 10% floor |
-| **Neutral** | 25% – 75% | **No effect** — production runs at its normal rate |
-| **High** | above 75% | **Bonus** — ramps up to **+20%** as morale approaches the cap |
+| Morale | Effect on All Production |
+|--------|--------------------------|
+| **At the 10% floor** | **×0.50** — half production (the worst case) |
+| **Below 50%** | **Penalty** — ramps linearly from ×0.50 (at the floor) up to ×1.00 (at 50%) |
+| **Exactly 50%** | **×1.00** — production runs at its normal baseline |
+| **Above 50%** | **Bonus** — ramps linearly from ×1.00 (at 50%) up to **+20%** (at the morale cap) |
+| **At the cap** | **+20%** — the full bonus (the best case) |
 
-The effect scales **smoothly** within the high and low bands — it is not a flat step. Just above 75% the bonus is tiny; the full +20% is only reached as morale nears its cap. Likewise, just below 25% the penalty is mild; the full ×0.50 only applies at the 10% floor.
+The effect scales **smoothly and continuously**. Just off 50% it is tiny — at 52% the bonus is well under +1% — and it grows with distance, reaching the tuned endpoints only at the extremes (+20% at the cap, ×0.50 at the 10% floor).
 
-The neutral band is wide on purpose. Normal play sits comfortably inside 25%–75% with no morale effect at all — you only feel morale once you actively push it high or let it collapse.
+The two sides are **not symmetric**: the 10% floor is closer to 50% than the cap is, so the downside ramp is **steeper than the upside**. A morale crash costs you more per point than an equally-distant high earns — a collapse hurts more than a peak helps. There is no longer any range where morale "does nothing"; staying near 50% simply keeps the effect small.
 
 ---
 
@@ -91,13 +93,13 @@ Stack enough of them and their per-tick lift outpaces the drift-to-neutral, park
 - **Stats panel** (`stats`) — when morale is off-neutral it appears under **Active Multipliers** in the **All Production** breakdown as a `Morale ×N.NN` factor, shown alongside your research, wonder, prestige, and active-event bonuses on that line.
 - **Load Game browser** — each save's detail pane shows its morale, so you can size up a civilization before loading it.
 
-The bar is **green when morale is boosting production** (high band), **neutral in the middle**, and **red when it is penalising production** (low band).
+The bar is **green when morale is above 50%** (boosting production), **neutral exactly at 50%**, and **red when it is below 50%** (penalising production).
 
 ---
 
 ## Managing Morale — Strategy
 
-1. **Ignore it until you want the bonus.** Normal play sits in the neutral band. There is no penalty for being at 50%, so early on, spend your effort elsewhere.
+1. **50% is the safe baseline.** At exactly 50% there is no bonus and no penalty, so early on you can leave morale alone and spend your effort elsewhere. Just remember the curve is live the moment morale drifts off 50% — small at first, larger the further it goes.
 2. **Keep food positive.** Starvation is the most common cause of a morale slide into the penalty band. Fix the food deficit and the drift heals the rest.
 3. **Don't over-militarise.** Keep military workers comfortably under 30% of population — past that, morale drains faster the more lopsided your army gets. (See [Military](military.md).)
 4. **Don't park idle workers.** More than half your population sitting idle drains morale on top of wasting their food. Assign them or `dismiss` them.

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -538,15 +538,13 @@ func (d *Dashboard) refreshStatus(state game.GameState) {
 		}
 		epochStr = fmt.Sprintf("  [%s]%s %s%s[-]", state.EpochColor, state.EpochIcon, state.EpochName, survivedMark)
 	}
-	// Colour morale by the banded production multiplier, not the raw percent:
+	// Colour morale by the continuous production multiplier, not the raw percent:
 	// green = bonus (mult>1.0), white = neutral (==1.0), red = penalty (<1.0).
 	// computeMoraleBand is the shared source of truth (same as the workers panel).
 	mBand := computeMoraleBand(state.Morale, state.MoraleMultiplier)
 	moraleDelta := ""
-	if mBand.Bonus {
-		moraleDelta = fmt.Sprintf(" [%s]+%d%%[-]", mBand.Color, mBand.DeltaPct)
-	} else if mBand.Penalty {
-		moraleDelta = fmt.Sprintf(" [%s]%d%%[-]", mBand.Color, mBand.DeltaPct) // DeltaPct already signed
+	if mBand.DeltaLabel != "" {
+		moraleDelta = fmt.Sprintf(" [%s]%s[-]", mBand.Color, mBand.DeltaLabel)
 	}
 	moraleStr := fmt.Sprintf("  Morale: [%s]%.0f%%[-]%s", mBand.Color, state.Morale*100, moraleDelta)
 	d.statusTV.SetText(fmt.Sprintf(

--- a/ui/morale_band_test.go
+++ b/ui/morale_band_test.go
@@ -26,8 +26,9 @@ func TestComputeMoraleBand_Bonus(t *testing.T) {
 }
 
 func TestComputeMoraleBand_Neutral(t *testing.T) {
-	// Neutral band: multiplier exactly 1.0 → neutral color, "steady", no penalty.
-	b := computeMoraleBand(0.52, 1.0)
+	// Only an exact-1.0 multiplier is neutral now, which the continuous curve
+	// produces solely at the 0.50 pivot → neutral color, "steady", no penalty.
+	b := computeMoraleBand(0.50, 1.0)
 	if b.Bonus || b.Penalty {
 		t.Fatalf("expected neutral band, got %+v", b)
 	}
@@ -37,11 +38,30 @@ func TestComputeMoraleBand_Neutral(t *testing.T) {
 	if b.DeltaPct != 0 {
 		t.Errorf("neutral delta = %d, want 0", b.DeltaPct)
 	}
-	if !strings.Contains(b.Status, "52%") || !strings.Contains(b.Status, "steady") {
-		t.Errorf("neutral status = %q, want it to mention 52%% and steady", b.Status)
+	if !strings.Contains(b.Status, "50%") || !strings.Contains(b.Status, "steady") {
+		t.Errorf("neutral status = %q, want it to mention 50%% and steady", b.Status)
 	}
 	if strings.Contains(strings.ToLower(b.Status), "penalty") {
 		t.Errorf("neutral status should not mention penalty: %q", b.Status)
+	}
+}
+
+func TestComputeMoraleBand_NearPivotHonest(t *testing.T) {
+	// A real bonus that rounds to 0% must read "+<1%", not a dishonest "+0%".
+	b := computeMoraleBand(0.51, 1.004)
+	if !b.Bonus || b.Penalty {
+		t.Fatalf("expected bonus band just above pivot, got %+v", b)
+	}
+	if !strings.Contains(b.Status, "+<1%") {
+		t.Errorf("near-pivot bonus status = %q, want it to contain +<1%%", b.Status)
+	}
+	// A real penalty that rounds to 0% must read "-<1%".
+	b = computeMoraleBand(0.49, 0.996)
+	if b.Bonus || !b.Penalty {
+		t.Fatalf("expected penalty band just below pivot, got %+v", b)
+	}
+	if !strings.Contains(b.Status, "-<1%") {
+		t.Errorf("near-pivot penalty status = %q, want it to contain -<1%%", b.Status)
 	}
 }
 

--- a/ui/overlay_history.go
+++ b/ui/overlay_history.go
@@ -35,7 +35,7 @@ func renderHistoryOverlay(state game.GameState, w int) string {
 	if graphW < 20 {
 		graphW = 20
 	}
-	const graphH = 4  // rows tall per graph
+	const graphH = 4 // rows tall per graph
 
 	ageCols := AgeMarkerCols(markerTicks, firstTick, lastTick, graphW)
 
@@ -52,6 +52,7 @@ func renderHistoryOverlay(state game.GameState, w int) string {
 		{"Food Rate", "[green]", func(s game.HistorySample) float64 { return s.FoodRate }, "/tick", true},
 		{"Knowledge", "[yellow]", func(s game.HistorySample) float64 { return s.KnowRate }, "/tick", true},
 		{"Faith", "[#cc88ff]", func(s game.HistorySample) float64 { return s.Faith }, "", false},
+		{"Morale", "[#ff66cc]", func(s game.HistorySample) float64 { return s.Morale * 100 }, "%", false},
 		{"Prod Bonus", "[orange]", func(s game.HistorySample) float64 { return s.ProdAll * 100 }, "%", false},
 		{"Tick Speed", "[gray]", func(s game.HistorySample) float64 { return s.TickSpeed }, "x", false},
 	}

--- a/ui/villager_panel.go
+++ b/ui/villager_panel.go
@@ -83,14 +83,15 @@ type buildingRow struct {
 
 // moraleBand describes how to render the banded morale state for the UI.
 // It is derived purely from the live morale fraction and the production
-// multiplier the engine's banded curve produced (state.MoraleMultiplier),
-// so the UI never re-derives the band formula itself.
+// multiplier the engine's continuous curve produced (state.MoraleMultiplier),
+// so the UI never re-derives the curve formula itself.
 type moraleBand struct {
-	Color    string // tview color for morale text + bar fill
-	Status   string // short player-facing status line, e.g. "production +18%"
-	Bonus    bool   // multiplier > 1.0 (high band)
-	Penalty  bool   // multiplier < 1.0 (low band)
-	DeltaPct int    // signed production delta in percent, rounded
+	Color      string // tview color for morale text + bar fill
+	Status     string // short player-facing status line, e.g. "production +18%"
+	Bonus      bool   // multiplier > 1.0 (above pivot)
+	Penalty    bool   // multiplier < 1.0 (below pivot)
+	DeltaPct   int    // signed production delta in percent, rounded
+	DeltaLabel string // pre-formatted signed percent ("+18%", "-34%", "+<1%", "-<1%"); "" when steady
 }
 
 // computeMoraleBand turns morale% + multiplier into colours and copy.
@@ -98,25 +99,39 @@ type moraleBand struct {
 //   - mult == 1.0 → neutral "… steady" (no penalty text)
 //   - mult < 1.0 → red "▼ … production −N%"
 //
+// Because the morale curve is now continuous, a real bonus/penalty can round to
+// 0%. Rather than printing a dishonest "+0%"/"-0%", DeltaLabel reads "+<1%" /
+// "-<1%" in that case so the player sees the effect exists but is tiny.
+//
 // moralePct is the raw morale fraction (e.g. 0.52); mult is state.MoraleMultiplier.
 func computeMoraleBand(moralePct, mult float64) moraleBand {
 	// Round the production delta off the multiplier, not the raw morale.
 	delta := int(roundHalf((mult - 1.0) * 100))
 	switch {
 	case mult > 1.0:
+		label := fmt.Sprintf("+%d%%", delta)
+		if delta == 0 {
+			label = "+<1%"
+		}
 		return moraleBand{
-			Color:    "green",
-			Status:   fmt.Sprintf("▲ Morale %.0f%% — production +%d%%", moralePct*100, delta),
-			Bonus:    true,
-			DeltaPct: delta,
+			Color:      "green",
+			Status:     fmt.Sprintf("▲ Morale %.0f%% — production %s", moralePct*100, label),
+			Bonus:      true,
+			DeltaPct:   delta,
+			DeltaLabel: label,
 		}
 	case mult < 1.0:
-		// delta is negative here; %d already carries the minus sign.
+		// delta is negative here; %d already carries the ASCII minus sign.
+		label := fmt.Sprintf("%d%%", delta)
+		if delta == 0 {
+			label = "-<1%"
+		}
 		return moraleBand{
-			Color:    "red",
-			Status:   fmt.Sprintf("▼ Morale %.0f%% — production %d%%", moralePct*100, delta),
-			Penalty:  true,
-			DeltaPct: delta,
+			Color:      "red",
+			Status:     fmt.Sprintf("▼ Morale %.0f%% — production %s", moralePct*100, label),
+			Penalty:    true,
+			DeltaPct:   delta,
+			DeltaLabel: label,
 		}
 	default:
 		return moraleBand{


### PR DESCRIPTION
## What & why

Playtest finding: at 52% morale the workers panel shows a morale bar and percent, but **Active Multipliers shows nothing**. Root cause wasn't a bug in the panel — morale used a wide **[25%, 75%] neutral dead zone** that returned exactly ×1.0. Half the entire range did nothing, which contradicts both the "managed two-way resource" framing and the "honest/literal" rule (the bar implied it mattered when it didn't).

## The new curve

Continuous, pivoted at 50%. Any deviation produces a small effect that grows with distance. **Tuned endpoints preserved** — only the dead zone is removed and the ramps re-pivoted to 50%:

| Morale | Multiplier | |
|---|---|---|
| cap (≥1.0) | ×1.20 | +20% (unchanged endpoint) |
| 75% | ×1.10 | +10% |
| **52%** | **×1.008** | **+0.8% — now visible** |
| 50% | ×1.00 | pivot / baseline preserved |
| 48% | ×0.975 | −2.5% |
| 30% | ×0.75 | −25% |
| 10% floor | ×0.50 | −50% (unchanged endpoint) |

- above: `1 + (m−0.50)/(cap−0.50) × 0.20`
- below: `1 − (0.50−m)/(0.50−0.10) × 0.50`

Downside ramps ~3× steeper than the upside (the floor is closer to the pivot than the cap) — intentional: a morale crash should bite harder than a high rewards.

## Honest display at the margins
A real sub-1% effect now renders `+<1%` / `-<1%` instead of `+0%`, in both the workers panel and the status bar (shared via `moraleBand.DeltaLabel`). The Active Multipliers panel needed **no** change — its epsilon is 0.05%, so it shows anything past ~50.1% morale; it just never received a non-1.0 morale value before.

## Morale history graph (now 7)
New `HistorySample.Morale`, sampled in `doTick`, rendered pink in Civilization History between Faith and Prod Bonus — directly answering "we need a morale line."

## Tests
- Rewrote the three morale band tests (neutral-only-at-50; ramps from 50 → cap / floor). Drift, building-lift, and baseline-preservation tests unchanged and green.
- Added near-pivot UI assertions (`+<1%` / `-<1%`).
- Golden test: **no assertion changes** — it derives expected from the live `moraleMultiplier()`, so the fixtures self-reconciled. Comments updated.
- `go build ./...` + `go test ./...` clean.

## Wiki
morale.md (bands → continuous curve), commands.md + history.md (6 → 7 graphs).

Trello: https://trello.com/c/5TDzSIT8

🎮 Worth a quick playtest — push morale above/below 50% and confirm the small multiplier shows in Active Multipliers and the history line tracks it.