### PR TITLE
feat(save): bare save reuses active slot + Load Game key legend

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -101,6 +101,11 @@ type GameEngine struct {
 	cheaterBadge bool
 	eliteBadge   bool
 
+	// activeSaveName is the slot a bare `save` writes to: the last name explicitly
+	// saved or loaded this session. Empty until set; ActiveSaveName falls back to
+	// AutosaveName. The periodic autosave does NOT touch this — it's a separate net.
+	activeSaveName string
+
 	// Phase 7: result of the most recent age advance transformation pass
 	lastAgeAdvanceSummary AgeAdvanceSummary
 
@@ -551,6 +556,25 @@ func (ge *GameEngine) GetMaxSpeed() float64 {
 	ge.mu.RLock()
 	defer ge.mu.RUnlock()
 	return ge.MaxSpeedForAge()
+}
+
+// ActiveSaveName is the slot a bare `save` writes to: the last name explicitly
+// saved or loaded this session, defaulting to AutosaveName until one is set.
+func (ge *GameEngine) ActiveSaveName() string {
+	ge.mu.RLock()
+	defer ge.mu.RUnlock()
+	if ge.activeSaveName == "" {
+		return AutosaveName
+	}
+	return ge.activeSaveName
+}
+
+// SetActiveSaveName records the slot a bare `save` should target. Call it after a
+// successful explicit `save <name>`; LoadGame sets it directly under its own lock.
+func (ge *GameEngine) SetActiveSaveName(name string) {
+	ge.mu.Lock()
+	defer ge.mu.Unlock()
+	ge.activeSaveName = name
 }
 
 // Stop halts the game tick loop. Safe to call multiple times; subsequent

--- a/game/save.go
+++ b/game/save.go
@@ -586,6 +586,12 @@ func (ge *GameEngine) LoadGame(filename string) error {
 	// Apply offline progress for time since save
 	ge.applyOfflineProgress(time.Since(save.Timestamp))
 
+	// Load succeeded: this is now the active slot a bare `save` writes to. We're
+	// still under the write lock (ge.mu.Lock at the top of this function), so set
+	// the field DIRECTLY — calling SetActiveSaveName would re-acquire the lock and
+	// deadlock.
+	ge.activeSaveName = filename
+
 	return nil
 }
 

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -362,6 +362,45 @@ func TestListSaveDetailsRichFields(t *testing.T) {
 	}
 }
 
+func TestActiveSaveNameDefaultsAndSetter(t *testing.T) {
+	// A fresh engine has never saved or loaded → bare `save` targets the autosave.
+	ge := NewGameEngine()
+	if got := ge.ActiveSaveName(); got != AutosaveName {
+		t.Errorf("fresh ActiveSaveName() = %q, want %q", got, AutosaveName)
+	}
+	// An explicit `save <name>` records the slot for future bare saves.
+	ge.SetActiveSaveName("test")
+	if got := ge.ActiveSaveName(); got != "test" {
+		t.Errorf("after SetActiveSaveName(\"test\"), ActiveSaveName() = %q, want \"test\"", got)
+	}
+}
+
+func TestLoadGameSetsActiveSaveName(t *testing.T) {
+	name := "test_active_load"
+	ge := writeTestSave(t, name) // writes name.json, registers cleanup
+
+	// A different engine that loads the slot should adopt it as its active name,
+	// so a subsequent bare `save` overwrites the loaded slot rather than autosave.
+	other := NewGameEngine()
+	if got := other.ActiveSaveName(); got != AutosaveName {
+		t.Fatalf("pre-load ActiveSaveName() = %q, want %q", got, AutosaveName)
+	}
+	if err := other.LoadGame(name); err != nil {
+		t.Fatalf("LoadGame(%q) failed: %v", name, err)
+	}
+	if got := other.ActiveSaveName(); got != name {
+		t.Errorf("after LoadGame(%q), ActiveSaveName() = %q, want %q", name, got, name)
+	}
+
+	// A failed load must NOT change the active slot.
+	if err := ge.LoadGame("test_active_load_missing"); err == nil {
+		t.Fatal("LoadGame on missing file = nil error, want error")
+	}
+	if got := ge.ActiveSaveName(); got != AutosaveName {
+		t.Errorf("after failed LoadGame, ActiveSaveName() = %q, want %q (unchanged)", got, AutosaveName)
+	}
+}
+
 func TestListSaveDetailsFlagsCorrupt(t *testing.T) {
 	// Ensure the dir exists, then drop a non-JSON .json file into it.
 	good := "test_corrupt_neighbor"

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -202,6 +202,8 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 
 Save files live in `./data/saves/*.json`, relative to the directory you launch the game from. The `save <name>` and `load <name>` commands above work with the same files as the **Load Game** browser below.
 
+A bare `save` (no name) re-saves to your most recent named or loaded save — it stays on the autosave slot only until you've explicitly `save <name>`d or loaded a named save this session. The periodic autosave always writes to the autosave slot regardless and never changes which slot a bare `save` targets.
+
 ---
 
 ## Saving & Loading
@@ -223,7 +225,7 @@ Highlighting a save updates a **detail pane** on the side with everything you ne
 | `c` | Duplicate the highlighted save (creates `<name>-copy`) |
 | `Esc` | Return to the main menu |
 
-**Row tags:**
+**Row tags:** these symbols are also explained on-screen in a bordered **Key** box between the save list and the detail pane, so you don't have to leave the browser to look them up.
 
 | Tag | Meaning |
 |---|---|

--- a/ui/input.go
+++ b/ui/input.go
@@ -546,12 +546,20 @@ func cmdStatus(engine *game.GameEngine) CommandResult {
 }
 
 func cmdSave(args []string, engine *game.GameEngine) CommandResult {
-	name := "autosave"
-	if len(args) > 0 {
+	// With a name: write that slot and make it the active one for future bare
+	// saves. Without: reuse the active slot (last named/loaded save, else autosave).
+	var name string
+	explicit := len(args) > 0
+	if explicit {
 		name = args[0]
+	} else {
+		name = engine.ActiveSaveName()
 	}
 	if err := engine.SaveGame(name); err != nil {
 		return CommandResult{Message: fmt.Sprintf("Save failed: %v", err), Type: "error"}
+	}
+	if explicit {
+		engine.SetActiveSaveName(name)
 	}
 	return CommandResult{Message: fmt.Sprintf("Game saved as '%s'", name), Type: "info"}
 }

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -66,6 +66,17 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 		b.updateDetail(index)
 	})
 
