### PR TITLE
feat(modifiers): color-code Active Multipliers by sign + show every source

### DIFF
--- a/site/docs/morale.md
+++ b/site/docs/morale.md
@@ -88,7 +88,7 @@ Stack enough of them and their per-tick lift outpaces the drift-to-neutral, park
 - **Workers panel** (`workers`) — a coloured morale bar.
 - **Villager sidebar** — the same coloured bar, always visible at a glance.
 - **Status bar** — the headline `Morale: NN%`, coloured by band, with a `+NN%` / `-NN%` tag when it is actively boosting or penalising production.
-- **Stats panel** (`stats`) — when morale is off-neutral it appears under **Active Multipliers** in the **All Production** breakdown as a `Morale ×N.NN` factor, shown alongside your research, wonder, prestige, and active-event bonuses on that line.
+- **Stats panel** (`stats`) — when morale is off-neutral it appears under **Active Multipliers** in the **All Production** breakdown as a `Morale ×N.NN` factor, shown alongside your research, wonder, prestige, and active-event bonuses on that line. Entries are colour-coded: a **green** headline (and fragment) is a net bonus, a **red** one a penalty, and a **white** headline marks a line that only shows because opposing sources cancel out. Each contributing source is listed and coloured individually, so a penalty (e.g. a famine event) is never hidden by a bonus on the same line. The panel lists **rate multipliers only** — capacity and storage bonuses (population cap, resource caps) are shown elsewhere, since they aren't rate multipliers.
 - **Load Game browser** — each save's detail pane shows its morale, so you can size up a civilization before loading it.
 
 The bar is **green when morale is boosting production** (high band), **neutral in the middle**, and **red when it is penalising production** (low band).

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -205,17 +205,29 @@ func renderActiveMultipliers(state game.GameState) string {
 
 	wrote := false
 	for _, target := range r.Targets() {
-		total := r.Total(target)
-		if absFloat(total-1.0) <= multEpsilon {
-			continue // no net effect — skip
+		if !isPanelMultiplier(target) {
+			continue // capacity/flat value (population, all, bare storage key) — not a rate multiplier
 		}
+		// Build the per-source breakdown FIRST. We render a target if ANY source
+		// contributes beyond epsilon — even when those sources net to ×1.0 — so an
+		// opposing +10%/-10% pair stays visible instead of silently collapsing.
 		breakdown := summarizeBreakdown(r.Breakdown(target))
 		if breakdown == "" {
-			continue // every contribution was a no-op
+			continue // genuinely empty — every contribution was a no-op
 		}
-		pct := (total - 1.0) * 100
-		fmt.Fprintf(&sb, "  [cyan]%-20s[-] [yellow]%+.0f%%[-]   [gray]%s[-]\n",
-			multiplierTargetLabel(target), pct, breakdown)
+		total := r.Total(target)
+		netPct := (total - 1.0) * 100
+		// Headline color by net sign: green bonus, red penalty, white if the row
+		// only renders because opposing sources cancel out.
+		headColor := "white"
+		switch {
+		case netPct > 0.5:
+			headColor = "green"
+		case netPct < -0.5:
+			headColor = "red"
+		}
+		fmt.Fprintf(&sb, "  [cyan]%-20s[-] [%s]%+.0f%%[-]   %s\n",
+			multiplierTargetLabel(target), headColor, netPct, breakdown)
 		wrote = true
 	}
 
@@ -233,9 +245,24 @@ func renderActiveMultipliers(state game.GameState) string {
 	return sb.String()
 }
 
-// multEpsilon is the tolerance below which a target's Total is treated as a
-// no-op (×1.0) and omitted from the panel.
+// multEpsilon is the tolerance below which a single source's contribution is
+// treated as a no-op and dropped from a target's per-source breakdown. (A
+// target row itself is no longer omitted on net ≈ 1.0 — opposing sources must
+// stay visible — so this guards fragment-level noise only.)
 const multEpsilon = 0.0005
+
+// isPanelMultiplier reports whether a resolver target is a genuine rate
+// multiplier that belongs in the Active Multipliers panel. Capacity/flat values
+// — population, "all", and bare-resource storage keys like "food"/"culture" —
+// are NOT rate multipliers and must not render as percentages here.
+func isPanelMultiplier(target string) bool {
+	switch target {
+	case "production_all", "gather_rate", "tick_speed", "military_power",
+		"expedition_reward", "research_speed", "build_cost":
+		return true
+	}
+	return strings.HasSuffix(target, "_rate")
+}
 
 // summarizeBreakdown collapses a target's per-modifier contributions into a
 // compact, source-labelled string like
@@ -286,7 +313,12 @@ func summarizeBreakdown(mods []game.Modifier) string {
 			if absFloat(a.mulProd-1.0) <= multEpsilon {
 				continue // ×1.00 — no-op
 			}
-			parts = append(parts, fmt.Sprintf("%s ×%.2f", label, a.mulProd))
+			// Color by sign: a multiplier above 1.0 is a bonus, below is a penalty.
+			color := "green"
+			if a.mulProd < 1.0 {
+				color = "red"
+			}
+			parts = append(parts, fmt.Sprintf("[%s]%s ×%.2f[-]", color, label, a.mulProd))
 			continue
 		}
 		// Additive (the common case). Fold any stray OpMul into the percent so
@@ -295,9 +327,14 @@ func summarizeBreakdown(mods []game.Modifier) string {
 		if absFloat(eff) <= multEpsilon {
 			continue // +0% — no-op
 		}
-		parts = append(parts, fmt.Sprintf("%s %+.0f%%", label, eff*100))
+		// Color by sign: positive contribution is a bonus, negative a penalty.
+		color := "green"
+		if eff < 0 {
+			color = "red"
+		}
+		parts = append(parts, fmt.Sprintf("[%s]%s %+.0f%%[-]", color, label, eff*100))
 	}
-	return strings.Join(parts, " · ")
+	return strings.Join(parts, " [gray]·[-] ")
 }
 
 // multiplierTargetLabel maps a resolver target id to a friendly panel label.

--- a/ui/overlay_stats_multipliers_test.go
+++ b/ui/overlay_stats_multipliers_test.go
@@ -47,7 +47,8 @@ func TestSummarizeBreakdown_AdditiveAndMul(t *testing.T) {
 		{Source: "morale", Target: "production_all", Op: game.OpMul, Value: 1.18},
 	}
 	got := summarizeBreakdown(mods)
-	want := "Research +10% · Wonders +5% · Morale ×1.18"
+	// Each fragment is wrapped in its own sign-colored tag; positives are green.
+	want := "[green]Research +10%[-] [gray]·[-] [green]Wonders +5%[-] [gray]·[-] [green]Morale ×1.18[-]"
 	if got != want {
 		t.Errorf("summarizeBreakdown = %q, want %q", got, want)
 	}
@@ -59,8 +60,8 @@ func TestSummarizeBreakdown_MergesSameSource(t *testing.T) {
 		{Source: "research", Target: "food_rate", Op: game.OpAdd, Value: 0.12},
 		{Source: "research", Target: "food_rate", Op: game.OpAdd, Value: 0.08},
 	}
-	if got := summarizeBreakdown(mods); got != "Research +20%" {
-		t.Errorf("summarizeBreakdown = %q, want %q", got, "Research +20%")
+	if got := summarizeBreakdown(mods); got != "[green]Research +20%[-]" {
+		t.Errorf("summarizeBreakdown = %q, want %q", got, "[green]Research +20%[-]")
 	}
 }
 
@@ -134,5 +135,98 @@ func TestRenderActiveMultipliers_NoopTargetsHidden(t *testing.T) {
 	out := renderActiveMultipliers(state)
 	if !strings.Contains(out, "No active multipliers") {
 		t.Errorf("no-op target should be hidden, got:\n%s", out)
+	}
+}
+
+// TestRenderActiveMultipliers_SignColors proves each contributing source is
+// colored by its own sign: a positive source gets [green], a negative [red].
+func TestRenderActiveMultipliers_SignColors(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 1.0,
+		Modifiers: []game.Modifier{
+			{Source: "research", Target: "production_all", Op: game.OpAdd, Value: 0.20},
+			{Source: "event:Famine", Target: "production_all", Op: game.OpAdd, Value: -0.05},
+		},
+	}
+	out := renderActiveMultipliers(state)
+	if !strings.Contains(out, "[green]Research +20%[-]") {
+		t.Errorf("positive source should be green-tagged:\n%s", out)
+	}
+	if !strings.Contains(out, "[red]Event: Famine -5%[-]") {
+		t.Errorf("negative source should be red-tagged:\n%s", out)
+	}
+	// Net +15% → green headline.
+	if !strings.Contains(out, "[green]+15%[-]") {
+		t.Errorf("net-positive headline should be green:\n%s", out)
+	}
+}
+
+// TestRenderActiveMultipliers_OpposingSourcesStillRender guards the net-zero
+// collapse fix: a target whose sources cancel to ×1.0 must STILL render, with
+// both the positive and negative fragments visible.
+func TestRenderActiveMultipliers_OpposingSourcesStillRender(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 1.0,
+		Modifiers: []game.Modifier{
+			{Source: "research", Target: "gather_rate", Op: game.OpAdd, Value: 0.10},
+			{Source: "event:Drought", Target: "gather_rate", Op: game.OpAdd, Value: -0.10},
+		},
+	}
+	out := renderActiveMultipliers(state)
+	if strings.Contains(out, "No active multipliers") {
+		t.Fatalf("opposing sources netting to ~1.0 must still render a line:\n%s", out)
+	}
+	if !strings.Contains(out, "[green]Research +10%[-]") {
+		t.Errorf("positive fragment missing from net-zero row:\n%s", out)
+	}
+	if !strings.Contains(out, "[red]Event: Drought -10%[-]") {
+		t.Errorf("negative fragment missing from net-zero row:\n%s", out)
+	}
+	// Net ~0% → white headline (neither bonus nor penalty).
+	if !strings.Contains(out, "[white]") {
+		t.Errorf("net-zero headline should be white:\n%s", out)
+	}
+}
+
+// TestRenderActiveMultipliers_CapacityTargetsExcluded guards the
+// isPanelMultiplier filter: flat/capacity targets (population, "all", bare
+// storage keys) are not rate multipliers and must not appear here as percents.
+func TestRenderActiveMultipliers_CapacityTargetsExcluded(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 1.0,
+		Modifiers: []game.Modifier{
+			{Source: "prestige", Target: "population", Op: game.OpAdd, Value: 2.0},
+			{Source: "wonders", Target: "all", Op: game.OpAdd, Value: 20.0},
+			{Source: "research", Target: "food", Op: game.OpAdd, Value: 0.50},
+		},
+	}
+	out := renderActiveMultipliers(state)
+	if strings.Contains(out, "Population") {
+		t.Errorf("population (capacity) must not render in the multiplier panel:\n%s", out)
+	}
+	if strings.Contains(out, "All ") || strings.Contains(out, "+2000%") {
+		t.Errorf("\"all\" (flat) must not render as a percentage:\n%s", out)
+	}
+	if !strings.Contains(out, "No active multipliers") {
+		t.Errorf("only capacity/flat targets present — panel should be empty:\n%s", out)
+	}
+}
+
+// TestIsPanelMultiplier covers the rate/flat classification directly.
+func TestIsPanelMultiplier(t *testing.T) {
+	rate := []string{
+		"production_all", "gather_rate", "tick_speed", "military_power",
+		"expedition_reward", "research_speed", "build_cost", "food_rate", "iron_rate",
+	}
+	for _, tgt := range rate {
+		if !isPanelMultiplier(tgt) {
+			t.Errorf("isPanelMultiplier(%q) = false, want true", tgt)
+		}
+	}
+	flat := []string{"population", "all", "food", "culture", "data"}
+	for _, tgt := range flat {
+		if isPanelMultiplier(tgt) {
+			t.Errorf("isPanelMultiplier(%q) = true, want false", tgt)
+		}
 	}
 }


