### PR TITLE
feat(save): render the Load Game lineage tree (phase 3)

### DIFF
--- a/site/docs/saving-and-loading.md
+++ b/site/docs/saving-and-loading.md
@@ -67,7 +67,13 @@ The game autosaves periodically and whenever you press `Esc`, writing to your **
 
 ## The Load Game browser
 
-From the main menu, choosing **Load Game** opens a save browser that lists every save in `./data/saves/`, most-recent first. Highlighting a save updates a **detail pane** showing everything you need to size up that save before loading it: its age and epoch, population, buildings, wonders, milestones, techs, soldiers, prestige, [morale](morale.md), a ⚠ warning if a catastrophe is pending, and the exact save time.
+From the main menu, choosing **Load Game** opens a save browser that lists every save in `./data/saves/`. Highlighting a save updates a **detail pane** showing everything you need to size up that save before loading it: its age and epoch, population, buildings, wonders, milestones, techs, soldiers, prestige, [morale](morale.md), a ⚠ warning if a catastrophe is pending, the exact save time, and — for branched saves — a **Branched from** line naming the save it forked off.
+
+**The lineage tree.** Saves aren't shown as a flat list — they're arranged as a **lineage tree**. When you [branch](saving-and-loading.md#branching-your-save) a new save off your current run, it appears **indented beneath its parent** with tree connectors (`├─`, `└─`), so you can see at a glance which saves descend from which. Top-level roots (saves you started fresh, plus any orphans) are ordered most-recent first, and each parent's children are likewise ordered most-recent first.
+
+A **● active** marker shows which save your game is currently autosaving into — the save the periodic autosave and `Esc` quick-save follow.
+
+If a save's parent has been **deleted or renamed**, the child can no longer point at it, so it becomes an **orphan** and is promoted to the top level of the tree (its detail pane marks the lost parent as *detached*). Renaming a save likewise detaches its own children, since they still reference the old name.
 
 **Keys inside the browser:**
 
@@ -89,6 +95,7 @@ Saves can carry a row tag in the list, explained on-screen in a bordered **Key**
 | Tag | Meaning |
 |---|---|
 | ★ auto | The automatic save slot |
+| ● active | The save your game is autosaving into (the active slot the autosave follows) |
 | ⚠ modified | The save file was edited outside the game (integrity check failed) |
 | ⚠ corrupt | The file could not be read. It is still listed but dimmed, and cannot be loaded |
 

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -97,7 +96,7 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 		AddItem(title, 1, 0, false).
 		AddItem(b.subtitle, 1, 0, false).
 		AddItem(b.list, 0, 1, true).     // weighted — takes remaining space
-		AddItem(legend, 5, 0, false).    // 3 content lines + border
+		AddItem(legend, 6, 0, false).    // 4 content lines + border
 		AddItem(b.detail, 10, 0, false). // fits 6 content lines + optional badge + border
 		AddItem(footer, 1, 0, false)
 
@@ -122,23 +121,28 @@ func (b *loadGameBrowser) refresh(wantIdx int) {
 		return
 	}
 
-	// Sort most-recent first by Timestamp.
-	sort.SliceStable(saves, func(i, j int) bool {
-		return saves[i].Timestamp.After(saves[j].Timestamp)
-	})
-	b.saves = saves
+	// Arrange the flat listing into a depth-first lineage forest. The rows carry
+	// their tree-connector prefixes; b.saves stays 1:1 with rendered rows in this
+	// same order so every handler still maps row i → b.saves[i].
+	rows := buildSaveTree(saves)
+	b.saves = make([]game.SaveInfo, len(rows))
+	for i, r := range rows {
+		b.saves[i] = r.Info
+	}
 
 	b.subtitle.SetText(fmt.Sprintf("[#8b949e]%s — %s[-]", savesDirLabel(), pluralSaves(len(saves))))
 
 	b.list.Clear()
-	if len(saves) == 0 {
+	if len(rows) == 0 {
 		// Empty state — the action keys become no-ops (handleKey guards on len).
 		b.detail.SetText("[#8b949e]No saved games found in " + savesDir() + ".\n\nStart a new game to create one.[-]")
 		return
 	}
 
-	for _, s := range saves {
-		b.list.AddItem(rowLabel(s), "", 0, nil)
+	// The active save is the one the autosave currently follows; mark its row.
+	activeName := b.engine.ActiveSaveName()
+	for _, r := range rows {
+		b.list.AddItem(rowLabel(r.Info, r.Prefix, r.Info.Name == activeName), "", 0, nil)
 	}
 
 	// Restore a sensible selection (clamp to range).
@@ -160,7 +164,21 @@ func (b *loadGameBrowser) updateDetail(index int) {
 	if index < 0 || index >= len(b.saves) {
 		return
 	}
-	b.detail.SetText(detailText(b.saves[index]))
+	b.detail.SetText(detailText(b.saves[index], b.parentPresent(b.saves[index])))
+}
+
+// parentPresent reports whether s names a lineage parent that is itself among
+// the loaded saves (so the detail pane can mark a missing parent "detached").
+func (b *loadGameBrowser) parentPresent(s game.SaveInfo) bool {
+	if s.ParentName == "" || s.ParentName == s.Name {
+		return false
+	}
+	for _, other := range b.saves {
+		if other.Name == s.ParentName {
+			return true
+		}
+	}
+	return false
 }
 
 // selected returns the currently selected SaveInfo and true, or a zero value and
@@ -216,12 +234,12 @@ func (b *loadGameBrowser) doLoad() {
 		return
 	}
 	if s.Corrupt {
-		b.detail.SetText(detailText(s) + "\n\n[red]Can't load a corrupt save.[-]")
+		b.detail.SetText(detailText(s, b.parentPresent(s)) + "\n\n[red]Can't load a corrupt save.[-]")
 		return
 	}
 	if err := b.engine.LoadGame(s.Name); err != nil {
 		b.engine.AddLog("error", fmt.Sprintf("Load failed: %v", err))
-		b.detail.SetText(detailText(s) + fmt.Sprintf("\n\n[red]Load failed: %v[-]", err))
+		b.detail.SetText(detailText(s, b.parentPresent(s)) + fmt.Sprintf("\n\n[red]Load failed: %v[-]", err))
 		return
 	}
 	b.engine.AddLog("success", "Game loaded!")
@@ -265,6 +283,11 @@ func (b *loadGameBrowser) doDelete() {
 // RenameSave (collision/invalid) surface inline in the dialog and let the player
 // retry. On success the dialog closes, the list refreshes, and the renamed item
 // stays selected.
+//
+// note: lineage is keyed by ParentName, so renaming a save detaches its children
+// — their stored ParentName still points at the old name, so they become orphans
+// (promoted to roots) in the tree. Acceptable for now; a future ticket can
+// re-parent children on rename.
 func (b *loadGameBrowser) doRename() {
 	s, ok := b.selected()
 	if !ok {
@@ -391,18 +414,26 @@ func (b *loadGameBrowser) selectByName(name string) {
 
 // ── Pure helpers (formatting) ───────────────────────────────────────────────
 
-// rowLabel renders one list row: name, age, relative time, and a trailing tag.
-// Corrupt rows are dimmed grey.
-func rowLabel(s game.SaveInfo) string {
+// rowLabel renders one list row: an optional tree-connector prefix, the name,
+// age, relative time, and trailing tags. Corrupt rows are dimmed grey. When
+// active is true (the save the autosave follows) a distinct aqua "● active" tag
+// is appended, separate from the gold ★ auto tag.
+func rowLabel(s game.SaveInfo, prefix string, active bool) string {
 	if s.Corrupt {
-		return fmt.Sprintf("[gray]%s   —   %s   ⚠ corrupt[-]", s.Name, relativeTime(s.Timestamp))
+		return fmt.Sprintf("[gray]%s%s   —   %s   ⚠ corrupt[-]", prefix, s.Name, relativeTime(s.Timestamp))
 	}
 	age := ageDisplay(s.Age)
 	tag := rowTag(s)
+	if active {
+		if tag != "" {
+			tag += " "
+		}
+		tag += "[aqua]● active[-]"
+	}
 	if tag != "" {
 		tag = "   " + tag
 	}
-	return fmt.Sprintf("%s   [#8b949e]%s   %s[-]%s", s.Name, age, relativeTime(s.Timestamp), tag)
+	return fmt.Sprintf("%s%s   [#8b949e]%s   %s[-]%s", prefix, s.Name, age, relativeTime(s.Timestamp), tag)
 }
 
 // rowTag returns the trailing status tag for a (non-corrupt) save row, or "".
@@ -432,6 +463,7 @@ func footerBar() string {
 func legendText() string {
 	return strings.Join([]string{
 		"[gold]★ auto[-]      automatic save slot (overwritten on autosave)",
+		"[aqua]● active[-]    the save your game is autosaving into",
 		"[red]⚠ modified[-]  save file edited outside the game",
 		"[red]⚠ corrupt[-]   file could not be read — cannot be loaded",
 	}, "\n")
@@ -457,7 +489,7 @@ const detailSep = " [gold]·[-] "
 // block (identity, population/structures, progress, prestige/morale, an optional
 // catastrophe warning, and save metadata); corrupt saves show only the
 // unloadable notice + file time.
-func detailText(s game.SaveInfo) string {
+func detailText(s game.SaveInfo, parentPresent bool) string {
 	if s.Corrupt {
 		return fmt.Sprintf(
 			"[red]⚠ Corrupt save — cannot be loaded[-]\n[#8b949e]File time: %s[-]",
@@ -514,6 +546,16 @@ func detailText(s game.SaveInfo) string {
 		"[#8b949e]Saved[-] %s [gold]·[-] [#8b949e]%s ticks[-]",
 		s.Timestamp.Format("Jan 2, 2006 3:04 PM"), commafy(s.Tick),
 	))
+
+	// Line 7 — lineage. Shown only for branched saves. A parent that is no longer
+	// present (deleted/renamed) is marked "(detached)" rather than implying a link.
+	if s.ParentName != "" && s.ParentName != s.Name {
+		if parentPresent {
+			lines = append(lines, fmt.Sprintf("[#8b949e]Branched from: %s[-]", s.ParentName))
+		} else {
+			lines = append(lines, fmt.Sprintf("[#8b949e]Branched from: %s (detached)[-]", s.ParentName))
+		}
+	}
 
 	out := strings.Join(lines, "\n")
 	if badges := detailBadges(s); badges != "" {

--- a/ui/load_game_test.go
+++ b/ui/load_game_test.go
@@ -95,15 +95,15 @@ func TestLegendTextCoversSymbolsWithMatchingColors(t *testing.T) {
 	if strings.Contains(legend, "elite") {
 		t.Errorf("legendText() leaks the elite easter egg\n%s", legend)
 	}
-	// Three symbols → three content lines (sizing assumes this for the height-5 box).
-	if lines := strings.Count(legend, "\n") + 1; lines != 3 {
-		t.Errorf("legendText() has %d lines, want 3", lines)
+	// Four symbols → four content lines (sizing assumes this for the height-6 box).
+	if lines := strings.Count(legend, "\n") + 1; lines != 4 {
+		t.Errorf("legendText() has %d lines, want 4", lines)
 	}
 }
 
 func TestDetailTextCorrupt(t *testing.T) {
 	s := game.SaveInfo{Name: "broken", Corrupt: true, Timestamp: time.Now()}
-	got := detailText(s)
+	got := detailText(s, false)
 	if want := "Corrupt save"; !contains(got, want) {
 		t.Errorf("detailText(corrupt) = %q, should mention %q", got, want)
 	}
@@ -129,7 +129,7 @@ func TestDetailTextPopulated(t *testing.T) {
 		MilestonesDone:     7,
 		MilestonesTotal:    33,
 	}
-	got := detailText(s)
+	got := detailText(s, false)
 
 	// Every stat label and the title must render.
 	for _, want := range []string{
@@ -155,7 +155,7 @@ func TestDetailTextOmitsEmptyTitleAndCatastrophe(t *testing.T) {
 		// No Title, no PendingCatastrophe, no MilestonesTotal.
 		MilestonesDone: 1,
 	}
-	got := detailText(s)
+	got := detailText(s, false)
 
 	// Empty title → no quoted segment leaking through.
 	if contains(got, "\"\"") {

--- a/ui/save_tree.go
+++ b/ui/save_tree.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"sort"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// treeRow is one rendered row of the save-lineage forest: the save it represents
+// plus the box-drawing connector prefix that places it under its parent.
+type treeRow struct {
+	Info   game.SaveInfo
+	Prefix string // tree connector prefix, e.g. "", "├─ ", "│  └─ "
+}
+
+// buildSaveTree orders saves into a depth-first lineage forest. Roots are saves
+// with no ParentName, or whose ParentName is not among the saves (orphans), or
+// that name themselves as parent (self-loop). Roots are ordered most-recent-first;
+// each node's children likewise. Returns rows in render order with a box-drawing
+// connector prefix per row.
+//
+// Connector scheme (standard): a node at depth d prefixes one segment per
+// ancestor — "│  " when that ancestor still has a later sibling below it, else
+// "   " — then its own segment: "├─ " when it has a later sibling at its level,
+// else "└─ ". Depth-0 roots carry no connector (empty prefix).
+//
+// Cycles are broken with a visited set: a save is emitted at most once, and a
+// child whose recursion would revisit an ancestor is simply not recursed into.
+func buildSaveTree(saves []game.SaveInfo) []treeRow {
+	// Index by name and gather children per parent. byName lets us tell a real
+	// parent from an orphan's dangling ParentName.
+	byName := make(map[string]game.SaveInfo, len(saves))
+	for _, s := range saves {
+		byName[s.Name] = s
+	}
+
+	children := make(map[string][]game.SaveInfo)
+	var roots []game.SaveInfo
+	for _, s := range saves {
+		p := s.ParentName
+		// Root when: no parent, parent missing among saves (orphan), or self-parent.
+		if p == "" || p == s.Name {
+			roots = append(roots, s)
+			continue
+		}
+		if _, ok := byName[p]; !ok {
+			roots = append(roots, s) // orphan — parent not present
+			continue
+		}
+		children[p] = append(children[p], s)
+	}
+
+	recent := func(list []game.SaveInfo) {
+		sort.SliceStable(list, func(i, j int) bool {
+			return list[i].Timestamp.After(list[j].Timestamp)
+		})
+	}
+	recent(roots)
+	for k := range children {
+		recent(children[k])
+	}
+
+	var rows []treeRow
+	visited := make(map[string]bool)
+
+	// ancestorMore holds one flag per *non-root* ancestor: whether that ancestor
+	// still has a later sibling, deciding its column draws "│  " (pillar) or "   "
+	// (blank). Roots contribute no column, so their direct children start with an
+	// empty ancestorMore and render a bare "├─ "/"└─ " with no leading pillar.
+	var walk func(node game.SaveInfo, ancestorMore []bool, isRoot, isLast bool)
+	walk = func(node game.SaveInfo, ancestorMore []bool, isRoot, isLast bool) {
+		if visited[node.Name] {
+			return // cycle break — never emit or recurse a node twice
+		}
+		visited[node.Name] = true
+
+		prefix := ""
+		if !isRoot {
+			for _, more := range ancestorMore {
+				if more {
+					prefix += "│  "
+				} else {
+					prefix += "   "
+				}
+			}
+			if isLast {
+				prefix += "└─ "
+			} else {
+				prefix += "├─ "
+			}
+		}
+		rows = append(rows, treeRow{Info: node, Prefix: prefix})
+
+		// The column this node passes to its descendants: roots add nothing; a
+		// non-root leaves a pillar iff it still has a later sibling (!isLast).
+		childAncestorMore := ancestorMore
+		if !isRoot {
+			childAncestorMore = append(append([]bool{}, ancestorMore...), !isLast)
+		}
+		kids := children[node.Name]
+		for i, c := range kids {
+			walk(c, childAncestorMore, false, i == len(kids)-1)
+		}
+	}
+
+	for i, r := range roots {
+		walk(r, nil, true, i == len(roots)-1)
+	}
+
+	// Stranded saves: a pure cycle (A↔B with no external root) leaves nodes that
+	// no root reaches. Promote any still-unvisited save to a root, in input order,
+	// so every save is rendered exactly once instead of vanishing.
+	for _, s := range saves {
+		if !visited[s.Name] {
+			walk(s, nil, true, true)
+		}
+	}
+	return rows
+}

--- a/ui/save_tree_test.go
+++ b/ui/save_tree_test.go
@@ -1,0 +1,161 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// at returns a SaveInfo with a Timestamp offset minutes into the past, so
+// "most-recent-first" ordering is deterministic: a larger min == older.
+func at(name, parent string, min int) game.SaveInfo {
+	return game.SaveInfo{
+		Name:       name,
+		ParentName: parent,
+		Timestamp:  time.Now().Add(-time.Duration(min) * time.Minute),
+	}
+}
+
+// rowByName returns the treeRow whose Info.Name matches, and a found flag.
+func rowByName(rows []treeRow, name string) (treeRow, bool) {
+	for _, r := range rows {
+		if r.Info.Name == name {
+			return r, true
+		}
+	}
+	return treeRow{}, false
+}
+
+// names extracts the render-order name slice for order assertions.
+func names(rows []treeRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Info.Name
+	}
+	return out
+}
+
+func TestBuildSaveTreeForestAndConnectors(t *testing.T) {
+	// Forest:
+	//   root_a (newest)
+	//     ├─ child_a1 (newer child)
+	//     │  └─ grandchild      ← 3rd level
+	//     └─ child_a2 (older child, last sibling)
+	//   root_b (older independent root)
+	//   orphan      (parent "ghost" not present → promoted to root)
+	//   selfloop    (parent == own name → root, no loop)
+	saves := []game.SaveInfo{
+		at("root_a", "", 1),
+		at("child_a1", "root_a", 2),
+		at("grandchild", "child_a1", 3),
+		at("child_a2", "root_a", 4),
+		at("root_b", "", 10),
+		at("orphan", "ghost", 5),
+		at("selfloop", "selfloop", 6),
+	}
+
+	rows := buildSaveTree(saves)
+
+	if len(rows) != len(saves) {
+		t.Fatalf("buildSaveTree returned %d rows, want %d", len(rows), len(saves))
+	}
+
+	// DFS pre-order, roots most-recent-first. root_a (1m) is newest root; its
+	// children newest-first (child_a1 2m before child_a2 4m), grandchild nested
+	// under child_a1. Then root_b, orphan, selfloop by recency (root_b 10m is
+	// oldest so it sorts after orphan 5m and selfloop 6m among the roots).
+	wantOrder := []string{
+		"root_a",
+		"child_a1",
+		"grandchild",
+		"child_a2",
+		"orphan",   // 5m
+		"selfloop", // 6m
+		"root_b",   // 10m
+	}
+	got := names(rows)
+	if len(got) != len(wantOrder) {
+		t.Fatalf("render order length %d, want %d (%v)", len(got), len(wantOrder), got)
+	}
+	for i := range wantOrder {
+		if got[i] != wantOrder[i] {
+			t.Errorf("render order[%d] = %q, want %q\nfull: %v", i, got[i], wantOrder[i], got)
+		}
+	}
+
+	// Roots carry no connector prefix.
+	for _, name := range []string{"root_a", "root_b", "orphan", "selfloop"} {
+		r, _ := rowByName(rows, name)
+		if r.Prefix != "" {
+			t.Errorf("root %q prefix = %q, want \"\" (no connector)", name, r.Prefix)
+		}
+	}
+
+	// child_a1 is a non-last sibling → "├─ "; child_a2 is the last → "└─ ".
+	if r, _ := rowByName(rows, "child_a1"); r.Prefix != "├─ " {
+		t.Errorf("child_a1 prefix = %q, want %q", r.Prefix, "├─ ")
+	}
+	if r, _ := rowByName(rows, "child_a2"); r.Prefix != "└─ " {
+		t.Errorf("child_a2 prefix = %q, want %q", r.Prefix, "└─ ")
+	}
+
+	// grandchild sits under child_a1, which still has a later sibling (child_a2),
+	// so the pillar persists: "│  " + its own last-child segment "└─ ".
+	if r, _ := rowByName(rows, "grandchild"); r.Prefix != "│  └─ " {
+		t.Errorf("grandchild prefix = %q, want %q", r.Prefix, "│  └─ ")
+	}
+}
+
+func TestBuildSaveTreeOrphanAndSelfParentAreRoots(t *testing.T) {
+	saves := []game.SaveInfo{
+		at("orphan", "does_not_exist", 1),
+		at("me", "me", 2),
+	}
+	rows := buildSaveTree(saves)
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows, got %d (%v)", len(rows), names(rows))
+	}
+	for _, name := range []string{"orphan", "me"} {
+		r, ok := rowByName(rows, name)
+		if !ok {
+			t.Fatalf("%q missing from tree", name)
+		}
+		if r.Prefix != "" {
+			t.Errorf("%q should be a top-level root (empty prefix), got %q", name, r.Prefix)
+		}
+	}
+}
+
+func TestBuildSaveTreeCycleTerminates(t *testing.T) {
+	// A.parent = B, B.parent = A — a 2-node cycle. Neither has an external root,
+	// so both are mutual children. buildSaveTree must terminate and emit each
+	// exactly once (no duplicates, no infinite recursion).
+	saves := []game.SaveInfo{
+		at("A", "B", 1),
+		at("B", "A", 2),
+	}
+
+	done := make(chan []treeRow, 1)
+	go func() { done <- buildSaveTree(saves) }()
+
+	var rows []treeRow
+	select {
+	case rows = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("buildSaveTree did not terminate on a 2-node cycle")
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("cycle: want 2 rows total, got %d (%v)", len(rows), names(rows))
+	}
+	seen := map[string]int{}
+	for _, r := range rows {
+		seen[r.Info.Name]++
+	}
+	for _, name := range []string{"A", "B"} {
+		if seen[name] != 1 {
+			t.Errorf("cycle: %q appears %d times, want exactly 1", name, seen[name])
+		}
+	}
+}


### PR DESCRIPTION
## Phase 3 — the lineage tree (final phase)

The Load Game browser now renders saves as a depth-first **lineage forest** instead of a flat list, using the `ParentName` edges your branches have been writing.

```
Sunspire Reach          Primitive Age   2h ago
├─ Ironhold Compact     Stone Age       1h ago
│  └─ The Potato Kingdom Bronze Age     just now   ● active
└─ Verdant Reach        Stone Age       30m ago
Republic of Naps        Primitive Age   1d ago
```

- **`buildSaveTree()`** (pure, fully tested): roots = no/missing/self parent; roots and each child group sorted most-recent-first; DFS pre-order with box-drawing connectors. Cycle-safe (visited set + stranded-saves pass → every save renders exactly once).
- Rows stay 1:1 with `b.saves`, so **load / delete / rename / duplicate / Esc all keep working** on the selected row.
- The **active save** (the one the autosave follows) gets a distinct aqua `● active` tag; the detail pane shows `Branched from: <parent>` (or `(detached)` if the parent's gone).
- Orphans (parent deleted/renamed) sit at the top level. Legend + wiki updated.

### Tests
`TestBuildSaveTreeForestAndConnectors` (3-level forest + second root + orphan + self-parent; checks DFS order and `├─`/`└─`/`│  └─` prefixes), `...OrphanAndSelfParentAreRoots`, `...CycleTerminates` (A↔B terminates, each once). `go build/vet/test` green.

### Known limitation (noted, not fixed)
Lineage is keyed by `ParentName`, so renaming a save detaches its children to roots (their stored parent still points at the old name). Future ticket can re-parent on rename.

### This completes the save-lineage feature
Phases 1–3 + the modal fix: generated names, autosave-overwrites-active, Overwrite/Branch prompt, and now the tree view.

Trello: https://trello.com/c/NwwPqS7O
