### PR TITLE
fix(save): bare load opens the browser; size name modal to content

### DIFF
--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -195,7 +195,8 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 |---|---|
 | `save` | Open an **Overwrite / Branch** prompt for your current run |
 | `save <name>` | **Branch** a new save with that name off your current run (autosave then follows it) |
-| `load [name]` | Load a saved game |
+| `load` | Open the **Load Game** browser (your save tree) to pick which save/branch to load |
+| `load <name>` | Load that save directly |
 | `saves` | List all save files |
 | `Esc` | Quick-save to your active save |
 | `dump` | Export logs to a file for debugging |
@@ -204,6 +205,8 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 Save files live in `./data/saves/*.json`, relative to the directory you launch the game from. The `save <name>` and `load <name>` commands above work with the same files as the **Load Game** browser below.
 
 A bare `save` (no name) opens a prompt: **Overwrite** writes your current run to its **active** save right now, while **Branch new** forks a fresh save (suggested name, editable) whose parent is your current save and then moves autosave onto the new branch — leaving the old save frozen at the branch point. `save <name>` branches straight to that name. The active save is the one you most recently named or loaded (a new game has you name it up front); the periodic autosave and `Esc` continuously overwrite it, so your current game is always kept current on disk. See [Saving & Loading](saving-and-loading.md) for the full model.
+
+A bare `load` (no name) opens the **Load Game** browser so you can pick which save/branch to load from your save tree — it never assumes a slot. You can open it mid-game; `Esc` returns you to your current run without loading anything. `load <name>` skips the browser and loads that save directly.
 
 See [Saving & Loading](saving-and-loading.md) for the full save system.
 

--- a/site/docs/saving-and-loading.md
+++ b/site/docs/saving-and-loading.md
@@ -22,16 +22,20 @@ Save files are written to `./data/saves/*.json`, relative to the directory you l
 |---|---|
 | `save` | Opens an **Overwrite / Branch** prompt for your current run (see below) |
 | `save <name>` | **Branches** a new save with that name off your current run; autosave then follows it |
-| `load [name]` | Load a named save |
+| `load` | Opens the **Load Game** browser (your lineage tree) to pick which save/branch to load |
+| `load <name>` | Loads that named save directly |
 | `saves` (or `save list`) | List all save files |
 | `Esc` | Quick-save to your current (active) save |
 
 ```
 save           # prompt: Overwrite this run, or Branch a new save?
 save hero      # branch a new save named "hero" off the current run
-load hero
+load           # open the Load Game browser to pick a save/branch
+load hero      # load the save named "hero" directly
 saves
 ```
+
+A bare `load` (no name) **opens the Load Game browser** — the lineage tree of every save — so you choose which save/branch to load instead of having a slot picked for you. You can open it mid-game; pressing `Esc` in the browser returns you to your current run without loading anything. `load <name>` skips the browser and loads that save directly.
 
 ---
 
@@ -67,7 +71,7 @@ The game autosaves periodically and whenever you press `Esc`, writing to your **
 
 ## The Load Game browser
 