### PR DESCRIPTION
## PR A of the Active Effects rebuild

First of four PRs from the multiplier-visibility audit. **Panel-render only — zero engine/apply changes**, so it's safe to land independently of #49/#50.

### What changed
- **Color by sign.** Green = bonus, red = penalty, white = a net-zero row that only renders because opposing sources cancel. Replaces the blanket `[yellow]` that made a −50% morale crash indistinguishable from a bonus.
- **Every source stays visible.** Each contributing source is colored by its *own* sign, and a target row now renders whenever any real source touches it — removing the `|Total−1| ≤ ε` skip. A −10% can no longer vanish behind a +10% that nets it to ~zero (the bug that was hiding the catastrophe debuff).
- **No more garbage rows.** `isPanelMultiplier()` keeps the panel to genuine rate multipliers (`production_all`, `gather_rate`, `tick_speed`, `military_power`, `expedition_reward`, `research_speed`, `build_cost`, `*_rate`). Capacity/flat targets (`population`, `all`, bare storage keys) no longer render as nonsense like "Population Cap +200%" / "+2000% All".

### Tests
New: sign colors, opposing-sources-still-render, capacity-target exclusion, classifier coverage. Existing `Contains` assertions still pass (substrings preserved inside the color tags). `go build ./...` + `go test ./...` green.

### Still to come (audit follow-ups)
- **B** — Temporary Effects section: surface active event + catastrophe flat per-tick deltas with countdowns (the big invisibility gap).
- **C** — `diplomacyModifiers()` into the resolver (allied trade bonus shows + applies from one source).
- **D** — drop the remaining `>0` gates (per-resource rate, gather) so negatives apply — sibling of #49's `production_all` fix.

Trello: https://trello.com/c/dN1GH97n