### PR TITLE
docs(saves): Saving & Loading wiki page; hide elite easter egg

### DIFF
--- a/site/docs/_sidebar.md
+++ b/site/docs/_sidebar.md
@@ -8,6 +8,7 @@
 - **Gameplay**
   - [How to Play](how-to-play.md)
   - [All Commands](commands.md)
+  - [Saving & Loading](saving-and-loading.md)
   - [Resources](resources.md)
   - [Workers](villagers.md)
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -204,6 +204,8 @@ Save files live in `./data/saves/*.json`, relative to the directory you launch t
 
 A bare `save` (no name) re-saves to your most recent named or loaded save — it stays on the autosave slot only until you've explicitly `save <name>`d or loaded a named save this session. The periodic autosave always writes to the autosave slot regardless and never changes which slot a bare `save` targets.
 
+See [Saving & Loading](saving-and-loading.md) for the full save system.
+
 ---
 
 ## Saving & Loading
@@ -230,7 +232,6 @@ Highlighting a save updates a **detail pane** on the side with everything you ne
 | Tag | Meaning |
 |---|---|
 | ★ auto | The autosave slot |
-| ⭐ elite | An elite save |
 | ⚠ modified | The save file was edited outside the game (cheater badge) |
 | ⚠ corrupt | The file could not be read. It is still listed but dimmed, and cannot be loaded |
 

--- a/site/docs/saving-and-loading.md
+++ b/site/docs/saving-and-loading.md
@@ -1,0 +1,87 @@
+# Saving & Loading
+
+AgeForge keeps your civilization safe with named saves, a continuous autosave, and a full save browser. This page covers where saves live, the commands that manage them, and how to read the Load Game browser.
+
+---
+
+## Where saves live
+
+Save files are written to `./data/saves/*.json`, relative to the directory you launch the game from. One file per save. The `save`/`load` commands and the **Load Game** browser all read and write the same files, so a save made one way shows up the other.
+
+---
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `save [name]` | Save to a named slot. With no name, writes to the active save slot (see below) |
+| `load [name]` | Load a named save |
+| `saves` (or `save list`) | List all save files |
+| `Esc` | Quick-save to the `autosave` slot |
+
+```
+save hero
+save
+load hero
+saves
+```
+
+---
+
+## Active save slot
+
+The game remembers the last slot you explicitly `save`d to or `load`ed. A bare `save` (no name) re-writes **that** slot — it is not a generic dump.
+
+- Until you've named a save or loaded one this session, a bare `save` defaults to the `autosave` slot.
+- Once you `save hero` or `load hero`, a bare `save` thereafter targets `hero`.
+
+The periodic autosave (and `Esc`) always writes to its own separate `autosave` slot, regardless of which slot a bare `save` targets. A background save will never clobber your named file.
+
+---
+
+## Autosave
+
+The game autosaves periodically and whenever you press `Esc`, always to the `autosave` slot. Treat it as a safety net rather than your primary save — name the runs you care about so a routine autosave can't overwrite them.
+
+---
+
+## The Load Game browser
+
+From the main menu, choosing **Load Game** opens a save browser that lists every save in `./data/saves/`, most-recent first. Highlighting a save updates a **detail pane** showing everything you need to size up that save before loading it: its age and epoch, population, buildings, wonders, milestones, techs, soldiers, prestige, [morale](morale.md), a ⚠ warning if a catastrophe is pending, and the exact save time.
+
+**Keys inside the browser:**
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move the highlight between saves |
+| `Enter` | Load the highlighted save |
+| `d` | Delete the highlighted save (asks you to confirm first) |
+| `r` | Rename the highlighted save |
+| `c` | Duplicate the highlighted save |
+| `Esc` | Return to the main menu |
+
+---
+
+## Save badges
+
+Saves can carry a row tag in the list, explained on-screen in a bordered **Key** box:
+
+| Tag | Meaning |
+|---|---|
+| ★ auto | The automatic save slot |
+| ⚠ modified | The save file was edited outside the game (integrity check failed) |
+| ⚠ corrupt | The file could not be read. It is still listed but dimmed, and cannot be loaded |
+
+---
+
+## Save integrity
+
+Saves are signed. If a save file is edited outside the game, the integrity check fails and the file is flagged `⚠ modified` in the browser. A `⚠ corrupt` file is one the game couldn't read at all — it stays in the list, dimmed, but cannot be loaded.
+
+---
+
+## Tips
+
+- **Name your important saves.** A bare `save` targets your active slot, but giving milestones their own names (`save iron_age_start`) keeps them out of harm's way.
+- **Duplicate before risky moves.** Press `c` in the Load Game browser to clone a save before a prestige, catastrophe, or any decision you might want to undo.
+- **Autosave is your safety net, not your archive.** It's there if the game closes unexpectedly — but it gets overwritten constantly, so don't rely on it for runs you want to keep.

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -68,7 +68,7 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 
 	// ── Key / legend ─────────────────────────────────────────────────────────
 	// Static box explaining the row symbols. Colours match the row tags exactly
