### PR TITLE
feat(save): bare save → Overwrite/Branch prompt + lineage branching (phase 2b)

### DIFF
--- a/game/save.go
+++ b/game/save.go
@@ -397,6 +397,24 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 	}
 }
 
+// BranchSave forks the current run into a NEW save named newName: its parent is
+// the current active save, and it becomes the active save (so autosave follows
+// the branch from here). Rejects an invalid or already-existing name. The old
+// (parent) save is left untouched on disk, frozen at the branch point.
+func (ge *GameEngine) BranchSave(newName string) error {
+	clean, err := ValidateSaveName(newName)
+	if err != nil {
+		return err
+	}
+	if SaveExists(clean) {
+		return fmt.Errorf("a save named %q already exists — pick another name", clean)
+	}
+	parent := ge.ActiveSaveName()
+	ge.SetActiveParentName(parent)
+	ge.SetActiveSaveName(clean)
+	return ge.SaveGame(clean)
+}
+
 // LoadGame reads a save file, verifies its integrity, and restores all engine
 // state under the write lock. File I/O is done outside the lock to avoid
 // blocking doTick for the duration of a slow disk read.

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -459,6 +459,67 @@ func TestStartNewNamedGame(t *testing.T) {
 	}
 }
 
+func TestBranchSave(t *testing.T) {
+	parent := "Branch Parent"
+	child := "Branch Child"
+	t.Cleanup(func() {
+		_ = os.Remove(savePath(parent))
+		_ = os.Remove(savePath(child))
+	})
+
+	ge := NewGameEngine()
+	if err := ge.StartNewNamedGame(parent); err != nil {
+		t.Fatalf("StartNewNamedGame(%q) failed: %v", parent, err)
+	}
+
+	// Capture the parent file's bytes so we can prove branching leaves it untouched.
+	parentBytesBefore, err := os.ReadFile(savePath(parent))
+	if err != nil {
+		t.Fatalf("read parent save: %v", err)
+	}
+
+	if err := ge.BranchSave(child); err != nil {
+		t.Fatalf("BranchSave(%q) failed: %v", child, err)
+	}
+
+	// The branch becomes the active slot with the parent recorded as its lineage.
+	if got := ge.ActiveSaveName(); got != child {
+		t.Errorf("ActiveSaveName() = %q, want %q", got, child)
+	}
+	if got := ge.ActiveParentName(); got != parent {
+		t.Errorf("ActiveParentName() = %q, want %q", got, parent)
+	}
+
+	// The child file exists and loads back with its parent recorded.
+	if !SaveExists(child) {
+		t.Fatalf("child save %q not found after BranchSave", child)
+	}
+	loaded := NewGameEngine()
+	if err := loaded.LoadGame(child); err != nil {
+		t.Fatalf("LoadGame(%q) failed: %v", child, err)
+	}
+	if got := loaded.ActiveParentName(); got != parent {
+		t.Errorf("after load, child ActiveParentName() = %q, want %q", got, parent)
+	}
+
+	// The parent save still exists, byte-identical (frozen at the branch point).
+	if !SaveExists(parent) {
+		t.Fatalf("parent save %q vanished after BranchSave", parent)
+	}
+	parentBytesAfter, err := os.ReadFile(savePath(parent))
+	if err != nil {
+		t.Fatalf("re-read parent save: %v", err)
+	}
+	if string(parentBytesBefore) != string(parentBytesAfter) {
+		t.Errorf("parent save bytes changed after BranchSave; want unchanged")
+	}
+
+	// Branching to the same name again is rejected (already exists).
+	if err := ge.BranchSave(child); err == nil {
+		t.Errorf("BranchSave(%q) twice = nil error, want already-exists error", child)
+	}
+}
+
 func TestActiveParentNameSetter(t *testing.T) {
 	// A fresh engine is a lineage root → empty parent.
 	ge := NewGameEngine()

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -193,7 +193,8 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 
 | Command | Description |
 |---|---|
-| `save [name]` | Save the game (optional name; with no name, writes to your active save) |
+| `save` | Open an **Overwrite / Branch** prompt for your current run |
+| `save <name>` | **Branch** a new save with that name off your current run (autosave then follows it) |
 | `load [name]` | Load a saved game |
 | `saves` | List all save files |
 | `Esc` | Quick-save to your active save |
@@ -202,7 +203,7 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 
 Save files live in `./data/saves/*.json`, relative to the directory you launch the game from. The `save <name>` and `load <name>` commands above work with the same files as the **Load Game** browser below.
 
-A bare `save` (no name) re-saves to your **active** save — the one you most recently named or loaded (a new game has you name it up front). The periodic autosave and `Esc` write to that same active save, continuously overwriting it, so your current game is always kept current on disk. See [Saving & Loading](saving-and-loading.md) for the full model.
+A bare `save` (no name) opens a prompt: **Overwrite** writes your current run to its **active** save right now, while **Branch new** forks a fresh save (suggested name, editable) whose parent is your current save and then moves autosave onto the new branch — leaving the old save frozen at the branch point. `save <name>` branches straight to that name. The active save is the one you most recently named or loaded (a new game has you name it up front); the periodic autosave and `Esc` continuously overwrite it, so your current game is always kept current on disk. See [Saving & Loading](saving-and-loading.md) for the full model.
 
 See [Saving & Loading](saving-and-loading.md) for the full save system.
 

--- a/site/docs/saving-and-loading.md
+++ b/site/docs/saving-and-loading.md
@@ -20,14 +20,15 @@ Save files are written to `./data/saves/*.json`, relative to the directory you l
 
 | Command | Description |
 |---|---|
-| `save [name]` | Save to a named slot. With no name, writes to the active save slot (see below) |
+| `save` | Opens an **Overwrite / Branch** prompt for your current run (see below) |
+| `save <name>` | **Branches** a new save with that name off your current run; autosave then follows it |
 | `load [name]` | Load a named save |
 | `saves` (or `save list`) | List all save files |
 | `Esc` | Quick-save to your current (active) save |
 
 ```
-save hero
-save
+save           # prompt: Overwrite this run, or Branch a new save?
+save hero      # branch a new save named "hero" off the current run
 load hero
 saves
 ```
@@ -36,12 +37,25 @@ saves
 
 ## Active save slot
 
-The game remembers the last slot you explicitly `save`d to or `load`ed. A bare `save` (no name) re-writes **that** slot — it is not a generic dump.
+The game remembers the last slot you explicitly saved to or `load`ed — your **active** save.
 
-- Until you've named a save or loaded one this session, a bare `save` defaults to the `autosave` slot.
-- Once you `save hero` or `load hero`, a bare `save` thereafter targets `hero`.
+- Until you've named a save or loaded one this session, the active slot defaults to `autosave`.
+- Once you branch to `hero` or `load hero`, the active slot is `hero` and autosave follows it.
 
 The periodic autosave and `Esc` quick-save both write to your **active** save, continuously overwriting it. Your current game *is* the autosave — there's no separate slot quietly shadowing it.
+
+---
+
+## Branching your save
+
+A bare `save` opens a prompt with two choices:
+
+- **Overwrite** — write your current run to the active slot now (the same thing autosave and `Esc` do, on demand).
+- **Branch new** — fork a brand-new save. You're given a generated name (editable; **Tab** rolls a fresh one, **Enter** confirms). The new save's *parent* is the save you branched from, and **autosave switches to follow the new branch** — so the old save is left frozen exactly at the branch point.
+
+`save <name>` skips the prompt and branches straight to that name.
+
+This is the way to preserve a moment without stopping play: branch before a prestige, a risky catastrophe, or any decision you might want to revisit. Your old save stays as it was; you keep playing on the new branch. Branched saves are ordinary files — they appear in the `saves` list and the Load Game browser alongside everything else. (The save names must be valid and unique; branching to a name that's already taken is rejected.)
 
 ---
 
@@ -88,6 +102,6 @@ Saves are signed. If a save file is edited outside the game, the integrity check
 
 ## Tips
 
-- **Name your important saves.** A bare `save` targets your active slot, but giving milestones their own names (`save iron_age_start`) keeps them out of harm's way.
-- **Duplicate before risky moves.** Press `c` in the Load Game browser to clone a save before a prestige, catastrophe, or any decision you might want to undo.
+- **Branch at milestones.** `save iron_age_start` forks a new save at that moment and moves autosave onto it, freezing the old run where it was — your snapshot can't be overwritten.
+- **Duplicate before risky moves.** Press `c` in the Load Game browser to clone a save before a prestige, catastrophe, or any decision you might want to undo. (Branching does much the same, but keeps you playing on the new copy rather than the old one.)
 - **Your active save is overwritten constantly.** Autosave keeps your current game up to date — but that means it's not a snapshot. To keep a run exactly as it is right now, duplicate it (`c`) or save it under a new name before risky moves.

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -251,6 +251,10 @@ func (d *Dashboard) build() {
 				}
 				return
 			}
+			if strings.ToLower(cmd) == "save" { // bare save — no name
+				d.showSaveChoiceModal()
+				return
+			}
 			result := HandleCommand(text, d.engine)
 			if result.OverlayName != "" {
 				state := d.engine.GetState()

--- a/ui/input.go
+++ b/ui/input.go
@@ -546,22 +546,23 @@ func cmdStatus(engine *game.GameEngine) CommandResult {
 }
 
 func cmdSave(args []string, engine *game.GameEngine) CommandResult {
-	// With a name: write that slot and make it the active one for future bare
-	// saves. Without: reuse the active slot (last named/loaded save, else autosave).
-	var name string
-	explicit := len(args) > 0
-	if explicit {
-		name = args[0]
-	} else {
-		name = engine.ActiveSaveName()
+	// With a name: branch a new save off the current run (BranchSave switches the
+	// active slot + sets the parent, so autosave follows the branch). Without a
+	// name: overwrite the active slot. The dashboard UI intercepts a bare `save`
+	// to pop the Overwrite/Branch modal, but this path stays sane for tests and
+	// other callers.
+	if len(args) > 0 {
+		name := args[0]
+		if err := engine.BranchSave(name); err != nil {
+			return CommandResult{Message: err.Error(), Type: "error"}
+		}
+		return CommandResult{Message: fmt.Sprintf("Branched a new save '%s' — autosave now follows it", name), Type: "info"}
 	}
-	if err := engine.SaveGame(name); err != nil {
+	active := engine.ActiveSaveName()
+	if err := engine.SaveGame(active); err != nil {
 		return CommandResult{Message: fmt.Sprintf("Save failed: %v", err), Type: "error"}
 	}
-	if explicit {
-		engine.SetActiveSaveName(name)
-	}
-	return CommandResult{Message: fmt.Sprintf("Game saved as '%s'", name), Type: "info"}
+	return CommandResult{Message: fmt.Sprintf("Saved to '%s'", active), Type: "info"}
 }
 
 func cmdLoad(args []string, engine *game.GameEngine) CommandResult {

--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -13,15 +13,24 @@ import (
 // newGameNamePage is the unique page name for the New Game name-entry modal.
 const newGameNamePage = "newgame_name"
 
-// showNewGameNameModal pops a centered, bordered prompt asking the player to name
-// their civilization. The input is pre-filled with a procedural suggestion that
-// Tab rerolls. Enter validates the name with the same rule the rename/save paths
-// use (game.ValidateSaveName) and, on success, removes the page and calls
-// onConfirm with the cleaned name. Esc cancels: it removes the page and restores
-// focus to the splash menu without resetting or starting a game.
+// showNewGameNameModal pops the New Game name prompt. It is a thin wrapper over
+// showSaveNameModal so the splash menu keeps its existing behavior unchanged.
 //
 // restoreFocus is the splash menu primitive to refocus on cancel.
 func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFocus tview.Primitive, onConfirm func(name string)) {
+	showSaveNameModal(app, pages, " Name Your Civilization ", newGameNamePage, restoreFocus, onConfirm)
+}
+
+// showSaveNameModal pops a centered, bordered name-entry prompt. The input is
+// pre-filled with a procedural suggestion (game.GenerateSaveName) that Tab
+// rerolls. Enter validates the name with the same rule the rename/save paths use
+// (game.ValidateSaveName) and, on success, removes the page and calls onConfirm
+// with the cleaned name. Esc cancels: it removes the page and restores focus to
+// focusReturn without invoking onConfirm.
+//
+// title customizes the heading; pageName must be distinct per caller so two
+// concurrent modals (e.g. New Game vs. Branch) can't collide on the page stack.
+func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageName string, focusReturn tview.Primitive, onConfirm func(name string)) {
 	errTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter)
@@ -34,15 +43,14 @@ func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFoc
 	hintTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
-		SetText("[#8b949e]Enter: begin  ·  Tab: reroll name  ·  Esc: cancel[-]")
+		SetText("[#8b949e]Enter: confirm  ·  Tab: reroll name  ·  Esc: cancel[-]")
 
-	// close removes the modal page and restores focus to the splash menu. Used on
-	// both cancel (Esc) and on a successful confirm (the page is gone before the
-	// game starts in either path).
+	// closeAndRestore removes the modal page and restores focus to focusReturn.
+	// Used on cancel (Esc).
 	closeAndRestore := func() {
-		pages.RemovePage(newGameNamePage)
-		if restoreFocus != nil {
-			app.SetFocus(restoreFocus)
+		pages.RemovePage(pageName)
+		if focusReturn != nil {
+			app.SetFocus(focusReturn)
 		}
 	}
 
@@ -58,7 +66,7 @@ func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFoc
 			app.SetFocus(input)
 			return
 		}
-		pages.RemovePage(newGameNamePage)
+		pages.RemovePage(pageName)
 		onConfirm(name)
 	}
 
@@ -82,7 +90,7 @@ func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFoc
 		AddItem(tview.NewBox(), 1, 0, false).
 		AddItem(hintTV, 1, 0, false)
 	inner.SetBorder(true).
-		SetTitle(" Name Your Civilization ").
+		SetTitle(title).
 		SetTitleColor(tcell.ColorGold).
 		SetBorderColor(tcell.ColorGold)
 
@@ -101,6 +109,6 @@ func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFoc
 		return ev
 	})
 
-	pages.AddPage(newGameNamePage, modal, true, true)
+	pages.AddPage(pageName, modal, true, true)
 	app.SetFocus(input)
 }

