### PR TITLE
feat(save): autosave overwrites active save + New Game names your run (phase 2a)

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -423,9 +423,11 @@ func (ge *GameEngine) Start() {
 		case <-timer.C:
 			ge.safeTick()
 
-			// Periodic autosave (outside the tick lock)
+			// Periodic autosave (outside the tick lock) → overwrite the active save
+			// slot, not a fixed "autosave" file. ActiveSaveName takes its own RLock;
+			// safe here because we are outside the tick write lock.
 			if time.Since(lastAutosave) >= AutosaveInterval {
-				if err := ge.SaveGame("autosave"); err != nil {
+				if err := ge.SaveGame(ge.ActiveSaveName()); err != nil {
 					ge.mu.Lock()
 					ge.addLog("warning", fmt.Sprintf("Autosave failed: %v", err))
 					ge.mu.Unlock()
@@ -579,6 +581,32 @@ func (ge *GameEngine) SetActiveSaveName(name string) {
 	ge.mu.Lock()
 	defer ge.mu.Unlock()
 	ge.activeSaveName = name
+}
+
+// ActiveParentName is the lineage parent of the current save ("" for a root).
+func (ge *GameEngine) ActiveParentName() string {
+	ge.mu.RLock()
+	defer ge.mu.RUnlock()
+	return ge.activeParentName
+}
+
+// SetActiveParentName records the lineage parent of the current save.
+func (ge *GameEngine) SetActiveParentName(name string) {
+	ge.mu.Lock()
+	defer ge.mu.Unlock()
+	ge.activeParentName = name
+}
+
+// StartNewNamedGame resets to a fresh game, makes `name` the active root save,
+// and writes the initial save file. It does NOT start the ticker — the caller
+// starts it. Returns the SaveGame error if any.
+func (ge *GameEngine) StartNewNamedGame(name string) error {
+	ge.Reset()
+	// Set names AFTER Reset so it can't clobber them (Reset leaves them alone, but
+	// the ordering keeps that guarantee local to this call).
+	ge.SetActiveSaveName(name)
+	ge.SetActiveParentName("") // root of a new lineage
+	return ge.SaveGame(name)
 }
 
 // Stop halts the game tick loop. Safe to call multiple times; subsequent

--- a/game/save.go
+++ b/game/save.go
@@ -883,6 +883,15 @@ func sanitizeSaveName(name string) (string, error) {
 	return name, nil
 }
 
+// ValidateSaveName is the exported entry point to the same validation the rename
+// and save paths use: it strips a trailing ".json", trims whitespace, and rejects
+// names that are empty, too long, contain a null byte / path separator / "..", or
+// begin with a dot. It returns the cleaned, filesystem-safe name. UI code (e.g. the
+// New Game name prompt) calls this so the rule lives in exactly one place.
+func ValidateSaveName(name string) (string, error) {
+	return sanitizeSaveName(name)
+}
+
 // DeleteSave removes a save file. The name is sanitized first so a crafted value
 // cannot escape the saves directory. Returns a clear error if the file is absent.
 func DeleteSave(filename string) error {

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -427,6 +427,51 @@ func TestParentNameRoundTrips(t *testing.T) {
 	}
 }
 
+func TestStartNewNamedGame(t *testing.T) {
+	name := "Test Realm"
+	t.Cleanup(func() { _ = os.Remove(savePath(name)) })
+
+	ge := NewGameEngine()
+	if err := ge.StartNewNamedGame(name); err != nil {
+		t.Fatalf("StartNewNamedGame(%q) failed: %v", name, err)
+	}
+
+	if got := ge.ActiveSaveName(); got != name {
+		t.Errorf("ActiveSaveName() = %q, want %q", got, name)
+	}
+	if got := ge.ActiveParentName(); got != "" {
+		t.Errorf("ActiveParentName() = %q, want \"\" (root)", got)
+	}
+	if !SaveExists(name) {
+		t.Fatalf("save %q not found after StartNewNamedGame", name)
+	}
+
+	// The written file must load back into a fresh engine as that named root save.
+	loaded := NewGameEngine()
+	if err := loaded.LoadGame(name); err != nil {
+		t.Fatalf("LoadGame(%q) failed: %v", name, err)
+	}
+	if got := loaded.ActiveSaveName(); got != name {
+		t.Errorf("after load, ActiveSaveName() = %q, want %q", got, name)
+	}
+	if got := loaded.ActiveParentName(); got != "" {
+		t.Errorf("after load, ActiveParentName() = %q, want \"\" (root)", got)
+	}
+}
+
+func TestActiveParentNameSetter(t *testing.T) {
+	// A fresh engine is a lineage root → empty parent.
+	ge := NewGameEngine()
+	if got := ge.ActiveParentName(); got != "" {
+		t.Errorf("fresh ActiveParentName() = %q, want \"\"", got)
+	}
+	// Setter/getter round-trip.
+	ge.SetActiveParentName("Ancestor Realm")
+	if got := ge.ActiveParentName(); got != "Ancestor Realm" {
+		t.Errorf("after SetActiveParentName, ActiveParentName() = %q, want %q", got, "Ancestor Realm")
+	}
+}
+
 func TestLegacySaveHasNoParentName(t *testing.T) {
 	// A legacy-style save written without parent_name must load as a root ("").
 	name := "test_lineage_legacy"

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -193,16 +193,16 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 
 | Command | Description |
 |---|---|
-| `save [name]` | Save the game (optional name; defaults to autosave) |
+| `save [name]` | Save the game (optional name; with no name, writes to your active save) |
 | `load [name]` | Load a saved game |
 | `saves` | List all save files |
-| `Esc` | Quick-save (autosave slot) |
+| `Esc` | Quick-save to your active save |
 | `dump` | Export logs to a file for debugging |
 | `help` | Open the Help panel — full command reference and list of available panels |
 
 Save files live in `./data/saves/*.json`, relative to the directory you launch the game from. The `save <name>` and `load <name>` commands above work with the same files as the **Load Game** browser below.
 
-A bare `save` (no name) re-saves to your most recent named or loaded save — it stays on the autosave slot only until you've explicitly `save <name>`d or loaded a named save this session. The periodic autosave always writes to the autosave slot regardless and never changes which slot a bare `save` targets.
+A bare `save` (no name) re-saves to your **active** save — the one you most recently named or loaded (a new game has you name it up front). The periodic autosave and `Esc` write to that same active save, continuously overwriting it, so your current game is always kept current on disk. See [Saving & Loading](saving-and-loading.md) for the full model.
 
 See [Saving & Loading](saving-and-loading.md) for the full save system.
 

--- a/site/docs/saving-and-loading.md
+++ b/site/docs/saving-and-loading.md
@@ -4,6 +4,12 @@ AgeForge keeps your civilization safe with named saves, a continuous autosave, a
 
 ---
 
+## Starting a new game
+
+When you choose **New Game**, you're prompted to name your civilization — pre-filled with a randomly generated name. Press **Enter** to accept it, type your own, or press **Tab** to roll a fresh suggestion. That name becomes your active save, and the game autosaves into it from there.
+
+---
+
 ## Where saves live
 
 Save files are written to `./data/saves/*.json`, relative to the directory you launch the game from. One file per save. The `save`/`load` commands and the **Load Game** browser all read and write the same files, so a save made one way shows up the other.
@@ -17,7 +23,7 @@ Save files are written to `./data/saves/*.json`, relative to the directory you l
 | `save [name]` | Save to a named slot. With no name, writes to the active save slot (see below) |
 | `load [name]` | Load a named save |
 | `saves` (or `save list`) | List all save files |
-| `Esc` | Quick-save to the `autosave` slot |
+| `Esc` | Quick-save to your current (active) save |
 
 ```
 save hero
@@ -35,13 +41,13 @@ The game remembers the last slot you explicitly `save`d to or `load`ed. A bare `
 - Until you've named a save or loaded one this session, a bare `save` defaults to the `autosave` slot.
 - Once you `save hero` or `load hero`, a bare `save` thereafter targets `hero`.
 
-The periodic autosave (and `Esc`) always writes to its own separate `autosave` slot, regardless of which slot a bare `save` targets. A background save will never clobber your named file.
+The periodic autosave and `Esc` quick-save both write to your **active** save, continuously overwriting it. Your current game *is* the autosave — there's no separate slot quietly shadowing it.
 
 ---
 
 ## Autosave
 
-The game autosaves periodically and whenever you press `Esc`, always to the `autosave` slot. Treat it as a safety net rather than your primary save — name the runs you care about so a routine autosave can't overwrite them.
+The game autosaves periodically and whenever you press `Esc`, writing to your **active** save — so your current game is always kept up to date on disk. To preserve a specific point you don't want overwritten, save it under a new name (or duplicate it with `c` in the Load Game browser).
 
 ---
 
@@ -84,4 +90,4 @@ Saves are signed. If a save file is edited outside the game, the integrity check
 
 - **Name your important saves.** A bare `save` targets your active slot, but giving milestones their own names (`save iron_age_start`) keeps them out of harm's way.
 - **Duplicate before risky moves.** Press `c` in the Load Game browser to clone a save before a prestige, catastrophe, or any decision you might want to undo.
-- **Autosave is your safety net, not your archive.** It's there if the game closes unexpectedly — but it gets overwritten constantly, so don't rely on it for runs you want to keep.
+- **Your active save is overwritten constantly.** Autosave keeps your current game up to date — but that means it's not a snapshot. To keep a run exactly as it is right now, duplicate it (`c`) or save it under a new name before risky moves.

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -239,7 +239,7 @@ func (d *Dashboard) build() {
 				d.cmdHistory = append(d.cmdHistory, cmd)
 			}
 			if strings.ToLower(cmd) == "quit" {
-				d.engine.SaveGame("autosave")
+				d.engine.SaveGame(d.engine.ActiveSaveName())
 				d.app.Stop()
 				return
 			}
@@ -345,7 +345,7 @@ func (d *Dashboard) build() {
 				d.overlayMgr.Hide()
 				return nil
 			}
-			d.engine.SaveGame("autosave")
+			d.engine.SaveGame(d.engine.ActiveSaveName())
 			d.engine.Stop()
 			d.pages.SwitchToPage("splash")
 			return nil

--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// newGameNamePage is the unique page name for the New Game name-entry modal.
+const newGameNamePage = "newgame_name"
+
+// showNewGameNameModal pops a centered, bordered prompt asking the player to name
+// their civilization. The input is pre-filled with a procedural suggestion that
+// Tab rerolls. Enter validates the name with the same rule the rename/save paths
+// use (game.ValidateSaveName) and, on success, removes the page and calls
+// onConfirm with the cleaned name. Esc cancels: it removes the page and restores
+// focus to the splash menu without resetting or starting a game.
+//
+// restoreFocus is the splash menu primitive to refocus on cancel.
+func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFocus tview.Primitive, onConfirm func(name string)) {
+	errTV := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter)
+
+	input := tview.NewInputField().
+		SetLabel("Name: ").
+		SetText(game.GenerateSaveName()).
+		SetFieldWidth(40)
+
+	hintTV := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("[#8b949e]Enter: begin  ·  Tab: reroll name  ·  Esc: cancel[-]")
+
+	// close removes the modal page and restores focus to the splash menu. Used on
+	// both cancel (Esc) and on a successful confirm (the page is gone before the
+	// game starts in either path).
+	closeAndRestore := func() {
+		pages.RemovePage(newGameNamePage)
+		if restoreFocus != nil {
+			app.SetFocus(restoreFocus)
+		}
+	}
+
+	submit := func() {
+		raw := strings.TrimSpace(input.GetText())
+		if raw == "" {
+			// Empty → fall back to a fresh suggestion rather than erroring out.
+			raw = game.GenerateSaveName()
+		}
+		name, err := game.ValidateSaveName(raw)
+		if err != nil {
+			errTV.SetText(fmt.Sprintf("[red]%v[-]", err))
+			app.SetFocus(input)
+			return
+		}
+		pages.RemovePage(newGameNamePage)
+		onConfirm(name)
+	}
+
+	reroll := func() {
+		input.SetText(game.GenerateSaveName())
+		errTV.SetText("")
+		app.SetFocus(input)
+	}
+
+	// Enter in the field submits.
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			submit()
+		}
+	})
+
+	inner := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(input, 1, 0, true).
+		AddItem(tview.NewBox(), 1, 0, false).
+		AddItem(errTV, 1, 0, false).
+		AddItem(tview.NewBox(), 1, 0, false).
+		AddItem(hintTV, 1, 0, false)
+	inner.SetBorder(true).
+		SetTitle(" Name Your Civilization ").
+		SetTitleColor(tcell.ColorGold).
+		SetBorderColor(tcell.ColorGold)
+
+	// Esc cancels; Tab rerolls a fresh suggestion. Enter is handled by the field's
+	// DoneFunc above so plain typing keys still reach the input.
+	modal := centeredModal(inner, 50, 9)
+	modal.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
+		switch ev.Key() {
+		case tcell.KeyEsc:
+			closeAndRestore()
+			return nil
+		case tcell.KeyTab, tcell.KeyBacktab:
+			reroll()
+			return nil
+		}
+		return ev
+	})
+
+	pages.AddPage(newGameNamePage, modal, true, true)
+	app.SetFocus(input)
+}