-	// (gold for ★/⭐, red for ⚠). Never changes, so no refresh wiring.
+	// (gold for ★, red for ⚠). Never changes, so no refresh wiring.
 	legend := tview.NewTextView().
 		SetDynamicColors(true).
 		SetText(legendText())
@@ -97,7 +97,7 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 		AddItem(title, 1, 0, false).
 		AddItem(b.subtitle, 1, 0, false).
 		AddItem(b.list, 0, 1, true).     // weighted — takes remaining space
-		AddItem(legend, 6, 0, false).    // 4 content lines + border
+		AddItem(legend, 5, 0, false).    // 3 content lines + border
 		AddItem(b.detail, 10, 0, false). // fits 6 content lines + optional badge + border
 		AddItem(footer, 1, 0, false)
 
@@ -427,12 +427,11 @@ func footerBar() string {
 }
 
 // legendText returns the static Key-box markup: one row symbol per line with a
-// short explanation. Colours match the row tags exactly (gold for ★/⭐, red for
+// short explanation. Colours match the row tags exactly (gold for ★, red for
 // ⚠) so the box reads as a direct legend for what's shown in the list.
 func legendText() string {
 	return strings.Join([]string{
 		"[gold]★ auto[-]      automatic save slot (overwritten on autosave)",
-		"[gold]⭐ elite[-]     an elite save",
 		"[red]⚠ modified[-]  save file edited outside the game",
 		"[red]⚠ corrupt[-]   file could not be read — cannot be loaded",
 	}, "\n")

--- a/ui/load_game_test.go
+++ b/ui/load_game_test.go
@@ -75,26 +75,29 @@ func TestRowTagPrecedence(t *testing.T) {
 
 func TestLegendTextCoversSymbolsWithMatchingColors(t *testing.T) {
 	legend := legendText()
-	// Every row symbol the browser can show must be explained in the Key box.
-	for _, sym := range []string{"★ auto", "⭐ elite", "⚠ modified", "⚠ corrupt"} {
+	// Every player-facing row symbol must be explained in the Key box.
+	for _, sym := range []string{"★ auto", "⚠ modified", "⚠ corrupt"} {
 		if !strings.Contains(legend, sym) {
 			t.Errorf("legendText() missing symbol %q\n%s", sym, legend)
 		}
 	}
-	// Colours must match the row tags exactly: gold for ★/⭐, red for ⚠.
-	for _, goldTag := range []string{"[gold]★ auto[-]", "[gold]⭐ elite[-]"} {
-		if !strings.Contains(legend, goldTag) {
-			t.Errorf("legendText() missing gold-tagged %q\n%s", goldTag, legend)
-		}
+	// Colours must match the row tags exactly: gold for ★, red for ⚠.
+	if goldTag := "[gold]★ auto[-]"; !strings.Contains(legend, goldTag) {
+		t.Errorf("legendText() missing gold-tagged %q\n%s", goldTag, legend)
 	}
 	for _, redTag := range []string{"[red]⚠ modified[-]", "[red]⚠ corrupt[-]"} {
 		if !strings.Contains(legend, redTag) {
 			t.Errorf("legendText() missing red-tagged %q\n%s", redTag, legend)
 		}
 	}
-	// Four symbols → four content lines (sizing assumes this for the height-6 box).
-	if lines := strings.Count(legend, "\n") + 1; lines != 4 {
-		t.Errorf("legendText() has %d lines, want 4", lines)
+	// The elite easter-egg badge must NOT be advertised in the legend, even
+	// though a real elite save still renders its ⭐ row tag.
+	if strings.Contains(legend, "elite") {
+		t.Errorf("legendText() leaks the elite easter egg\n%s", legend)
+	}
+	// Three symbols → three content lines (sizing assumes this for the height-5 box).
+	if lines := strings.Count(legend, "\n") + 1; lines != 3 {
+		t.Errorf("legendText() has %d lines, want 3", lines)
 	}
 }
 


### PR DESCRIPTION
Adds **site/docs/saving-and-loading.md** documenting the whole save system in one place — file location, `save`/`load`/`saves`/`Esc`, the new active-slot reuse behavior, autosave, the Load Game browser, and the three player-facing badges (★ auto, ⚠ modified, ⚠ corrupt). Linked in the sidebar; cross-linked from commands.md.

Per your call, **elite stays a hidden easter egg**: removed from the loader's in-game Key box and from commands.md's row-tag table. A real elite save still *renders* its ⭐ (rowTag/detail logic untouched) — just not advertised. `go build/test` green.

Trello: https://trello.com/c/5FWggNdi