+	// ── Key / legend ─────────────────────────────────────────────────────────
+	// Static box explaining the row symbols. Colours match the row tags exactly
+	// (gold for ★/⭐, red for ⚠). Never changes, so no refresh wiring.
+	legend := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText(legendText())
+	legend.SetBorder(true).
+		SetBorderColor(tcell.ColorGold).
+		SetTitle(" Key ").
+		SetTitleColor(tcell.ColorGold)
+
 	// ── Detail pane ──────────────────────────────────────────────────────────
 	b.detail = tview.NewTextView().
 		SetDynamicColors(true).
@@ -86,6 +97,7 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 		AddItem(title, 1, 0, false).
 		AddItem(b.subtitle, 1, 0, false).
 		AddItem(b.list, 0, 1, true).     // weighted — takes remaining space
+		AddItem(legend, 6, 0, false).    // 4 content lines + border
 		AddItem(b.detail, 10, 0, false). // fits 6 content lines + optional badge + border
 		AddItem(footer, 1, 0, false)
 
@@ -412,6 +424,18 @@ func footerBar() string {
 		footerButton("C", "Duplicate"),
 		footerButton("Esc", "Back"),
 	}, "  ") + "  "
+}
+
+// legendText returns the static Key-box markup: one row symbol per line with a
+// short explanation. Colours match the row tags exactly (gold for ★/⭐, red for
+// ⚠) so the box reads as a direct legend for what's shown in the list.
+func legendText() string {
+	return strings.Join([]string{
+		"[gold]★ auto[-]      automatic save slot (overwritten on autosave)",
+		"[gold]⭐ elite[-]     an elite save",
+		"[red]⚠ modified[-]  save file edited outside the game",
+		"[red]⚠ corrupt[-]   file could not be read — cannot be loaded",
+	}, "\n")
 }
 
 func rowTag(s game.SaveInfo) string {

--- a/ui/load_game_test.go
+++ b/ui/load_game_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -69,6 +70,31 @@ func TestRowTagPrecedence(t *testing.T) {
 	plain := game.SaveInfo{Name: "hero"}
 	if got := rowTag(plain); got != "" {
 		t.Errorf("rowTag(plain) = %q, want empty", got)
+	}
+}
+
+func TestLegendTextCoversSymbolsWithMatchingColors(t *testing.T) {
+	legend := legendText()
+	// Every row symbol the browser can show must be explained in the Key box.
+	for _, sym := range []string{"★ auto", "⭐ elite", "⚠ modified", "⚠ corrupt"} {
+		if !strings.Contains(legend, sym) {
+			t.Errorf("legendText() missing symbol %q\n%s", sym, legend)
+		}
+	}
+	// Colours must match the row tags exactly: gold for ★/⭐, red for ⚠.
+	for _, goldTag := range []string{"[gold]★ auto[-]", "[gold]⭐ elite[-]"} {
+		if !strings.Contains(legend, goldTag) {
+			t.Errorf("legendText() missing gold-tagged %q\n%s", goldTag, legend)
+		}
+	}
+	for _, redTag := range []string{"[red]⚠ modified[-]", "[red]⚠ corrupt[-]"} {
+		if !strings.Contains(legend, redTag) {
+			t.Errorf("legendText() missing red-tagged %q\n%s", redTag, legend)
+		}
+	}
+	// Four symbols → four content lines (sizing assumes this for the height-6 box).
+	if lines := strings.Count(legend, "\n") + 1; lines != 4 {
+		t.Errorf("legendText() has %d lines, want 4", lines)
 	}
 }
 


### PR DESCRIPTION
Two save/load UX fixes from playtest.

## Bug — bare `save` forgot your slot
`save test` then a later bare `save` wrote a fresh `autosave.json` instead of updating `test`. Now the engine tracks an **active save name**:
- Set on any explicit `save <name>` and on a successful `LoadGame` (so `load`, and the Load Game browser, inherit it).
- A bare `save` writes to that slot — defaulting to `autosave` only until you've named or loaded one.
- The **periodic/Esc autosave stays on its own `autosave` slot** — a background save should never silently clobber your named file.
- Lock-safe: `LoadGame` sets the field directly under its own write lock (calling the setter would re-acquire → deadlock); getter/setter guard with `ge.mu`.

## Feature — Load Game symbol Key
The loader showed `★ auto` / `⭐ elite` / `⚠ modified` / `⚠ corrupt` with no explanation. Added a bordered **Key** box between the save list and the detail pane spelling each out, colored to match the tags.

## Tests
`TestActiveSaveNameDefaultsAndSetter`, `TestLoadGameSetsActiveSaveName` (incl. failed-load-doesn't-change-slot), `TestLegendTextCoversSymbolsWithMatchingColors`. `go build ./...` + `go test ./...` green. Wiki: commands.md updated for both.

Tickets: https://trello.com/c/jexsqkk2 (bug) · https://trello.com/c/NZVQEJPq (legend)