--- a/ui/save_cmd_test.go
+++ b/ui/save_cmd_test.go
@@ -1,0 +1,61 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// TestCmdSaveBranches verifies the explicit `save <name>` path forks a new save:
+// it branches off the active run, switches the active slot to the new name, and
+// records the old slot as the parent. A second branch to the same name is
+// rejected with an error message. The bare `save` (no args) path overwrites the
+// active slot without branching. Save-dir isolation/cleanup mirrors the
+// game-package save tests.
+func TestCmdSaveBranches(t *testing.T) {
+	parent := "Cmd Save Parent"
+	child := "Cmd Save Child"
+	t.Cleanup(func() {
+		_ = game.DeleteSave(parent)
+		_ = game.DeleteSave(child)
+	})
+
+	engine := game.NewGameEngine()
+	if err := engine.StartNewNamedGame(parent); err != nil {
+		t.Fatalf("StartNewNamedGame(%q) failed: %v", parent, err)
+	}
+
+	// save <name> → branch.
+	res := cmdSave([]string{child}, engine)
+	if res.Type == "error" {
+		t.Fatalf("cmdSave(%q) returned error: %s", child, res.Message)
+	}
+	if engine.ActiveSaveName() != child {
+		t.Errorf("after branch, ActiveSaveName() = %q, want %q", engine.ActiveSaveName(), child)
+	}
+	if engine.ActiveParentName() != parent {
+		t.Errorf("after branch, ActiveParentName() = %q, want %q", engine.ActiveParentName(), parent)
+	}
+	if !game.SaveExists(child) {
+		t.Errorf("branch save %q not written", child)
+	}
+
+	// save <existing-name> → error (already exists).
+	res = cmdSave([]string{child}, engine)
+	if res.Type != "error" {
+		t.Errorf("cmdSave to existing name = %q type, want error", res.Type)
+	}
+	if !strings.Contains(res.Message, "already exists") {
+		t.Errorf("cmdSave to existing name message = %q, want it to mention 'already exists'", res.Message)
+	}
+
+	// Bare save (no args) → overwrite the active slot (now the child), no branch.
+	res = cmdSave(nil, engine)
+	if res.Type == "error" {
+		t.Fatalf("bare cmdSave returned error: %s", res.Message)
+	}
+	if engine.ActiveSaveName() != child {
+		t.Errorf("bare save changed active slot to %q, want %q", engine.ActiveSaveName(), child)
+	}
+}

