### PR TITLE
feat(morale): faith production rate lifts morale

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -226,6 +226,9 @@ const (
 	moraleMaxBonus = 0.20   // max production bonus at moraleCap()
 	moraleMinMult  = 0.50   // production multiplier at the 0.10 morale floor
 	moraleDrift    = 0.0008 // per-tick gentle pull back toward moraleNeutral
+
+	faithMoraleFactor = 0.0002 // morale lift per faith/tick produced
+	faithMoraleCap    = 0.0040 // max per-tick morale lift from faith rate (saturates ~20 faith/tick; bounds late-game firehose)
 )
 
 // moraleMultiplier converts the current morale into a production multiplier
@@ -339,6 +342,17 @@ func (ge *GameEngine) updateMoraleTick() {
 	}
 	if moraleFromBuildings != 0 {
 		ge.applyMorale(moraleFromBuildings)
+	}
+
+	// Faith-rate morale lift: an active faith economy keeps spirits up. Scales with
+	// faith PRODUCTION rate (not hoarded stock), capped per tick so a late-game
+	// faith firehose can't peg morale in one step. Tunable via the consts above.
+	faithRate := 0.0
+	if fr, ok := ge.Resources.resources["faith"]; ok {
+		faithRate = fr.Rate
+	}
+	if faithRate > 0 {
+		ge.applyMorale(math.Min(faithRate*faithMoraleFactor, faithMoraleCap))
 	}
 
 	// Drift gently toward neutral. A stable, fed, non-over-militarized civ with

--- a/game/morale_test.go
+++ b/game/morale_test.go
@@ -183,6 +183,63 @@ func TestMorale_NoMoraleBuildingsNoLift(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Faith-rate morale lift
+// ---------------------------------------------------------------------------
+
+func TestMorale_FaithRateRaisesMorale(t *testing.T) {
+	ge := NewGameEngine()
+	ge.morale = moraleNeutral
+
+	// A positive faith production rate must out-pull the per-tick drift over a
+	// few ticks (5 × faithMoraleFactor = 0.001/tick of lift vs 0.0008 drift).
+	ge.mu.Lock()
+	ge.Resources.resources["faith"].Rate = 5.0
+	ge.mu.Unlock()
+
+	start := ge.morale
+	tickMoraleN(ge, 20)
+	if ge.morale <= start {
+		t.Errorf("faith Rate 5.0 over 20 ticks: morale %.6f did not rise above start %.6f", ge.morale, start)
+	}
+}
+
+func TestMorale_NoFaithRateNoLift(t *testing.T) {
+	// Default faith Rate is 0 on a fresh engine → no lift, morale holds at neutral.
+	ge := NewGameEngine()
+	if r := ge.Resources.resources["faith"]; r != nil && r.Rate != 0 {
+		t.Fatalf("precondition: fresh engine faith Rate = %.6f, want 0", r.Rate)
+	}
+	ge.morale = moraleNeutral
+	tickMoraleN(ge, 50)
+	if ge.morale > moraleNeutral+1e-6 {
+		t.Errorf("zero faith Rate raised morale to %.6f, want ≤ neutral", ge.morale)
+	}
+}
+
+func TestMorale_FaithRateContributionCapped(t *testing.T) {
+	ge := NewGameEngine()
+	ge.morale = moraleNeutral
+
+	// An enormous faith Rate must not lift morale proportionally: the per-tick
+	// contribution is bounded by faithMoraleCap. We compare against neutral and
+	// add back the per-tick drift (which pulls neutral → neutral, i.e. nothing
+	// here since we start exactly at neutral) so the delta is purely the lift.
+	ge.mu.Lock()
+	ge.Resources.resources["faith"].Rate = 10000
+	ge.mu.Unlock()
+
+	start := ge.morale
+	tickMoraleN(ge, 1)
+	delta := ge.morale - start
+	if delta > faithMoraleCap+moraleEps {
+		t.Errorf("single-tick faith lift = %.9f, want ≤ faithMoraleCap %.9f (cap must bound it)", delta, faithMoraleCap)
+	}
+	if delta <= 0 {
+		t.Errorf("single-tick faith lift = %.9f, want a positive (capped) lift", delta)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Production baseline preserved at neutral morale
 // ---------------------------------------------------------------------------
 

--- a/site/docs/faith.md
+++ b/site/docs/faith.md
@@ -6,7 +6,8 @@ Faith is a resource that accumulates from Faith lineage buildings and faith-doma
 
 ## Why Faith Matters
 
-1. **Epoch Roll Odds** — The only mechanical effect of faith. Faith % directly determines your chances of getting a good (vs bad) event at each epoch transition.
+1. **Epoch Roll Odds** — Faith % directly determines your chances of getting a good (vs bad) event at each epoch transition.
+2. **Worker Morale** — Producing faith now also lifts worker [morale](morale.md). An active faith economy keeps spirits up: a small morale lift each tick scales with your faith **production rate** (faith/tick), not your stored faith. The per-tick lift is **capped**, so even a late-game faith firehose can't peg morale in one step — but a steady faith income is a passive, ongoing morale source on top of the epoch odds.
 
 ---
 

--- a/site/docs/morale.md
+++ b/site/docs/morale.md
@@ -63,6 +63,7 @@ In short: neutral is the resting state. You have to spend effort to live above i
 | Source | Effect |
 |--------|--------|
 | **Morale-restoring buildings** | The main lever. Worship buildings (shrines, temples, and their later-age equivalents) and culture/entertainment buildings lift morale **each tick just by existing** — no workers required. |
+| **Faith production rate** | An active faith economy keeps spirits up. A small morale lift scales with your **faith produced per tick** (your faith *rate*, not your stored faith), so the more faith you are actively generating, the higher it nudges morale. The per-tick lift is **capped**, so a late-game faith firehose can't peg morale in a single step. |
 | **Good events** | A favourable event lifts morale. |
 | **Advancing to a new age** | Reaching a new age gives a one-time morale boost. |
 


### PR DESCRIPTION
## What
Faith production rate now contributes a small per-tick morale lift — a faithful, *active* civilisation stays content. Previously the faith stat/economy did nothing for morale; only buildings with a `morale` effect lifted it.

In `updateMoraleTick`:
```
moraleFromFaith = min(faithRate × faithMoraleFactor, faithMoraleCap)
```
- Scales with faith **rate**, not hoarded stock — rewards running a faith economy, not banking it.
- Capped per tick so a late-game faith firehose can't peg morale in one step.
- Stacks with building morale effects; clamped by `moraleCap` like every other source.
- Lock-safe (reads `Resources.resources["faith"].Rate` directly under the write lock).

## Tuning (a knob — playtest and tell me)
`faithMoraleFactor = 0.0002`, `faithMoraleCap = 0.0040` → the lift is proportional from 0 up to ~20 faith/tick, then bounded. (Started narrower at 7.5/tick saturation, widened so it feels proportional rather than on/off.)

**Honest caveat:** because it's linear-in-rate, the lift is genuinely tiny at very low early-game faith rates (e.g. +0.2/tick → negligible vs the 0.0008/tick drift). If you'd rather it feel proportional *from the very start* across the whole faith curve (early single-digits → late hundreds), I'd swap the linear+cap for a log/sqrt curve — say the word and it's a one-line change.

## Tests
`TestMorale_FaithRateRaisesMorale`, `TestMorale_NoFaithRateNoLift`, `TestMorale_FaithRateContributionCapped`. Fresh-engine faith Rate is 0, so existing drift/baseline tests are unaffected. `go build ./...` + `go test ./...` green.

Trello: https://trello.com/c/6FBiWx6v