### PR TITLE
fix(ui): make save-name modal opaque + fit the hint

### DIFF
--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -93,10 +93,15 @@ func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageNa
 		SetTitle(title).
 		SetTitleColor(tcell.ColorGold).
 		SetBorderColor(tcell.ColorGold)
+	// Paint the box opaque so the page beneath (the dashboard, for a Branch
+	// save) doesn't bleed through the modal's empty rows — matches the
+	// dev-unlock / rename modals. Without this, tview leaves unwritten cells
+	// transparent and the layer below shows through.
+	inner.SetBackgroundColor(tcell.ColorBlack)
 
 	// Esc cancels; Tab rerolls a fresh suggestion. Enter is handled by the field's
 	// DoneFunc above so plain typing keys still reach the input.
-	modal := centeredModal(inner, 50, 9)
+	modal := centeredModal(inner, 60, 9)
 	modal.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
 		switch ev.Key() {
 		case tcell.KeyEsc:


### PR DESCRIPTION
## Fix: save-name modal was transparent

From the screenshot — the **Branch a New Save** modal let dashboard content (worker panel: "…kers: 0/0 Knowledge", "…d Camp x0") bleed through its empty interior rows, and the hint clipped "cancel".

**Cause:** `showSaveNameModal`'s bordered box never set a background. tview only paints cells a primitive actually draws, so the empty/spacer rows stayed transparent and the page beneath (the dashboard) showed through. The working modals (dev-unlock, rename) all `SetBackgroundColor`.

**Fix:**
- `inner.SetBackgroundColor(tcell.ColorBlack)` → opaque box, nothing bleeds through.
- `centeredModal` width 50 → 60 so "…· Esc: cancel" fits instead of clipping.

Affects both the Branch modal (over the dashboard — where you saw it) and the New Game modal (over the splash — the dark canvas had masked it).

`go build/vet/test` green. Worth a quick look since it's a render fix I can't unit-test.

Trello: https://trello.com/c/zCTuGorf
