### PR TITLE
feat(save): name generator + ParentName lineage field (phase 1)

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -106,6 +106,10 @@ type GameEngine struct {
 	// AutosaveName. The periodic autosave does NOT touch this — it's a separate net.
 	activeSaveName string
 
+	// activeParentName tracks the parent of the current save in the save-lineage
+	// tree (Phase 1: plumbed but always "" — branching populates it in Phase 2).
+	activeParentName string
+
 	// Phase 7: result of the most recent age advance transformation pass
 	lastAgeAdvanceSummary AgeAdvanceSummary
 

--- a/game/save.go
+++ b/game/save.go
@@ -72,8 +72,13 @@ type GameSave struct {
 	// Integrity fields
 	CheaterBadge bool   `json:"cheater_badge,omitempty"`
 	EliteBadge   bool   `json:"elite_badge,omitempty"`
-	Signature    string `json:"_sig,omitempty"`
-	Proof        string `json:"_proof,omitempty"`
+	// ParentName records the save this one branched from, for the save-lineage
+	// tree (Phase 1: plumbed through but always "" — branching lands in Phase 2).
+	// Legacy saves lack the field → "" → a root. omitempty keeps current saves
+	// byte-identical when empty.
+	ParentName string `json:"parent_name,omitempty"`
+	Signature  string `json:"_sig,omitempty"`
+	Proof      string `json:"_proof,omitempty"`
 }
 
 // signSave returns the HMAC-SHA256 hex of the save payload.
@@ -378,6 +383,7 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 		LegacyBuildings:    ge.Buildings.GetLegacyBuildings(),
 		CheaterBadge:       ge.cheaterBadge,
 		EliteBadge:         ge.eliteBadge,
+		ParentName:         ge.activeParentName,
 		CurrentEpoch:       ge.currentEpoch,
 		EpochEventFired:    copyBoolMap(ge.epochEventFired),
 		SurvivedEpochs:     copyBoolMap(ge.survivedEpochs),
@@ -591,6 +597,8 @@ func (ge *GameEngine) LoadGame(filename string) error {
 	// the field DIRECTLY — calling SetActiveSaveName would re-acquire the lock and
 	// deadlock.
 	ge.activeSaveName = filename
+	// Adopt the loaded save's lineage parent (empty for legacy/root saves).
+	ge.activeParentName = save.ParentName
 
 	return nil
 }
@@ -670,6 +678,9 @@ type SaveInfo struct {
 	PendingCatastrophe string // pending_catastrophe → catastrophe display name ("" if none)
 	MilestonesDone     int    // count of completed milestones
 	MilestonesTotal    int    // total milestones defined in config (0 if unavailable)
+	// ParentName is the lineage parent of this save ("" for a root). Surfaced
+	// here so Phase 3 can assemble the save-tree without re-reading files.
+	ParentName string
 	// Corrupt is set when the file could not be read or JSON-parsed. The entry
 	// is still returned (Name + mtime Timestamp) so the UI can show it as
 	// greyed/unloadable rather than silently dropping it.
@@ -723,8 +734,9 @@ func ListSaveDetails() ([]SaveInfo, error) {
 			Research           struct {
 				Researched []string `json:"researched"`
 			} `json:"research"`
-			CheaterBadge bool `json:"cheater_badge"`
-			EliteBadge   bool `json:"elite_badge"`
+			CheaterBadge bool   `json:"cheater_badge"`
+			EliteBadge   bool   `json:"elite_badge"`
+			ParentName   string `json:"parent_name"`
 		}
 		if err := json.Unmarshal(data, &header); err != nil {
 			saves = append(saves, corruptInfo(name, e))
@@ -769,6 +781,7 @@ func ListSaveDetails() ([]SaveInfo, error) {
 			PendingCatastrophe: catastropheDisplayName(header.PendingCatastrophe),
 			MilestonesDone:     len(header.Milestones),
 			MilestonesTotal:    len(config.Milestones()),
+			ParentName:         header.ParentName,
 		})
 	}
 	return saves, nil

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -401,6 +401,54 @@ func TestLoadGameSetsActiveSaveName(t *testing.T) {
 	}
 }
 