--- a/ui/save_modal.go
+++ b/ui/save_modal.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/rivo/tview"
+)
+
+// saveChoicePage is the unique page name for the Overwrite/Branch save prompt.
+const saveChoicePage = "save_choice"
+
+// branchNamePage is the page name for the Branch name-entry modal. It is
+// distinct from newGameNamePage so the two name modals can't collide.
+const branchNamePage = "branch_name"
+
+// showSaveChoiceModal pops the Overwrite-vs-Branch prompt a bare `save` triggers.
+// Overwrite writes the current run to its active slot. Branch forks a new save
+// (suggested name, editable) whose parent is the current save; autosave then
+// follows the new branch, leaving the old save frozen at the branch point.
+// Cancel dismisses without saving. Every exit path refocuses the input field.
+func (d *Dashboard) showSaveChoiceModal() {
+	active := d.engine.ActiveSaveName()
+
+	modal := tview.NewModal().
+		SetText(fmt.Sprintf("Save %q?", active)).
+		AddButtons([]string{"Overwrite", "Branch new", "Cancel"}).
+		SetDoneFunc(func(_ int, label string) {
+			d.pages.RemovePage(saveChoicePage)
+			switch label {
+			case "Overwrite":
+				name := d.engine.ActiveSaveName()
+				if err := d.engine.SaveGame(name); err != nil {
+					d.engine.AddLog("error", err.Error())
+				} else {
+					d.engine.AddLog("info", "[lime]Saved → "+name)
+				}
+				d.app.SetFocus(d.inputField)
+			case "Branch new":
+				showSaveNameModal(d.app, d.pages, " Branch a New Save ", branchNamePage, d.inputField, func(name string) {
+					// showSaveNameModal validates the name format; BranchSave guards
+					// against an existing name and logs an error if it's taken.
+					if err := d.engine.BranchSave(name); err != nil {
+						d.engine.AddLog("error", err.Error())
+					} else {
+						d.engine.AddLog("info", "[lime]Branched → "+name+" (autosave now follows it)")
+					}
+					d.app.SetFocus(d.inputField)
+				})
+			default: // Cancel (or Esc)
+				d.app.SetFocus(d.inputField)
+			}
+		})
+
+	d.pages.AddPage(saveChoicePage, modal, true, true)
+	d.app.SetFocus(modal)
+}


