### PR TITLE
feat(modifiers): surface active-event effect magnitudes, color-coded

### DIFF
--- a/game/events.go
+++ b/game/events.go
@@ -257,10 +257,25 @@ func (em *EventManager) Modifiers() []Modifier {
 func (em *EventManager) GetActive() []ActiveEventState {
 	var out []ActiveEventState
 	for _, ae := range em.active {
+		// Surface only ongoing-rate effects. Instant/one-shot types
+		// ("instant_resource", "steal_resource", "worker_loss") fired once at
+		// trigger and are not ongoing, so they don't belong in the panel.
+		var effects []EventEffectInfo
+		for _, eff := range ae.Effects {
+			switch eff.Type {
+			case "production", "production_all", "tick_speed":
+				effects = append(effects, EventEffectInfo{
+					Type:   eff.Type,
+					Target: eff.Target,
+					Value:  eff.Value,
+				})
+			}
+		}
 		out = append(out, ActiveEventState{
 			Name:      ae.Name,
 			Key:       ae.Key,
 			TicksLeft: ae.TicksLeft,
+			Effects:   effects,
 		})
 	}
 	return out

--- a/game/events_test.go
+++ b/game/events_test.go
@@ -44,6 +44,41 @@ func TestEventManager_InjectEvent(t *testing.T) {
 	}
 }
 
+// TestGetActive_SurfacesOngoingEffects proves the view struct now carries each
+// active event's ongoing-rate effects (production / production_all / tick_speed)
+// and drops instant/one-shot types that already fired at trigger.
+func TestGetActive_SurfacesOngoingEffects(t *testing.T) {
+	em := NewEventManager()
+	em.InjectEvent(ActiveEvent{
+		Key:       "famine",
+		Name:      "Famine",
+		TicksLeft: 8,
+		Effects: []config.Effect{
+			{Type: "production", Target: "food", Value: -3.0},
+			{Type: "instant_resource", Target: "wood", Value: 100.0}, // one-shot, must be dropped
+		},
+	})
+
+	active := em.GetActive()
+	if len(active) != 1 {
+		t.Fatalf("expected 1 active event, got %d", len(active))
+	}
+	got := active[0]
+
+	if len(got.Effects) != 1 {
+		t.Fatalf("expected 1 ongoing effect (instant dropped), got %d: %+v", len(got.Effects), got.Effects)
+	}
+	eff := got.Effects[0]
+	if eff.Type != "production" || eff.Target != "food" || eff.Value != -3.0 {
+		t.Errorf("ongoing effect = %+v, want {production food -3.0}", eff)
+	}
+	for _, e := range got.Effects {
+		if e.Type == "instant_resource" {
+			t.Errorf("instant_resource effect must NOT be surfaced in the view: %+v", e)
+		}
+	}
+}
+
 func TestEventManager_InjectedEventExpires(t *testing.T) {
 	em := NewEventManager()
 	em.InjectEvent(ActiveEvent{

--- a/game/types.go
+++ b/game/types.go
@@ -357,11 +357,19 @@ type PrestigeUpgradeState struct {
 
 // === Event Types ===
 
+// EventEffectInfo is one ongoing effect of an active event, for UI display.
+type EventEffectInfo struct {
+	Type   string  // config.Effect.Type: "production" | "production_all" | "tick_speed"
+	Target string  // resource key for "production"; empty/"" for the global ones
+	Value  float64 // per-tick delta for "production"; fraction for "production_all"/"tick_speed"
+}
+
 // ActiveEventState represents an active timed event for UI
 type ActiveEventState struct {
 	Name      string
 	Key       string
 	TicksLeft int
+	Effects   []EventEffectInfo
 }
 
 // === Trade Types ===

--- a/site/docs/events.md
+++ b/site/docs/events.md
@@ -59,6 +59,8 @@ At 1x speed (default 2 seconds per tick):
 
 Use the `logs` command (or press `L`) to open the Logs overlay and see your full event history. Events appear as log entries with their effect description and duration. When a timed event ends, the "ended" entry shows accumulated losses in yellow — useful for assessing actual damage.
 
+The **Stats overlay** lists every currently active timed event under "Active Events" with its ticks remaining. Beneath each event, its ongoing per-tick or percentage effect is now shown explicitly and color-coded — **green** for a bonus, **red** for a penalty — so you can see at a glance exactly what each active event is doing to your economy (e.g. a Famine shows `food -3.0/t` in red; a production-boost event shows `all production +10%` in green). Instant one-shot effects (resource grants, theft) are not listed here since they already fired at trigger.
+
 ---
 
 ## Base Event Reference

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -114,6 +114,20 @@ func statsProvider(state game.GameState, _ int) string {
 	} else {
 		for _, evt := range state.ActiveEvents {
 			fmt.Fprintf(&sb, " [yellow]⚡[-] [yellow]%s[-] (%d ticks left)\n", evt.Name, evt.TicksLeft)
+			for _, eff := range evt.Effects {
+				color := "green"
+				if eff.Value < 0 {
+					color = "red"
+				}
+				switch eff.Type {
+				case "production":
+					fmt.Fprintf(&sb, " [%s]    %s %+.1f/t[-]\n", color, eff.Target, eff.Value)
+				case "production_all":
+					fmt.Fprintf(&sb, " [%s]    all production %+.0f%%[-]\n", color, eff.Value*100)
+				case "tick_speed":
+					fmt.Fprintf(&sb, " [%s]    tick speed %+.0f%%[-]\n", color, eff.Value*100)
+				}
+			}
 		}
 	}
 

--- a/ui/overlay_stats_multipliers_test.go
+++ b/ui/overlay_stats_multipliers_test.go
@@ -212,6 +212,41 @@ func TestRenderActiveMultipliers_CapacityTargetsExcluded(t *testing.T) {
 	}
 }
 
+// TestStatsProvider_ActiveEventEffects proves the stats overlay now renders
+// each active event's ongoing effects beneath it, color-coded by sign: a
+// negative production effect gets a [red] "food" line, a positive one [green].
+func TestStatsProvider_ActiveEventEffects(t *testing.T) {
+	state := game.GameState{
+		SpeedMultiplier: 1.0,
+		ActiveEvents: []game.ActiveEventState{
+			{
+				Name:      "Famine",
+				Key:       "famine",
+				TicksLeft: 8,
+				Effects: []game.EventEffectInfo{
+					{Type: "production", Target: "food", Value: -3.0},
+				},
+			},
+			{
+				Name:      "Gold Rush",
+				Key:       "gold_rush",
+				TicksLeft: 12,
+				Effects: []game.EventEffectInfo{
+					{Type: "production", Target: "gold", Value: 1.0},
+				},
+			},
+		},
+	}
+	out := statsProvider(state, 0)
+
+	if !strings.Contains(out, "[red]    food -3.0/t[-]") {
+		t.Errorf("negative production effect should render red-tagged:\n%s", out)
+	}
+	if !strings.Contains(out, "[green]    gold +1.0/t[-]") {
+		t.Errorf("positive production effect should render green-tagged:\n%s", out)
+	}
+}
+
 // TestIsPanelMultiplier covers the rate/flat classification directly.
 func TestIsPanelMultiplier(t *testing.T) {
 	rate := []string{


### PR DESCRIPTION
## PR B of the Active Effects rebuild

Closes the **biggest** gap from the multiplier-visibility audit: every per-resource timed event (the entire random pool + epoch good/bad events — Famine, Epidemic, Gold Rush, Trade Winds) was completely invisible. They take the direct-rate path and never become resolver Modifiers, so the stats overlay listed only their name + ticks-left.

### What changed
- `ActiveEventState` now carries `Effects []EventEffectInfo`; `GetActive()` copies each event's effects across, filtered to **ongoing** types (`production`, `production_all`, `tick_speed`). Instant one-shots (`instant_resource`, `steal_resource`, `worker_loss`) are dropped — they fire once at trigger, there's nothing ongoing to display.
- The stats overlay renders each effect beneath its event, sign-colored green/red:
  - `<resource> +/-N/t` (e.g. `food -3.0/t`)
  - `all production +/-N%`
  - `tick speed +/-N%`

**View-layer only** — no engine/apply/resolver changes, so it's independent of the rest of the queue.

### Tests
- `game`: `TestGetActive_SurfacesOngoingEffects` — ongoing effect carried through, instant excluded.
- `ui`: `TestStatsProvider_ActiveEventEffects` — `[red]` line for a penalty, `[green]` for a bonus.
- `go build ./...` + `go test ./...` green.

### Remaining
- **C** — `diplomacyModifiers()` into the resolver (allied trade bonus shows + applies from one source). *(now unblocked — #49 merged)*
- **D** — drop the remaining `>0` gates (per-resource rate, gather). *(now unblocked)*

Trello: https://trello.com/c/dN1GH97n