--- a/ui/newgame_modal_test.go
+++ b/ui/newgame_modal_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/rivo/tview"
+)
+
+// TestShowNewGameNameModalAddsPage is a light lifecycle check: the modal must add
+// its page to the supplied Pages under the expected name. The validation rule
+// itself is covered by game.TestSanitizeSaveName (the modal calls the same
+// game.ValidateSaveName wrapper), and the engine side is covered by
+// game.TestStartNewNamedGame — a full focus/draw-loop UI test would be brittle, so
+// we deliberately keep this to the add-page contract.
+func TestShowNewGameNameModalAddsPage(t *testing.T) {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+
+	if pages.HasPage(newGameNamePage) {
+		t.Fatalf("page %q present before the modal was shown", newGameNamePage)
+	}
+
+	showNewGameNameModal(app, pages, nil, func(string) {
+		t.Fatal("onConfirm should not fire when the modal merely opens")
+	})
+
+	if !pages.HasPage(newGameNamePage) {
+		t.Errorf("showNewGameNameModal did not add page %q", newGameNamePage)
+	}
+}

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -57,10 +57,14 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 		app.SetFocus(page)
 	})
 	mainList.AddItem("  ✦  New Game", "", 'n', func() {
-		nav(func() {
-			engine.Reset()
-			pages.SwitchToPage("dashboard")
-			go engine.Start()
+		// Prompt for a civilization name first; only start the game on confirm.
+		// Cancel returns to the splash with the canvas still animating.
+		showNewGameNameModal(app, pages, mainList, func(name string) {
+			nav(func() {
+				engine.StartNewNamedGame(name)
+				pages.SwitchToPage("dashboard")
+				go engine.Start()
+			})
 		})
 	})
 	mainList.AddItem("  ✗  Quit", "", 'q', func() {


### PR DESCRIPTION
## Phase 2a — the new save model becomes visible

- **New Game → a name prompt.** A "Name Your Civilization" modal, pre-filled with a generated name. **Tab** rerolls, type to override, **Enter** begins, **Esc** cancels. `StartNewNamedGame()` resets, makes that the active *root* save, and writes it.
- **Autosave overwrites your active save.** The periodic autosave and the `Esc`/exit quick-saves now write to your current save instead of a fixed `autosave` slot — your game *is* the autosave. (Reverses #55's separate-slot decision, per the new design.)
- Engine gains `ActiveParentName()`/`SetActiveParentName()` (root `""` for now — branching is 2b). Name validation reuses the canonical rule via `game.ValidateSaveName`.
- **Wiki synced** in this PR: Saving & Loading + commands.md now describe the overwrite-active model and the New Game naming.

### Tests
`StartNewNamedGame` (active name + empty parent + file written/loads back), parent-name setter round-trip, modal add-page lifecycle. `go build/vet/test` green.

### Worth a playtest
New Game → you should get the name modal (Tab to reroll). Play, then check `./data/saves/` — your named file should be updating, not a stray `autosave`.

### Next
- **2b** — bare `save` → Overwrite / Branch prompt.
- **3** — Load Game tree view.

Trello: https://trello.com/c/NwwPqS7O
