### PR TITLE
feat(modifiers): diplomacy trade bonus into resolver + prove negatives apply

### DIFF
--- a/game/active_effects_test.go
+++ b/game/active_effects_test.go
@@ -1,0 +1,167 @@
+package game
+
+import (
+	"math"
+	"testing"
+
+	"github.com/espresso20/ageforge/config"
+)
+
+// active_effects_test.go guards PRs C and D of the Active Effects work:
+//   - Part D: recalculateRates now APPLIES negative per-resource / gather rate
+//     pools (gate→floor), proven by the engine reducing a real production rate.
+//   - Part C: the allied-faction trade bonus is emitted as a resolver Modifier so
+//     it surfaces in the Active Multipliers panel, without changing apply math.
+
+// addProductionBuilding injects a synthetic worker-free building that produces a
+// flat `value × count` of `res` per tick (WorkerCapacity 0 → no fill scaling), so
+// recalculateRates has a positive base rate to multiply. Mirrors addWonder's
+// approach but for a production effect rather than a bonus effect.
+func addProductionBuilding(ge *GameEngine, key, res string, value float64, count int) {
+	ge.Buildings.defs[key] = config.BuildingDef{
+		Key:      key,
+		Name:     key,
+		Category: "production",
+		Effects:  []config.Effect{{Type: "production", Target: res, Value: value}},
+	}
+	ge.Buildings.counts[key] = count
+}
+
+// TestRecalculateRates_NegativeResRateReducesRate is the Part D apply-side guard:
+// a negative <res>_rate additive pool must now reduce the resource's rate. Before
+// the gate→floor change the engine ran `if bonus > 0 { rate *= 1+bonus }`, so a
+// negative pool was silently dropped and this assertion would have FAILED (rate
+// unchanged). Morale is pinned neutral (×1.0) to isolate the per-resource factor.
+func TestRecalculateRates_NegativeResRateReducesRate(t *testing.T) {
+	ge := NewGameEngine()
+	ge.morale = moraleNeutral // moraleMultiplier() == 1.0
+	addProductionBuilding(ge, "test_food_farm", "food", 10.0, 1)
+
+	// Baseline: no rate bonus → flat 10.0/tick.
+	ge.recalculateRates()
+	base := ge.Resources.GetRate("food")
+	if math.Abs(base-10.0) > 1e-9 {
+		t.Fatalf("baseline food rate = %.6f, want 10.0", base)
+	}
+
+	// Negative per-resource pool: -0.20 → factor max(0.10, 0.80) = 0.80.
+	ge.permanentBonuses["food_rate"] = -0.20
+	ge.recalculateRates()
+	got := ge.Resources.GetRate("food")
+	want := 10.0 * 0.80
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("negative food_rate: rate = %.6f, want %.6f (debuff must reduce the rate)", got, want)
+	}
+	if got >= base {
+		t.Fatalf("negative food_rate did not reduce the rate: got %.6f, base %.6f", got, base)
+	}
+}
+
+// TestRecalculateRates_NegativeGatherRateReducesRate is the Part D apply-side
+// guard for the gather pool. gather_rate is applied as an additive delta on the
+// worker-generated portion of a rate; a negative pool must now pull it down. We
+// seed worker production by stubbing GetProductionRates via a real worker setup
+// would be heavy, so we drive the same code path through the engine's gather
+// application using a production building plus a gather debuff and assert the
+// floored delta reduces output. Morale pinned neutral.
+//
+// Note: gather_rate scales ge.Workers.GetProductionRates(), which is empty on a
+// fresh engine (worker output is folded into BuildingRate). So we assert the
+// resolver-side invariant the engine consumes — AddTotal(gather_rate) — is
+// negative and that the floored factor the engine computes is < 1.0, which is the
+// exact term recalculateRates multiplies the worker delta by.
+func TestRecalculateRates_NegativeGatherRateFlooredFactor(t *testing.T) {
+	ge := NewGameEngine()
+	ge.morale = moraleNeutral
+	ge.permanentBonuses["gather_rate"] = -0.30
+
+	add := ge.buildResolver().AddTotal("gather_rate")
+	if math.Abs(add-(-0.30)) > 1e-9 {
+		t.Fatalf("gather_rate AddTotal = %.6f, want -0.30", add)
+	}
+	// Engine computes gatherDelta = max(productionFloor, 1+add) - 1.0; for -0.30
+	// that is 0.70 - 1.0 = -0.30 (floor not binding), i.e. a real reduction.
+	factor := math.Max(productionFloor, 1.0+add)
+	if factor >= 1.0 {
+		t.Fatalf("negative gather_rate floored factor = %.6f, want < 1.0 (debuff must apply)", factor)
+	}
+}
+
+// allyFaction marks a faction allied directly (bypassing the gold cost of
+// SetStatus) so GetTradeBonus returns its specialty TradeBonus. Mirrors how the
+// diplomacy manager stores state internally.
+func allyFaction(ge *GameEngine, key string) {
+	ge.Diplomacy.factions[key] = &FactionState{
+		Discovered: true,
+		Opinion:    50,
+		Status:     "allied",
+	}
+}
+
+// TestDiplomacyModifiers_EmitsOpMulForAlly is the Part C guard: an allied faction
+// produces an OpMul Modifier on its specialty <res>_rate, and that Modifier shows
+// up in buildResolver().All() (the slice the Active Multipliers panel renders).
+func TestDiplomacyModifiers_EmitsOpMulForAlly(t *testing.T) {
+	ge := NewGameEngine()
+	// merchant_guild: Specialty "gold", TradeBonus 0.20.
+	allyFaction(ge, "merchant_guild")
+
+	if got := ge.Diplomacy.GetTradeBonus("gold"); math.Abs(got-0.20) > 1e-9 {
+		t.Fatalf("GetTradeBonus(gold) = %.6f, want 0.20 (ally not set up)", got)
+	}
+
+	mods := ge.diplomacyModifiers()
+	var found *Modifier
+	for i := range mods {
+		if mods[i].Target == "gold_rate" {
+			found = &mods[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("diplomacyModifiers() emitted no gold_rate modifier: %+v", mods)
+	}
+	if found.Source != "diplomacy" || found.Op != OpMul || math.Abs(found.Value-1.20) > 1e-9 {
+		t.Fatalf("gold_rate modifier = %+v, want {Source:diplomacy Op:OpMul Value:1.20}", *found)
+	}
+
+	// It must reach the panel via buildResolver().All().
+	all := ge.buildResolver().All()
+	var inAll bool
+	for _, m := range all {
+		if m.Source == "diplomacy" && m.Target == "gold_rate" && m.Op == OpMul {
+			inAll = true
+			break
+		}
+	}
+	if !inAll {
+		t.Fatalf("diplomacy gold_rate OpMul not present in buildResolver().All() — panel would not show it")
+	}
+}
+
+// TestDiplomacyModifiers_FreshEngineEmpty confirms a fresh engine has no allies, so
+// GetTradeBonus is 0 and diplomacyModifiers emits nothing — this is why the golden
+// fixtures (default fresh engines) are unaffected by Part C.
+func TestDiplomacyModifiers_FreshEngineEmpty(t *testing.T) {
+	ge := NewGameEngine()
+	if got := ge.Diplomacy.GetTradeBonus("gold"); got != 0 {
+		t.Fatalf("fresh-engine GetTradeBonus(gold) = %.6f, want 0", got)
+	}
+	if mods := ge.diplomacyModifiers(); len(mods) != 0 {
+		t.Fatalf("fresh-engine diplomacyModifiers() = %+v, want empty", mods)
+	}
+}
+
+// TestDiplomacyModifiers_DoesNotChangeAppliedRate verifies the no-double-count
+// invariant: the engine consumes <res>_rate via AddTotal (OpAdd only), so adding
+// an OpMul diplomacy Modifier does NOT change the additive pool the engine
+// applies. The panel gains a line; the math does not move.
+func TestDiplomacyModifiers_DoesNotChangeAppliedRate(t *testing.T) {
+	ge := NewGameEngine()
+	allyFaction(ge, "merchant_guild") // gold_rate OpMul ×1.20
+
+	// AddTotal ignores OpMul, so the additive gold_rate pool stays 0.
+	if got := ge.buildResolver().AddTotal("gold_rate"); got != 0 {
+		t.Fatalf("gold_rate AddTotal with diplomacy OpMul = %.6f, want 0 (OpMul must not enter additive pool)", got)
+	}
+}

--- a/game/engine.go
+++ b/game/engine.go
@@ -1677,6 +1677,23 @@ func (ge *GameEngine) moraleModifiers() []Modifier {
 	return []Modifier{{Source: "morale", Target: "production_all", Op: OpMul, Value: ge.moraleMultiplier()}}
 }
 
+// diplomacyModifiers emits the allied-faction trade bonus as an OpMul on each
+// affected <resource>_rate so it surfaces in the Active Multipliers panel. The
+// engine still APPLIES the bonus directly in recalculateRates (the additive
+// pool uses AddTotal, which ignores OpMul, so there is no double-count); this
+// Modifier is the panel's view of that same GetTradeBonus value — they cannot
+// drift because both read GetTradeBonus. Must read only already-held state.
+func (ge *GameEngine) diplomacyModifiers() []Modifier {
+	out := make([]Modifier, 0, len(ge.Resources.defs))
+	for _, def := range ge.Resources.defs {
+		b := ge.Diplomacy.GetTradeBonus(def.Key)
+		if b != 0 {
+			out = append(out, Modifier{Source: "diplomacy", Target: def.Key + "_rate", Op: OpMul, Value: 1.0 + b})
+		}
+	}
+	return out
+}
+
 // buildResolver constructs a fresh Resolver from every bonus source and returns
 // it. Pull model: a NEW resolver is built each call so nothing mutable is shared
 // across goroutines. Lock safety: only call from a context that already holds the
@@ -1690,6 +1707,7 @@ func (ge *GameEngine) buildResolver() *Resolver {
 	r.AddAll(ge.permanentModifiers())
 	r.AddAll(ge.eventModifiers())
 	r.AddAll(ge.moraleModifiers())
+	r.AddAll(ge.diplomacyModifiers())
 	return r
 }
 

--- a/game/modifiers_golden_test.go
+++ b/game/modifiers_golden_test.go
@@ -216,6 +216,42 @@ func TestResolverGolden_NegativeProdAll(t *testing.T) {
 	assertResolverGolden(t, ge, "wood", true)
 }
 
+// TestResolverGolden_NegativeResRate is the Part D anti-tautology fixture for the
+// per-resource pool: a negative <res>_rate additive (here permanent food_rate
+// -0.20) must now apply. Before the gate→floor change, recalculateRates ran
+// `if bonus > 0 { rate *= 1+bonus }`, which SILENTLY DROPPED any negative pool —
+// the panel showed the debuff but the rate was untouched. expectedResRate models
+// the floored form max(productionFloor, 1+add); for -0.20 that is 0.80 (floor not
+// binding), so the resolver Total and the engine factor agree at ×0.80. If the
+// gate ever creeps back the expected side would still want 0.80 while a re-gated
+// engine would apply 1.0, and this assertion would catch the divergence.
+func TestResolverGolden_NegativeResRate(t *testing.T) {
+	ge := NewGameEngine()
+	ge.permanentBonuses["food_rate"] = -0.20
+
+	// Sanity: the additive pool is exactly -0.20 and the floored factor is 0.80
+	// (well above productionFloor), so the debuff lands — it is not swallowed.
+	if got, want := ge.buildResolver().Total("food_rate"), 0.80; math.Abs(got-want) > goldenEps {
+		t.Fatalf("negative food_rate: resolver Total=%.12f want %.12f (debuff must apply)", got, want)
+	}
+	assertResolverGolden(t, ge, "food", false)
+}
+
+// TestResolverGolden_NegativeGatherRate is the Part D anti-tautology fixture for
+// the gather pool: a negative gather_rate additive (permanent -0.30) must now
+// reduce worker output. Same story as the per-resource case — the old
+// `if gatherBonus > 0` gate dropped negatives. expectedGatherRate models
+// max(productionFloor, 1-0.30) = 0.70, so resolver Total and engine agree at ×0.70.
+func TestResolverGolden_NegativeGatherRate(t *testing.T) {
+	ge := NewGameEngine()
+	ge.permanentBonuses["gather_rate"] = -0.30
+
+	if got, want := ge.buildResolver().Total("gather_rate"), 0.70; math.Abs(got-want) > goldenEps {
+		t.Fatalf("negative gather_rate: resolver Total=%.12f want %.12f (debuff must apply)", got, want)
+	}
+	assertResolverGolden(t, ge, "", true)
+}
+
 func TestResolverGolden_ActiveEventTickSpeed(t *testing.T) {
 	ge := NewGameEngine()
 	ge.Events.InjectEvent(ActiveEvent{

--- a/site/docs/catastrophe.md
+++ b/site/docs/catastrophe.md
@@ -123,6 +123,8 @@ Effect: production_all -10% for 216 ticks
 
 This is separate from the building loss. Even buildings that survived are producing at 90% for the reconstruction period, and this now applies in full — negative production modifiers are floored so production can't drop below 10% of base, but a single −10% debuff lands cleanly off the top regardless of what other bonuses you hold. Plan for both effects simultaneously.
 
+This flooring applies to **all** rate pools, not just `production_all`: negative per-resource rate modifiers (e.g. `food_rate`) and negative gather-rate modifiers now apply the same way, each clamped to no lower than 10% of the base they act on. A future debuff or negative milestone targeting a single resource (or worker gather output) reduces that rate as designed instead of being silently ignored — and it appears in the Active Multipliers panel alongside the positive bonuses.
+
 **Recovery checklist after Endure:**
 1. Check which buildings were destroyed (the log lists every lost building by name)
 2. Rebuild the most impactful lost buildings first (usually food and worker capacity)

--- a/site/docs/trade.md
+++ b/site/docs/trade.md
@@ -159,6 +159,8 @@ actual import = base import × (1.0 + trade_bonus)
 
 Bonuses from multiple allied factions stack additively if they share a specialty (unlikely, but possible in theory).
 
+The allied trade bonus also surfaces in the **Active Multipliers** panel (Stats overlay) as a `Diplomacy` line on the affected resource's rate, so you can see at a glance which of your production rates an alliance is amplifying. The number shown is the same `1 + trade_bonus` factor described above — the panel and the applied bonus read from the same source, so they can't drift.
+
 | Faction | Specialty | Allied Bonus |
 |---|---|---|
 | Merchant Guild | gold | +20% |

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -367,6 +367,8 @@ func multiplierSourceLabel(src string) string {
 		return "Morale"
 	case "event":
 		return "Event"
+	case "diplomacy":
+		return "Diplomacy"
 	}
 	return capitalize(src)
 }


### PR DESCRIPTION
## PRs C + D of the Active Effects rebuild (the last gaps)

### C — Diplomacy trade bonus → resolver
The allied-faction trade bonus is a *persistent* ×(1+b) on a specialty resource's rate, but it was applied by direct mutation and never appeared in Active Multipliers. Now `diplomacyModifiers()` emits an `OpMul` on each affected `<res>_rate`, wired into `buildResolver()`, so it shows as a colored **Diplomacy** line.

**No double-count, no drift:** the engine still applies the bonus directly; the per-resource rate pool consumes via `AddTotal` (OpAdd only), which ignores the OpMul — so the panel gains a line without moving the applied rate. Both the apply and the Modifier read the same `GetTradeBonus`, so they can't diverge. Pure read, lock-safe under the engine write lock. Pinned by `TestDiplomacyModifiers_DoesNotChangeAppliedRate`.

### D — Negative rate pools
Turned out the `res_rate` and `gather_rate` pools were **already** ungated+floored (landed alongside the `production_all` fix in #49 — the audit predated that merge). What was missing was *proof*. Added anti-tautology fixtures:
- `TestResolverGolden_NegativeResRate` — `food_rate −0.20` → resolver Total 0.80, golden re-check.
- `TestResolverGolden_NegativeGatherRate` — `gather_rate −0.30` → Total 0.70.
- `TestRecalculateRates_NegativeResRateReducesRate` — engine actually drops a 10/t producer to 8/t (the ungate changed real behavior).

### Tests
New diplomacy + negative-pool tests; golden suite green. `go build ./...` + `go test ./...` clean.

### Wraps the audit
With #51 (color + per-source), #52 (temporary event effects), and this, all four gaps are closed: every +/- effect — permanent, temporary, or diplomatic — now surfaces in the panel, color-coded, with nothing netting away.

Trello: https://trello.com/c/dN1GH97n