-From the main menu, choosing **Load Game** opens a save browser that lists every save in `./data/saves/`. Highlighting a save updates a **detail pane** showing everything you need to size up that save before loading it: its age and epoch, population, buildings, wonders, milestones, techs, soldiers, prestige, [morale](morale.md), a ⚠ warning if a catastrophe is pending, the exact save time, and — for branched saves — a **Branched from** line naming the save it forked off.
+Choosing **Load Game** from the main menu — or typing a bare `load` mid-game — opens a save browser that lists every save in `./data/saves/`. Highlighting a save updates a **detail pane** showing everything you need to size up that save before loading it: its age and epoch, population, buildings, wonders, milestones, techs, soldiers, prestige, [morale](morale.md), a ⚠ warning if a catastrophe is pending, the exact save time, and — for branched saves — a **Branched from** line naming the save it forked off. Opened mid-game, `Esc` returns you to your current run without loading anything.
 
 **The lineage tree.** Saves aren't shown as a flat list — they're arranged as a **lineage tree**. When you [branch](saving-and-loading.md#branching-your-save) a new save off your current run, it appears **indented beneath its parent** with tree connectors (`├─`, `└─`), so you can see at a glance which saves descend from which. Top-level roots (saves you started fresh, plus any orphans) are ordered most-recent first, and each parent's children are likewise ordered most-recent first.
 
@@ -84,7 +88,7 @@ If a save's parent has been **deleted or renamed**, the child can no longer poin
 | `d` | Delete the highlighted save (asks you to confirm first) |
 | `r` | Rename the highlighted save |
 | `c` | Duplicate the highlighted save |
-| `Esc` | Return to the main menu |
+| `Esc` | Return to where you opened it from — the main menu, or your current run if opened mid-game |
 
 ---
 

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -255,6 +255,12 @@ func (d *Dashboard) build() {
 				d.showSaveChoiceModal()
 				return
 			}
+			if strings.ToLower(cmd) == "load" { // bare load — open the browser instead of assuming a slot
+				page := CreateLoadGamePage(d.app, d.pages, d.engine, "dashboard", false)
+				d.pages.AddPage(loadGamePage, page, true, true)
+				d.app.SetFocus(page)
+				return
+			}
 			result := HandleCommand(text, d.engine)
 			if result.OverlayName != "" {
 				state := d.engine.GetState()

--- a/ui/input.go
+++ b/ui/input.go
@@ -566,10 +566,13 @@ func cmdSave(args []string, engine *game.GameEngine) CommandResult {
 }
 
 func cmdLoad(args []string, engine *game.GameEngine) CommandResult {
-	name := "autosave"
-	if len(args) > 0 {
-		name = args[0]
+	// No name: do NOT silently load autosave. Guide the player to the browser.
+	// The dashboard intercepts a bare `load` to open the Load Game tree; this
+	// fallback keeps other callers (and tests) from loading a slot by surprise.
+	if len(args) == 0 {
+		return CommandResult{Message: "Type 'load <name>' to load a specific save, or open Load Game from the menu (or press Esc) to browse your save tree.", Type: "info"}
 	}
+	name := args[0]
 	if err := engine.LoadGame(name); err != nil {
 		return CommandResult{Message: fmt.Sprintf("Load failed: %v", err), Type: "error"}
 	}

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -31,6 +31,13 @@ type loadGameBrowser struct {
 	subtitle *tview.TextView
 
 	saves []game.SaveInfo // current rows, sorted most-recent first
+
+	// backPage is the page to return to on Back/Esc (e.g. "splash" from the menu,
+	// "dashboard" when opened mid-game). startOnLoad gates engine.Start() after a
+	// successful load: true from the splash (first start), false mid-game (the
+	// engine is already running — a second Start() would double-run the ticker).
+	backPage    string
+	startOnLoad bool
 }
 
 // CreateLoadGamePage builds the full-screen Load Game browser and returns its
@@ -38,11 +45,17 @@ type loadGameBrowser struct {
 // and sets focus to the returned primitive's list — call SetFocus on the value
 // returned by FocusTarget, or just rely on AddPage's focus when it is the only
 // page shown. The screen is self-contained: all key handling lives on the list.
-func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game.GameEngine) tview.Primitive {
+//
+// backPage names the page to return to on Back/Esc; startOnLoad decides whether
+// a successful load should start the engine (true from the splash for the first
+// start, false mid-game where the engine is already running).
+func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game.GameEngine, backPage string, startOnLoad bool) tview.Primitive {
 	b := &loadGameBrowser{
-		app:    app,
-		pages:  pages,
-		engine: engine,
+		app:         app,
+		pages:       pages,
+		engine:      engine,
+		backPage:    backPage,
+		startOnLoad: startOnLoad,
 	}
 
 	// ── Title ────────────────────────────────────────────────────────────────
@@ -220,10 +233,11 @@ func (b *loadGameBrowser) handleKey(event *tcell.EventKey) *tcell.EventKey {
 	return event
 }
 
-// back removes the load_game page and returns to the splash.
+// back removes the load_game page and returns to the page it was opened from
+// (splash from the menu, dashboard when opened mid-game).
 func (b *loadGameBrowser) back() {
 	b.pages.RemovePage(loadGamePage)
-	b.pages.SwitchToPage("splash")
+	b.pages.SwitchToPage(b.backPage)
 }
 
 // doLoad loads the selected save and transitions to the dashboard. Corrupt saves
@@ -243,10 +257,14 @@ func (b *loadGameBrowser) doLoad() {
 		return
 	}
 	b.engine.AddLog("success", "Game loaded!")
-	// Mirror splash.go's post-load transition exactly.
 	b.pages.RemovePage(loadGamePage)
 	b.pages.SwitchToPage("dashboard")
-	go b.engine.Start()
+	// From the splash this performs the first engine start; mid-game the engine is
+	// already running (LoadGame swapped state under the lock and the live ticker
+	// picks it up), so a second Start() would double-run the ticker.
+	if b.startOnLoad {
+		go b.engine.Start()
+	}
 }
 
 // doDelete shows a red confirm modal, then deletes on confirm and refreshes.

--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -83,25 +83,30 @@ func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageNa
 		}
 	})
 
+	// Opaque spacers between the fields. tview only clears cells a primitive
+	// actually draws, so transparent spacers would let the page beneath (the
+	// dashboard, for a Branch save) bleed through; an explicit background paints
+	// them.
+	spacer := func() *tview.Box { return tview.NewBox().SetBackgroundColor(tcell.ColorBlack) }
 	inner := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(input, 1, 0, true).
-		AddItem(tview.NewBox(), 1, 0, false).
+		AddItem(spacer(), 1, 0, false).
 		AddItem(errTV, 1, 0, false).
-		AddItem(tview.NewBox(), 1, 0, false).
+		AddItem(spacer(), 1, 0, false).
 		AddItem(hintTV, 1, 0, false)
 	inner.SetBorder(true).
 		SetTitle(title).
 		SetTitleColor(tcell.ColorGold).
 		SetBorderColor(tcell.ColorGold)
-	// Paint the box opaque so the page beneath (the dashboard, for a Branch
-	// save) doesn't bleed through the modal's empty rows — matches the
-	// dev-unlock / rename modals. Without this, tview leaves unwritten cells
-	// transparent and the layer below shows through.
 	inner.SetBackgroundColor(tcell.ColorBlack)
 
 	// Esc cancels; Tab rerolls a fresh suggestion. Enter is handled by the field's
 	// DoneFunc above so plain typing keys still reach the input.
-	modal := centeredModal(inner, 60, 9)
+	//
+	// Height is sized to the exact content (5 rows + 2 border = 7). An oversized
+	// box would leave unallocated interior rows that no primitive paints, and
+	// those rows would show the dashboard through them.
+	modal := centeredModal(inner, 60, 7)
 	modal.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
 		switch ev.Key() {
 		case tcell.KeyEsc:

--- a/ui/save_cmd_test.go
+++ b/ui/save_cmd_test.go
@@ -59,3 +59,74 @@ func TestCmdSaveBranches(t *testing.T) {
 		t.Errorf("bare save changed active slot to %q, want %q", engine.ActiveSaveName(), child)
 	}
 }
+
+// TestCmdLoadNoArgsDoesNotLoad verifies a bare `load` no longer silently loads
+// the "autosave" slot. Instead it returns an informational usage message and
+// leaves the engine's active save untouched — the dashboard intercepts the bare
+// command to open the browser, so this fallback must never load a slot by
+// surprise.
+func TestCmdLoadNoArgsDoesNotLoad(t *testing.T) {
+	name := "Cmd Load Current"
+	t.Cleanup(func() {
+		_ = game.DeleteSave(name)
+	})
+
+	engine := game.NewGameEngine()
+	if err := engine.StartNewNamedGame(name); err != nil {
+		t.Fatalf("StartNewNamedGame(%q) failed: %v", name, err)
+	}
+	wantActive := engine.ActiveSaveName()
+
+	res := cmdLoad(nil, engine)
+	if res.Type != "info" {
+		t.Errorf("bare cmdLoad type = %q, want %q", res.Type, "info")
+	}
+	if !strings.Contains(res.Message, "load <name>") {
+		t.Errorf("bare cmdLoad message = %q, want it to mention the 'load <name>' usage", res.Message)
+	}
+	if strings.HasPrefix(res.Message, "Game loaded") {
+		t.Errorf("bare cmdLoad returned a success-style message %q; it must not load a slot", res.Message)
+	}
+	// The active slot must be unchanged — no load happened.
+	if got := engine.ActiveSaveName(); got != wantActive {
+		t.Errorf("bare cmdLoad changed active slot to %q, want %q (unchanged)", got, wantActive)
+	}
+}
+
+// TestCmdLoadWithNameLoads verifies that `load <name>` still loads the named
+// save directly through the engine.
+func TestCmdLoadWithNameLoads(t *testing.T) {
+	current := "Cmd Load Running"
+	target := "Cmd Load Target"
+	t.Cleanup(func() {
+		_ = game.DeleteSave(current)
+		_ = game.DeleteSave(target)
+	})
+
+	engine := game.NewGameEngine()
+	if err := engine.StartNewNamedGame(current); err != nil {
+		t.Fatalf("StartNewNamedGame(%q) failed: %v", current, err)
+	}
+	// Branch a second save so there is a distinct slot to load.
+	if res := cmdSave([]string{target}, engine); res.Type == "error" {
+		t.Fatalf("cmdSave(%q) returned error: %s", target, res.Message)
+	}
+	// Switch the active slot back so loading the target is an observable change.
+	if res := cmdLoad([]string{current}, engine); res.Type == "error" {
+		t.Fatalf("cmdLoad(%q) returned error: %s", current, res.Message)
+	}
+	if engine.ActiveSaveName() != current {
+		t.Fatalf("after load %q, ActiveSaveName() = %q, want %q", current, engine.ActiveSaveName(), current)
+	}
+
+	res := cmdLoad([]string{target}, engine)
+	if res.Type == "error" {
+		t.Fatalf("cmdLoad(%q) returned error: %s", target, res.Message)
+	}
+	if !strings.Contains(res.Message, target) {
+		t.Errorf("cmdLoad(%q) message = %q, want it to name the loaded save", target, res.Message)
+	}
+	if engine.ActiveSaveName() != target {
+		t.Errorf("after load %q, ActiveSaveName() = %q, want %q", target, engine.ActiveSaveName(), target)
+	}
+}

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -52,7 +52,7 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 		// halt the canvas here: the browser is an opaque full-screen page, so the
 		// animation runs harmlessly underneath and is still live when the player
 		// returns via Back (no need to rebuild the splash).
-		page := CreateLoadGamePage(app, pages, engine)
+		page := CreateLoadGamePage(app, pages, engine, "splash", true)
 		pages.AddPage(loadGamePage, page, true, true)
 		app.SetFocus(page)
 	})


### PR DESCRIPTION
Two save-UX fixes you flagged.

## `load` no longer assumes autosave
A bare `load` now opens the **Load Game lineage browser** so you pick which branch to load — no silent autosave default. The browser learned its return context:
- From the **splash**: back → splash, starts the engine on load (unchanged).
- **Mid-game**: back → dashboard, and it does NOT call `engine.Start()` again (the ticker's already running — `LoadGame` swaps state under the lock and the live ticker picks it up).

`load <name>` still loads directly; `cmdLoad` with no name returns guidance instead of loading a slot.

## Name modal still bled — now sized to content
#60's opaque background wasn't enough: the box was height **9** but its content is only **7** rows (5 + border), so 2 unallocated interior rows never got painted and the dashboard showed through them. Sized the modal to its exact content (7) and gave the spacers an explicit background — no unpainted cells left. Fixes both the Branch and New Game modals.

`go build/vet/test` green.

### Worth a look
- Type `load` in-game → the tree browser should open; Esc returns you to your run, Enter loads the picked branch.
- Open the Branch modal (`save` → Branch) → no more worker-panel text bleeding through the bottom.

Trello: https://trello.com/c/AvkUgZOV