### PR DESCRIPTION
## Phase 2b — manual saving becomes Overwrite vs Branch

Bare `save` no longer silently overwrites — it asks:

- **Overwrite** → save now to your current run.
- **Branch new** → fork a new save (suggested generated name, editable, Tab to reroll) whose **parent is your current save**; the autosave then follows the new branch, leaving the old save frozen at the branch point.
- **Cancel** → dismiss.

`save <name>` branches directly to that name.

### Under the hood
- `engine.BranchSave(newName)` — validates, rejects an existing name, sets `ParentName = current active`, switches active, writes the child. This is the lineage edge phase 3's tree will render.
- The name-entry modal is generalized (`showSaveNameModal`) and shared by New Game and Branch. The bare-`save` intercept sits next to the dev-command intercept in the dashboard input handler.

### Tests
`TestBranchSave` (parent set, active switched, child carries `ParentName`, parent file untouched, dup name errors), `TestCmdSaveBranches` (`save <name>` branches; existing name errors; bare `save` overwrites). `go build/vet/test` green.

### Worth a playtest
Type `save` → you should get the Overwrite/Branch prompt. Branch one, keep playing, and confirm the autosave now updates the *new* file while the old one stays put.

### Next
**Phase 3** — the Load Game browser renders these parent→child links as a navigable lineage tree.

Trello: https://trello.com/c/NwwPqS7O