+func TestParentNameRoundTrips(t *testing.T) {
+	name := "test_lineage_child"
+	ge := NewGameEngine()
+	t.Cleanup(func() { _ = os.Remove(savePath(name)) })
+
+	// Same-package test → set the unexported field directly (no setter needed).
+	ge.activeParentName = "RootGame"
+	if err := ge.SaveGame(name); err != nil {
+		t.Fatalf("SaveGame(%q) failed: %v", name, err)
+	}
+
+	// A fresh engine loading the child must adopt the persisted parent.
+	loaded := NewGameEngine()
+	if err := loaded.LoadGame(name); err != nil {
+		t.Fatalf("LoadGame(%q) failed: %v", name, err)
+	}
+	if loaded.activeParentName != "RootGame" {
+		t.Errorf("activeParentName after load = %q, want %q", loaded.activeParentName, "RootGame")
+	}
+
+	// ListSaveDetails must surface the same parent for Phase 3's tree.
+	if got := findDetail(t, name).ParentName; got != "RootGame" {
+		t.Errorf("SaveInfo.ParentName = %q, want %q", got, "RootGame")
+	}
+}
+
+func TestLegacySaveHasNoParentName(t *testing.T) {
+	// A legacy-style save written without parent_name must load as a root ("").
+	name := "test_lineage_legacy"
+	writeTestSave(t, name) // ensures the dir exists + registers cleanup
+	writeRawSave(t, name, GameSave{
+		Timestamp: time.Now(),
+		Age:       "stone_age",
+		// ParentName intentionally omitted (zero value, omitempty drops it).
+	})
+
+	loaded := NewGameEngine()
+	if err := loaded.LoadGame(name); err != nil {
+		t.Fatalf("LoadGame(%q) failed: %v", name, err)
+	}
+	if loaded.activeParentName != "" {
+		t.Errorf("legacy save loaded with activeParentName = %q, want \"\"", loaded.activeParentName)
+	}
+	if got := findDetail(t, name).ParentName; got != "" {
+		t.Errorf("legacy SaveInfo.ParentName = %q, want \"\"", got)
+	}
+}
+
 func TestListSaveDetailsFlagsCorrupt(t *testing.T) {
 	// Ensure the dir exists, then drop a non-JSON .json file into it.
 	good := "test_corrupt_neighbor"

--- a/game/savenames.go
+++ b/game/savenames.go
@@ -1,0 +1,155 @@
+package game
+
+import (
+	"math/rand"
+	"strings"
+)
+
+// GenerateSaveName returns a procedural, human-friendly name for a new save
+// slot. It picks one of three style families at random (epic / mythic /
+// whimsical) and assembles a name from curated word banks.
+//
+// The result is always FILESYSTEM-SAFE: it becomes a save filename
+// (<name>.json), so it contains letters and single spaces only — never an
+// apostrophe, slash, dot, colon, quote, or other path-hostile character.
+// Mythic names therefore use no apostrophes. Output is trimmed and has
+// internal whitespace collapsed to single spaces.
+//
+// Names are cosmetic and MAY repeat across calls — there is no uniqueness
+// guarantee. We use math/rand's global source (auto-seeded by modern Go),
+// so callers do not need to seed anything.
+func GenerateSaveName() string {
+	switch rand.Intn(3) {
+	case 0:
+		return cleanSaveName(generateEpicName())
+	case 1:
+		return cleanSaveName(generateMythicName())
+	default:
+		return cleanSaveName(generateWhimsicalName())
+	}
+}
+
+// cleanSaveName collapses internal whitespace to single spaces and trims the
+// ends, guaranteeing the no-leading/trailing-space invariant the word-bank
+// assembly relies on. The banks themselves never introduce path-hostile
+// characters, so a strings.Fields round-trip is all the sanitising we need.
+func cleanSaveName(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// --- EPIC: grand, dominion-flavoured. "The <Adj> <Noun>" / "<Root> <Suffix>".
+
+var epicAdjectives = []string{
+	"Gilded", "Verdant", "Azure", "Eternal", "Radiant", "Sovereign",
+	"Ironclad", "Crimson", "Golden", "Boundless", "Towering", "Glorious",
+	"Ascendant", "Resolute", "Imperial", "Hallowed",
+}
+
+var epicNouns = []string{
+	"Dominion", "Ascendancy", "Reach", "Compact", "Hegemony", "Empire",
+	"Realm", "Bastion", "Sovereignty", "Accord", "Expanse", "Citadel",
+	"Crown", "Vanguard", "Concord", "Mandate",
+}
+
+var epicPlaceRoots = []string{
+	"Ironhold", "Sunspire", "Stormhall", "Goldmere", "Highreach", "Frosthold",
+	"Emberfall", "Greywatch", "Brightspire", "Stonereach", "Dawnhold", "Ashmere",
+	"Westmarch", "Thornwall", "Silvermoor", "Oakenford",
+}
+
+var epicSuffixes = []string{
+	"Ascendancy", "Hegemony", "Dominion", "Reach", "Compact", "Accord",
+	"Realm", "Empire", "Sovereignty", "Mandate", "Expanse", "Crown",
+}
+
+func generateEpicName() string {
+	if rand.Intn(2) == 0 {
+		return "The " + pick(epicAdjectives) + " " + pick(epicNouns)
+	}
+	return pick(epicPlaceRoots) + " " + pick(epicSuffixes)
+}
+
+// --- MYTHIC: coined ancient-sounding names. No apostrophes (filesystem-safe).
+
+var mythicRoots = []string{
+	"Vaelthar", "Kael", "Drovia", "Zhanggar", "Obsidian", "Aeon",
+	"Myrr", "Thalor", "Eldros", "Korvath", "Nyxara", "Velmara",
+	"Azhul", "Sorrowmere", "Caldris", "Ophis",
+}
+
+var mythicConnectors = []string{
+	"", "", "Drovia", "Vey", "Anar", "Mor", "Sael", "Thun",
+	"Vora", "Eth", "Kah", "Ulm",
+}
+
+var mythicSuffixes = []string{
+	"um", "ia", "or", "eth", "an", "is", "ar", "yx",
+	"ondor", "athar", "evar", "umir",
+}
+
+var mythicAdjectives = []string{
+	"Obsidian", "Eternal", "Forgotten", "Shrouded", "Ancient", "Hollow",
+	"Sunken", "Veiled", "Silent", "Endless", "First", "Pale",
+}
+
+var mythicEpochNouns = []string{
+	"Aeon", "Epoch", "Dominion", "Throne", "Expanse", "Covenant",
+	"Sanctum", "Vault", "Spire", "Reach", "Hollow", "Marches",
+}
+
+func generateMythicName() string {
+	switch rand.Intn(3) {
+	case 0:
+		// Coined single word: <Root><connector><suffix>
+		return pick(mythicRoots) + pick(mythicConnectors) + pick(mythicSuffixes)
+	case 1:
+		// Two coined words: <Root> <Root+suffix>
+		return pick(mythicRoots) + " " + pick(mythicRoots) + pick(mythicSuffixes)
+	default:
+		// "The <Adj> <EpochNoun>" / "<Adj> <Root>"
+		if rand.Intn(2) == 0 {
+			return "The " + pick(mythicAdjectives) + " " + pick(mythicEpochNouns)
+		}
+		return pick(mythicAdjectives) + " " + pick(mythicRoots)
+	}
+}
+
+// --- WHIMSICAL: playful, low-stakes. "The <Adj> <Noun>" / "Grand Duchy of ...".
+
+var whimsicalWholeNames = []string{
+	"Cluckington", "Snoozeburg", "Wobbleton", "Crumbshire", "Mittensgard",
+	"Biscuitania", "Fluffhaven", "Pottersville", "Snackopolis", "Lazyfields",
+	"Bumbleshire", "Quackmoor",
+}
+
+var whimsicalAdjectives = []string{
+	"Potato", "Mildly Cross", "Reluctant", "Comfy", "Sleepy", "Grumpy",
+	"Snacking", "Wobbly", "Indignant", "Cozy", "Disgruntled", "Cheerful",
+}
+
+var whimsicalNouns = []string{
+	"Kingdom", "Empire", "Republic", "Federation", "Collective", "Commonwealth",
+	"Confederacy", "League", "Syndicate", "Assembly", "Council", "Order",
+}
+
+var whimsicalOfThings = []string{
+	"Snacks", "Naps", "Mild Inconvenience", "Slightly Burnt Toast", "Spare Buttons",
+	"Lost Socks", "Excellent Cheese", "Questionable Decisions", "Afternoon Tea",
+	"Reasonable Doubt", "Comfortable Chairs", "Forgotten Errands",
+}
+
+func generateWhimsicalName() string {
+	switch rand.Intn(3) {
+	case 0:
+		return pick(whimsicalWholeNames)
+	case 1:
+		return "The " + pick(whimsicalAdjectives) + " " + pick(whimsicalNouns)
+	default:
+		return "Grand Duchy of " + pick(whimsicalOfThings)
+	}
+}
+
+// pick returns a uniformly random element from a non-empty slice.
+func pick(bank []string) string {
+	return bank[rand.Intn(len(bank))]
+}

--- a/game/savenames_test.go
+++ b/game/savenames_test.go
@@ -1,0 +1,35 @@
+package game
+
+import (
+	"strings"
+	"testing"
+)
+
+// pathHostile is the set of characters that must never appear in a generated
+// save name, since the name becomes a save filename (<name>.json).
+const pathHostile = `/\:.'"*?<>|`
+
+func TestGenerateSaveNameFilesystemSafe(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		name := GenerateSaveName()
+		if name == "" {
+			t.Fatalf("GenerateSaveName() returned empty string")
+		}
+		if strings.ContainsAny(name, pathHostile) {
+			t.Fatalf("GenerateSaveName() = %q contains a path-hostile char from %q", name, pathHostile)
+		}
+		if name != strings.TrimSpace(name) {
+			t.Fatalf("GenerateSaveName() = %q has leading/trailing whitespace", name)
+		}
+	}
+}
+
+func TestGenerateSaveNameVariety(t *testing.T) {
+	seen := make(map[string]struct{})
+	for i := 0; i < 200; i++ {
+		seen[GenerateSaveName()] = struct{}{}
+	}
+	if len(seen) <= 5 {
+		t.Errorf("GenerateSaveName() produced only %d distinct values across 200 calls, want > 5", len(seen))
+	}
+}


### PR DESCRIPTION
## Phase 1 of the save-lineage feature — foundation

Pure plumbing, **no behavior change**: autosave, prompts, and the Load Game browser are untouched; the generator isn't called anywhere yet (Phase 2 wires it in).

- **`GenerateSaveName()`** (game/savenames.go) — mixed-bag procedural namer across three families (epic / mythic / whimsical), output guaranteed **filesystem-safe** (letters + single spaces, no `/ \ : . ' " * ? < > |`). Sample runs: *The Verdant Accord*, *Highreach Ascendancy*, *Vaeltharum*, *Kael Drovia*, *The Potato Kingdom*, *Biscuitania*.
- **`ParentName`** lineage field on `GameSave` (omitempty) + `activeParentName` on the engine (stays `""` until Phase 2 branching); plumbed through save/load and surfaced on `SaveInfo` so Phase 3 can build the tree. Legacy saves load as roots.

Tests: generator safety + variety; ParentName round-trip; legacy-save → root. `go build/vet/test` green.

Next: **Phase 2** — autosave overwrites the active save; new-game name prompt; manual `save` → Overwrite/Branch.

Trello: https://trello.com/c/NwwPqS7O