### PR TITLE
fix(save): re-parent child saves on rename (keep lineage intact)

### DIFF
--- a/game/save.go
+++ b/game/save.go
@@ -955,7 +955,69 @@ func RenameSave(oldName, newName string) error {
 	if err := os.Rename(srcPath, dstPath); err != nil {
 		return fmt.Errorf("failed to rename save: %w", err)
 	}
+
+	// Re-parent any children so the lineage survives the rename. Best-effort:
+	// a child that fails to rewrite simply stays detached (the prior behavior),
+	// so we don't fail the rename — the file move already succeeded. The listing
+	// runs AFTER the rename, so the renamed save now shows up as dst; skip it.
+	if details, err := ListSaveDetails(); err == nil {
+		for _, info := range details {
+			if info.Corrupt || info.Name == dst {
+				continue
+			}
+			if info.ParentName == src {
+				_ = reparentSaveFile(info.Name, dst)
+			}
+		}
+	}
 	return nil
+}
+
+// reparentSaveFile rewrites the ParentName of an existing save to newParent and
+// re-signs it. The signature covers ParentName, so it must be recomputed or the
+// save would load flagged as modified. A save that is currently MODIFIED
+// (signature invalid) is left untouched — we must not silently launder a
+// tampered save's badge. A valid elite proof is preserved by recomputing it
+// from the new signature. Best-effort: returns an error only on I/O/parse
+// failure the caller may choose to ignore.
+func reparentSaveFile(name, newParent string) error {
+	path := savePath(name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var gs GameSave
+	if err := json.Unmarshal(data, &gs); err != nil {
+		return err // corrupt → skip upstream
+	}
+	sigValid, eliteValid := verifySave(&gs)
+	if !sigValid {
+		return nil // modified save — leave it (and its badge) alone
+	}
+	if gs.ParentName == newParent {
+		return nil // nothing to do
+	}
+	gs.ParentName = newParent
+	sig := signSave(gs, saveHMACKey)
+	gs.Signature = sig
+	if eliteValid {
+		mac := hmac.New(sha256.New, []byte(forgeMasterKey))
+		mac.Write([]byte(sig))
+		gs.Proof = hex.EncodeToString(mac.Sum(nil))
+	} else {
+		gs.Proof = ""
+	}
+	out, err := json.MarshalIndent(gs, "", "  ")
+	if err != nil {
+		return err
+	}
+	// Atomic write into the file's own directory (matches SaveGame's pattern and
+	// keeps a legacy-dir save in its dir).
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 // DuplicateSave copies a save to a new name and returns the new base name. The

--- a/game/save_management_test.go
+++ b/game/save_management_test.go
@@ -555,6 +555,105 @@ func TestLegacySaveHasNoParentName(t *testing.T) {
 	}
 }
 
+// writeSignedSaveWithParent creates a real, signed, loadable save under name with
+// the given ParentName, via the engine's SaveGame path (so verifySave passes), and
+// registers cleanup. Same-package access lets us set the unexported parent field
+// directly, matching TestParentNameRoundTrips.
+func writeSignedSaveWithParent(t *testing.T, name, parent string) {
+	t.Helper()
+	ge := NewGameEngine()
+	ge.activeParentName = parent
+	if err := ge.SaveGame(name); err != nil {
+		t.Fatalf("SaveGame(%q) failed: %v", name, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(savePath(name)) })
+}
+
+// readSaveFromDisk reads and JSON-parses a save by name for assertions.
+func readSaveFromDisk(t *testing.T, name string) GameSave {
+	t.Helper()
+	data, err := os.ReadFile(savePath(name))
+	if err != nil {
+		t.Fatalf("read save %q: %v", name, err)
+	}
+	var gs GameSave
+	if err := json.Unmarshal(data, &gs); err != nil {
+		t.Fatalf("unmarshal save %q: %v", name, err)
+	}
+	return gs
+}
+
+func TestRenameSaveReparentsChildren(t *testing.T) {
+	writeSignedSaveWithParent(t, "Parent", "")          // root
+	writeSignedSaveWithParent(t, "Child", "Parent")     // child of Parent
+	writeSignedSaveWithParent(t, "Grandchild", "Child") // child of Child
+	t.Cleanup(func() { _ = os.Remove(savePath("NewParent")) })
+
+	if err := RenameSave("Parent", "NewParent"); err != nil {
+		t.Fatalf("RenameSave(Parent, NewParent) failed: %v", err)
+	}
+
+	// File move happened.
+	if SaveExists("Parent") {
+		t.Errorf("old save \"Parent\" still exists after rename")
+	}
+	if !SaveExists("NewParent") {
+		t.Fatalf("renamed save \"NewParent\" missing")
+	}
+
+	// Child re-parented to the new name...
+	child := readSaveFromDisk(t, "Child")
+	if child.ParentName != "NewParent" {
+		t.Errorf("Child.ParentName = %q, want \"NewParent\"", child.ParentName)
+	}
+	// ...and still verifies (re-sign worked → NOT flagged modified).
+	if sigValid, _ := verifySave(&child); !sigValid {
+		t.Errorf("Child failed signature verification after reparent — re-sign broken")
+	}
+
+	// Grandchild's parent ("Child") is untouched — only direct children move.
+	grand := readSaveFromDisk(t, "Grandchild")
+	if grand.ParentName != "Child" {
+		t.Errorf("Grandchild.ParentName = %q, want \"Child\" (unaffected)", grand.ParentName)
+	}
+}
+
+func TestRenameSaveDoesNotLaunderModifiedChild(t *testing.T) {
+	writeSignedSaveWithParent(t, "Parent", "")      // root
+	writeSignedSaveWithParent(t, "Child", "Parent") // child of Parent
+	t.Cleanup(func() { _ = os.Remove(savePath("NewParent")) })
+
+	// Tamper the child: bump a signed field but keep the stored signature, so the
+	// file still parses as JSON yet fails verifySave (modified).
+	child := readSaveFromDisk(t, "Child")
+	child.Tick += 1000 // mutate a payload field WITHOUT re-signing
+	tampered, err := json.Marshal(child)
+	if err != nil {
+		t.Fatalf("marshal tampered child: %v", err)
+	}
+	if err := os.WriteFile(savePath("Child"), tampered, 0644); err != nil {
+		t.Fatalf("write tampered child: %v", err)
+	}
+	// Sanity: the tampered child must already read as modified.
+	if sigValid, _ := verifySave(&child); sigValid {
+		t.Fatalf("test setup failed — tampered child still verifies")
+	}
+
+	if err := RenameSave("Parent", "NewParent"); err != nil {
+		t.Fatalf("RenameSave(Parent, NewParent) failed: %v", err)
+	}
+
+	after := readSaveFromDisk(t, "Child")
+	// ParentName left untouched — we don't rewrite a modified save.
+	if after.ParentName != "Parent" {
+		t.Errorf("modified Child.ParentName = %q, want unchanged \"Parent\"", after.ParentName)
+	}
+	// Still detected as modified — no laundering of the badge.
+	if sigValid, _ := verifySave(&after); sigValid {
+		t.Errorf("modified Child now verifies after rename — badge was laundered")
+	}
+}
+
 func TestListSaveDetailsFlagsCorrupt(t *testing.T) {
 	// Ensure the dir exists, then drop a non-JSON .json file into it.
 	good := "test_corrupt_neighbor"

--- a/site/docs/saving-and-loading.md
+++ b/site/docs/saving-and-loading.md
@@ -73,7 +73,7 @@ From the main menu, choosing **Load Game** opens a save browser that lists every
 
 A **● active** marker shows which save your game is currently autosaving into — the save the periodic autosave and `Esc` quick-save follow.
 
-If a save's parent has been **deleted or renamed**, the child can no longer point at it, so it becomes an **orphan** and is promoted to the top level of the tree (its detail pane marks the lost parent as *detached*). Renaming a save likewise detaches its own children, since they still reference the old name.
+If a save's parent has been **deleted**, the child can no longer point at it, so it becomes an **orphan** and is promoted to the top level of the tree (its detail pane marks the lost parent as *detached*). **Renaming** a save, by contrast, **keeps its children attached** — they're automatically re-parented to the new name (and re-signed, so they don't load flagged as modified), so the lineage follows the rename intact. Children that are themselves flagged as *modified* are left untouched, so renaming never launders a tampered save's badge.
 
 **Keys inside the browser:**
 

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -284,10 +284,10 @@ func (b *loadGameBrowser) doDelete() {
 // retry. On success the dialog closes, the list refreshes, and the renamed item
 // stays selected.
 //
-// note: lineage is keyed by ParentName, so renaming a save detaches its children
-// — their stored ParentName still points at the old name, so they become orphans
-// (promoted to roots) in the tree. Acceptable for now; a future ticket can
-// re-parent children on rename.
+// note: lineage is keyed by ParentName. RenameSave re-parents the children to the
+// new name (and re-signs them), so the lineage follows the rename instead of
+// detaching. We mirror that into the engine's in-memory active pointers below so
+// the running session's next autosave doesn't re-orphan anything.
 func (b *loadGameBrowser) doRename() {
 	s, ok := b.selected()
 	if !ok {
@@ -321,6 +321,15 @@ func (b *loadGameBrowser) doRename() {
 			errTV.SetText(fmt.Sprintf("[red]%v[-]", err))
 			b.app.SetFocus(input)
 			return
+		}
+		// Keep the running session's lineage pointers consistent: if the renamed
+		// save IS the active slot, point autosave at the new name; if it was this
+		// run's parent, follow it so the next autosave doesn't re-orphan us.
+		if b.engine.ActiveSaveName() == s.Name {
+			b.engine.SetActiveSaveName(newName)
+		}
+		if b.engine.ActiveParentName() == s.Name {
+			b.engine.SetActiveParentName(newName)
 		}
 		b.pages.RemovePage(page)
 		b.app.SetFocus(b.list)


### PR DESCRIPTION
## Fix: rename now keeps the lineage intact

Closes the phase-3 limitation. Renaming a save used to orphan its children (their stored `ParentName` still pointed at the old name). Now `RenameSave` walks every save whose `ParentName` matches the old name and rewrites it to the new one.

**The careful bit:** the HMAC signature covers `ParentName`, so each reparented child is **re-signed** (and a valid elite proof recomputed from the new sig) — otherwise the child would load falsely flagged `⚠ modified`. A child that's *already* modified (invalid signature) is **left untouched**, so a rename can never silently launder a tampered save's cheater badge.

The Load Game rename handler also updates the engine's in-memory active + parent pointers when you rename the current run, so the next autosave doesn't re-orphan anything.

### Tests
- `TestRenameSaveReparentsChildren` — Parent→Child→Grandchild; rename Parent, assert Child follows to the new name AND still verifies (re-sign worked), Grandchild unaffected.
- `TestRenameSaveDoesNotLaunderModifiedChild` — a tampered child keeps its old parent and stays flagged modified.

`go build/vet/test` green. Wiki updated (rename keeps children; delete still orphans).

Trello: https://trello.com/c/VJNJg9pg
