### PR TITLE
feat(military): classify expeditions scouting vs military; soldier-free scouting (phase 1)

### DIFF
--- a/game/military.go
+++ b/game/military.go
@@ -6,10 +6,19 @@ import (
 	"sort"
 )
 
+// Expedition categories. Scouting expeditions cost only resources (no soldiers)
+// and are playable before the soldiers resource exists (pre-iron_age). Military
+// expeditions cost soldiers (plus any Cost).
+const (
+	ExpeditionScouting = "scouting"
+	ExpeditionMilitary = "military"
+)
+
 // ExpeditionDef defines an available expedition
 type ExpeditionDef struct {
 	Name           string
 	Key            string
+	Category       string // ExpeditionScouting or ExpeditionMilitary
 	MinAge         string
 	MaxAge         string // empty = no upper bound; expedition is unavailable once past this age
 	SoldiersNeeded int
@@ -49,7 +58,8 @@ func NewMilitaryManager() *MilitaryManager {
 		expeditions: []ExpeditionDef{
 			{
 				Name: "Scout Party", Key: "scout_party",
-				MinAge: "primitive_age", MaxAge: "bronze_age",
+				Category: ExpeditionScouting,
+				MinAge:   "primitive_age", MaxAge: "bronze_age",
 				SoldiersNeeded: 0, Duration: 20,
 				DifficultyBase: 0.2,
 				Cost:           map[string]float64{"food": 30, "wood": 30},
@@ -58,105 +68,122 @@ func NewMilitaryManager() *MilitaryManager {
 			},
 			{
 				Name: "Scout Nearby Ruins", Key: "scout_ruins",
-				MinAge: "bronze_age", SoldiersNeeded: 2, Duration: 10,
+				Category: ExpeditionScouting,
+				MinAge:   "bronze_age", SoldiersNeeded: 0, Duration: 10,
 				DifficultyBase: 0.2,
+				Cost:           map[string]float64{"food": 40, "wood": 30},
 				Rewards:        map[string]float64{"food": 30, "wood": 20, "stone": 15},
 				Description:    "Send scouts to explore nearby ruins for resources.",
 			},
 			{
 				Name: "Raid Bandit Camp", Key: "raid_bandits",
-				MinAge: "bronze_age", SoldiersNeeded: 5, Duration: 15,
+				Category: ExpeditionMilitary,
+				MinAge:   "bronze_age", SoldiersNeeded: 5, Duration: 15,
 				DifficultyBase: 0.4,
 				Rewards:        map[string]float64{"gold": 30, "iron": 15, "food": 20},
 				Description:    "Attack a bandit encampment and seize their loot.",
 			},
 			{
 				Name: "Trade Escort", Key: "trade_escort",
-				MinAge: "iron_age", SoldiersNeeded: 3, Duration: 12,
+				Category: ExpeditionMilitary,
+				MinAge:   "iron_age", SoldiersNeeded: 3, Duration: 12,
 				DifficultyBase: 0.3,
 				Rewards:        map[string]float64{"gold": 50, "knowledge": 10},
 				Description:    "Escort merchants on a dangerous trade route.",
 			},
 			{
 				Name: "Conquer Territory", Key: "conquer_territory",
-				MinAge: "iron_age", SoldiersNeeded: 10, Duration: 25,
+				Category: ExpeditionMilitary,
+				MinAge:   "iron_age", SoldiersNeeded: 10, Duration: 25,
 				DifficultyBase: 0.6,
 				Rewards:        map[string]float64{"gold": 80, "iron": 40, "food": 50},
 				Description:    "Conquer a neighboring territory for its resources.",
 			},
 			{
 				Name: "Siege Enemy Castle", Key: "siege_castle",
-				MinAge: "medieval_age", SoldiersNeeded: 15, Duration: 30,
+				Category: ExpeditionMilitary,
+				MinAge:   "medieval_age", SoldiersNeeded: 15, Duration: 30,
 				DifficultyBase: 0.7,
 				Rewards:        map[string]float64{"gold": 150, "steel": 30, "faith": 20},
 				Description:    "Lay siege to an enemy stronghold.",
 			},
 			{
 				Name: "Naval Expedition", Key: "naval_expedition",
-				MinAge: "renaissance_age", SoldiersNeeded: 10, Duration: 35,
+				Category: ExpeditionScouting,
+				MinAge:   "renaissance_age", SoldiersNeeded: 0, Duration: 35,
 				DifficultyBase: 0.5,
+				Cost:           map[string]float64{"food": 150, "wood": 100},
 				Rewards:        map[string]float64{"gold": 200, "culture": 30, "knowledge": 40},
 				Description:    "Explore distant lands by sea.",
 			},
 			{
 				Name: "Colonial Campaign", Key: "colonial_campaign",
-				MinAge: "industrial_age", SoldiersNeeded: 20, Duration: 40,
+				Category: ExpeditionMilitary,
+				MinAge:   "industrial_age", SoldiersNeeded: 20, Duration: 40,
 				DifficultyBase: 0.6,
 				Rewards:        map[string]float64{"gold": 300, "oil": 50, "steel": 40},
 				Description:    "Establish colonial presence in new territories.",
 			},
 			{
 				Name: "World Domination", Key: "world_domination",
-				MinAge: "modern_age", SoldiersNeeded: 50, Duration: 60,
+				Category: ExpeditionMilitary,
+				MinAge:   "modern_age", SoldiersNeeded: 50, Duration: 60,
 				DifficultyBase: 0.8,
 				Rewards:        map[string]float64{"gold": 1000, "electricity": 200, "knowledge": 500},
 				Description:    "Launch a global military campaign for world domination.",
 			},
 			{
 				Name: "Cyber Raid", Key: "cyber_raid",
-				MinAge: "information_age", SoldiersNeeded: 30, Duration: 45,
+				Category: ExpeditionMilitary,
+				MinAge:   "information_age", SoldiersNeeded: 30, Duration: 45,
 				DifficultyBase: 0.6,
 				Rewards:        map[string]float64{"data": 200, "crypto": 50, "gold": 500},
 				Description:    "Hack into enemy networks and steal digital assets.",
 			},
 			{
 				Name: "Neon Heist", Key: "neon_heist",
-				MinAge: "cyberpunk_age", SoldiersNeeded: 25, Duration: 35,
+				Category: ExpeditionMilitary,
+				MinAge:   "cyberpunk_age", SoldiersNeeded: 25, Duration: 35,
 				DifficultyBase: 0.55,
 				Rewards:        map[string]float64{"crypto": 100, "data": 150, "gold": 800},
 				Description:    "Pull off a daring heist in the neon-lit underworld.",
 			},
 			{
 				Name: "Fusion Plant Assault", Key: "fusion_assault",
-				MinAge: "fusion_age", SoldiersNeeded: 35, Duration: 40,
+				Category: ExpeditionMilitary,
+				MinAge:   "fusion_age", SoldiersNeeded: 35, Duration: 40,
 				DifficultyBase: 0.65,
 				Rewards:        map[string]float64{"plasma": 120, "electricity": 500, "uranium": 50},
 				Description:    "Capture a rival's fusion power facility.",
 			},
 			{
 				Name: "Orbital Strike", Key: "orbital_strike",
-				MinAge: "space_age", SoldiersNeeded: 40, Duration: 50,
+				Category: ExpeditionMilitary,
+				MinAge:   "space_age", SoldiersNeeded: 40, Duration: 50,
 				DifficultyBase: 0.7,
 				Rewards:        map[string]float64{"titanium": 100, "plasma": 80, "knowledge": 300},
 				Description:    "Deploy orbital weapons platform against hostile targets.",
 			},
 			{
 				Name: "Warp Invasion", Key: "warp_invasion",
-				MinAge: "interstellar_age", SoldiersNeeded: 60, Duration: 65,
+				Category: ExpeditionMilitary,
+				MinAge:   "interstellar_age", SoldiersNeeded: 60, Duration: 65,
 				DifficultyBase: 0.75,
 				Rewards:        map[string]float64{"dark_matter": 50, "titanium": 200, "gold": 2000},
 				Description:    "Invade a neighboring star system through warp gates.",
 			},
 			{
 				Name: "Galactic Conquest", Key: "galactic_conquest",
-				MinAge: "galactic_age", SoldiersNeeded: 80, Duration: 80,
+				Category: ExpeditionMilitary,
+				MinAge:   "galactic_age", SoldiersNeeded: 80, Duration: 80,
 				DifficultyBase: 0.8,
 				Rewards:        map[string]float64{"antimatter": 30, "dark_matter": 100, "gold": 5000},
 				Description:    "Conquer an entire galactic sector.",
 			},
 			{
 				Name: "Quantum Incursion", Key: "quantum_incursion",
-				MinAge: "quantum_age", SoldiersNeeded: 100, Duration: 90,
+				Category: ExpeditionMilitary,
+				MinAge:   "quantum_age", SoldiersNeeded: 100, Duration: 90,
 				DifficultyBase: 0.85,
 				Rewards:        map[string]float64{"quantum_flux": 20, "antimatter": 50, "knowledge": 5000},
 				Description:    "Launch an incursion across quantum realities.",
@@ -278,6 +305,18 @@ func (mm *MilitaryManager) GetAvailableExpeditions(currentAge string, ageOrder m
 	return available
 }
 
+// GetAvailableExpeditionsByCategory is GetAvailableExpeditions filtered to one
+// Category (ExpeditionScouting or ExpeditionMilitary).
+func (mm *MilitaryManager) GetAvailableExpeditionsByCategory(category, currentAge string, ageOrder map[string]int) []ExpeditionDef {
+	var filtered []ExpeditionDef
+	for _, def := range mm.GetAvailableExpeditions(currentAge, ageOrder) {
+		if def.Category == category {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered
+}
+
 // launchability reports whether an expedition can be launched right now and, if
 // not, a short player-facing reason. It mirrors the engine's LaunchExpedition
 // validation order: single-active rule, then soldiers, then each Cost resource.
@@ -338,6 +377,7 @@ func (mm *MilitaryManager) Snapshot(currentAge string, ageOrder map[string]int, 
 		expList = append(expList, ExpeditionInfo{
 			Name:              def.Name,
 			Key:               def.Key,
+			Category:          def.Category,
 			SoldiersNeeded:    def.SoldiersNeeded,
 			Duration:          def.Duration,
 			Difficulty:        def.DifficultyBase,

--- a/game/military_rework_test.go
+++ b/game/military_rework_test.go
@@ -233,3 +233,93 @@ func TestCanLaunch_RespectsCost(t *testing.T) {
 		t.Fatalf("scout_party not present in available expeditions with resources")
 	}
 }
+
+// === Scouting / Army split (Phase 1) ===
+
+// TestExpeditionCategory_AllValid verifies every expedition is classified as one
+// of the two known categories — no blanks or typos that would drop it from both
+// grouped subsections.
+func TestExpeditionCategory_AllValid(t *testing.T) {
+	mm := NewMilitaryManager()
+	for _, def := range mm.expeditions {
+		switch def.Category {
+		case ExpeditionScouting, ExpeditionMilitary:
+			// ok
+		default:
+			t.Errorf("expedition %q has invalid Category %q (want %q or %q)",
+				def.Key, def.Category, ExpeditionScouting, ExpeditionMilitary)
+		}
+	}
+}
+
+// TestScoutingExpeditions_SoldierFree verifies all scouting expeditions cost zero
+// soldiers — scouting must be playable before the soldiers resource exists
+// (pre-iron_age).
+func TestScoutingExpeditions_SoldierFree(t *testing.T) {
+	mm := NewMilitaryManager()
+	scoutCount := 0
+	for _, def := range mm.expeditions {
+		if def.Category != ExpeditionScouting {
+			continue
+		}
+		scoutCount++
+		if def.SoldiersNeeded != 0 {
+			t.Errorf("scouting expedition %q has SoldiersNeeded=%d, want 0",
+				def.Key, def.SoldiersNeeded)
+		}
+	}
+	if scoutCount != 3 {
+		t.Errorf("expected 3 scouting expeditions, found %d", scoutCount)
+	}
+}
+
+// TestScoutRuins_LaunchableWithZeroSoldiers guards the Phase 1 bug fix:
+// scout_ruins previously needed 2 (nonexistent, pre-iron_age) soldiers and so was
+// never launchable. It must now be launchable with zero soldiers given enough
+// resources for its Cost.
+func TestScoutRuins_LaunchableWithZeroSoldiers(t *testing.T) {
+	mm := NewMilitaryManager()
+	def := mm.ExpeditionDefByKey("scout_ruins")
+	if def == nil {
+		t.Fatal("scout_ruins not found")
+	}
+	if def.SoldiersNeeded != 0 {
+		t.Fatalf("scout_ruins SoldiersNeeded=%d, want 0", def.SoldiersNeeded)
+	}
+
+	// Resources covering its Cost, zero soldiers.
+	resources := map[string]float64{"food": 100, "wood": 100}
+	ok, reason := mm.launchability(*def, 0, resources)
+	if !ok {
+		t.Errorf("scout_ruins not launchable with 0 soldiers + sufficient resources: %q", reason)
+	}
+
+	// It should also be available in bronze_age (its MinAge).
+	available := mm.GetAvailableExpeditionsByCategory(ExpeditionScouting, "bronze_age", fullAgeOrder())
+	foundRuins := false
+	for _, d := range available {
+		if d.Key == "scout_ruins" {
+			foundRuins = true
+		}
+	}
+	if !foundRuins {
+		t.Error("scout_ruins not present among available scouting expeditions in bronze_age")
+	}
+}
+
+// TestMilitaryExpeditions_RequireSoldiers verifies at least one military
+// expedition still costs soldiers (the classification didn't accidentally zero
+// everyone out).
+func TestMilitaryExpeditions_RequireSoldiers(t *testing.T) {
+	mm := NewMilitaryManager()
+	found := false
+	for _, def := range mm.expeditions {
+		if def.Category == ExpeditionMilitary && def.SoldiersNeeded > 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("no military expedition requires soldiers — classification likely broken")
+	}
+}

--- a/game/types.go
+++ b/game/types.go
@@ -257,6 +257,7 @@ type ExpeditionSnapshot struct {
 type ExpeditionInfo struct {
 	Name           string
 	Key            string
+	Category       string // "scouting" or "military"
 	SoldiersNeeded int
 	Duration       int
 	Difficulty     float64

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -90,7 +90,7 @@ expedition scout_ruins
 speed 1.5
 ```
 
-Expeditions **spend the `soldiers` resource** at launch (and sometimes a resource cost too) — the cost is deducted whether the run succeeds or fails; only the reward differs. Before the Iron Age, `scout_party` costs 0 soldiers (just food + wood). Only one expedition can be active at a time. Check the **Military** overlay (`army`) for available expeditions and their soldier costs.
+Expeditions come in two kinds. **Scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) cost only resources — **0 soldiers** — and are available early, before the `soldiers` resource exists at the Iron Age. **Military campaigns** (everything else) **spend the `soldiers` resource** at launch, plus any resource cost. Either way the cost is deducted whether the run succeeds or fails; only the reward differs, and only one expedition can be active at a time. The **Military** overlay (`army`) groups available expeditions under **Scouting** and **Military Campaigns** headers (display grouping only — the commands above are unchanged).
 
 ---
 

--- a/site/docs/military.md
+++ b/site/docs/military.md
@@ -13,7 +13,12 @@ The military system does four things:
 - **Milestones** — five military milestones grant permanent `military_power` bonuses and chain into a title reward.
 - **Prestige** — prestige upgrades `military_power` and `expedition_loot` carry over through resets, compounding across runs.
 
-**Soldiers are a resource** (the 26th), not a worker domain count. They are *produced and stored by your military buildings*: assign military-domain workers to a War Camp or Barracks and it generates the `soldiers` resource every tick, the same way a Farm generates food. The military domain — and the soldiers resource — unlock at the **Iron Age**. Before then, use the `scout_party` expedition (see [§4](#4-expeditions)) to scout for resources without any soldiers at all.
+**Soldiers are a resource** (the 26th), not a worker domain count. They are *produced and stored by your military buildings*: assign military-domain workers to a War Camp or Barracks and it generates the `soldiers` resource every tick, the same way a Farm generates food. The military domain — and the soldiers resource — unlock at the **Iron Age**. Before then, the **scouting** expeditions (see [§4](#4-expeditions)) let you explore for resources without any soldiers at all.
+
+Expeditions come in **two kinds**:
+
+- **Scouting** — cost only resources (no soldiers), and are available early, before the soldiers resource exists at the Iron Age. There are exactly three: `scout_party`, `scout_ruins`, and `naval_expedition`.
+- **Military campaigns** — cost soldiers (plus any resource `Cost`), and are gated behind the Iron Age and beyond.
 
 ---
 
@@ -49,7 +54,7 @@ The military *workers* who produce soldiers eat food at the base rate for their 
 
 Soldiers leave your stockpile in two ways:
 
-- **Expedition launch** — every expedition spends its soldier cost up front, deducted whether the run later succeeds or fails. (The `scout_party` expedition costs **0** soldiers — see [§4](#4-expeditions).)
+- **Expedition launch** — every *military campaign* spends its soldier cost up front, deducted whether the run later succeeds or fails. The three **scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) cost **0** soldiers and instead charge a resource `Cost` — see [§4](#4-expeditions).
 - **Catastrophe events** — certain hostile epoch events can drain stored soldiers along with other losses.
 
 Spent or lost soldiers are simply removed from the stockpile. To replenish, keep military workers assigned to your military buildings so production continues.
@@ -105,13 +110,18 @@ All military buildings belong to the **military lineage** (22 tiers, stone_age t
 
 ### What expeditions are
 
-Expeditions are timed missions that **spend the soldiers resource** to launch. The soldier cost (and any additional resource `Cost`, such as the food/wood for `scout_party`) is deducted from your stockpiles the moment you launch — there's no refund. After a set number of ticks, the expedition resolves. **Success and failure differ only in the size of the reward, not the cost:** the soldiers are spent either way. A successful run pays full loot; a failed run pays a reduced amount. Only **one expedition can be active at a time**.
+Expeditions are timed missions launched from your stockpiles. They come in **two kinds**:
+
+- **Scouting** (`scout_party`, `scout_ruins`, `naval_expedition`) — cost only a resource `Cost`, **0 soldiers**. These are available early, before the `soldiers` resource exists at the Iron Age.
+- **Military campaigns** (everything else — 13 of them) — **spend the soldiers resource** to launch, plus any additional resource `Cost`.
+
+Whatever the kind, the cost is deducted from your stockpiles the moment you launch — there's no refund. After a set number of ticks, the expedition resolves. **Success and failure differ only in the size of the reward, not the cost:** the soldiers and/or resources are spent either way. A successful run pays full loot; a failed run pays a reduced amount. Only **one expedition can be active at a time**.
 
 ### Cost, gating, and rewards
 
-- **Soldier cost** — spent from the `soldiers` resource at launch. You cannot launch an expedition you can't afford. The `scout_party` is the exception: it costs **0 soldiers**, only food and wood.
-- **Resource `Cost`** — some expeditions also charge resources up front (e.g. `scout_party` costs 30 food + 30 wood). Deducted at launch alongside the soldier cost.
-- **Age gating** — every expedition has a `MinAge`. Some now also have a `MaxAge` and disappear once you advance past it. `scout_party` is gated to primitive → bronze ages (it vanishes at Iron Age, when real soldiers become available).
+- **Soldier cost** — military campaigns spend it from the `soldiers` resource at launch, and you cannot launch one you can't afford. The three scouting expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) cost **0 soldiers** — they charge only a resource `Cost`.
+- **Resource `Cost`** — many expeditions charge resources up front (e.g. `scout_party` costs 30 food + 30 wood; `naval_expedition` costs 150 food + 100 wood). Deducted at launch alongside any soldier cost.
+- **Age gating** — every expedition has a `MinAge`. Some also have a `MaxAge` and disappear once you advance past it. `scout_party` is gated to primitive → bronze ages (it vanishes at Iron Age, when real soldiers become available); `scout_ruins` opens at Bronze Age and `naval_expedition` at Renaissance Age — both scouting, both 0 soldiers.
 - **Reward** — paid on resolution: full amount on success, reduced amount on failure. The soldier and resource costs are *not* part of the reward calculation; they're already gone.
 
 ### Commands
@@ -124,6 +134,8 @@ exp <key>               # Shorthand
 ```
 
 Keys with underscores can be typed with spaces and are joined: `expedition scout ruins` is equivalent to `expedition scout_ruins`.
+
+The **Military** overlay (`army`) groups the expeditions available in your current age into two subsections — **Scouting** and **Military Campaigns** — so you can see at a glance which ones need soldiers and which are resource-only. This is a display grouping; the commands are unchanged (`expedition list`, `expedition <key>`).
 
 ### Success probability formula
 
@@ -145,17 +157,17 @@ The soldier (and resource) cost is already spent at launch, so the outcome only 
 
 ### Full expedition table
 
-The **Soldier Cost** column is now spent from the `soldiers` resource at launch (not a soldier headcount requirement). Some expeditions also charge a resource `Cost` up front — noted in the table.
+The **Soldier Cost** column is spent from the `soldiers` resource at launch (not a soldier headcount requirement). The three **scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) show **0** in that column and instead charge a resource `Cost`; the **military campaigns** spend soldiers plus any resource `Cost`. Both are noted in the table.
 
 | Key | Name | Min Age | Soldier Cost | Resource Cost | Duration | Difficulty | Rewards on Success |
 |-----|------|---------|--------------|---------------|----------|------------|-------------------|
 | `scout_party` | Scout Party | Primitive Age (max Bronze Age) | 0 | 30 food, 30 wood | 20t | — | 60 food, 60 wood, 20 stone |
-| `scout_ruins` | Scout Nearby Ruins | Bronze Age | 2 | — | 10t | 0.20 | 30 food, 20 wood, 15 stone |
+| `scout_ruins` | Scout Nearby Ruins | Bronze Age | 0 | 40 food, 30 wood | 10t | 0.20 | 30 food, 20 wood, 15 stone |
 | `raid_bandits` | Raid Bandit Camp | Bronze Age | 5 | — | 15t | 0.40 | 30 gold, 15 iron, 20 food |
 | `trade_escort` | Trade Escort | Iron Age | 3 | — | 12t | 0.30 | 50 gold, 10 knowledge |
 | `conquer_territory` | Conquer Territory | Iron Age | 10 | — | 25t | 0.60 | 80 gold, 40 iron, 50 food |
 | `siege_castle` | Siege Enemy Castle | Medieval Age | 15 | — | 30t | 0.70 | 150 gold, 30 steel, 20 faith |
-| `naval_expedition` | Naval Expedition | Renaissance Age | 10 | — | 35t | 0.50 | 200 gold, 30 culture, 40 knowledge |
+| `naval_expedition` | Naval Expedition | Renaissance Age | 0 | 150 food, 100 wood | 35t | 0.50 | 200 gold, 30 culture, 40 knowledge |
 | `colonial_campaign` | Colonial Campaign | Industrial Age | 20 | — | 40t | 0.60 | 300 gold, 50 oil, 40 steel |
 | `world_domination` | World Domination | Modern Age | 50 | — | 60t | 0.80 | 1,000 gold, 200 electricity, 500 knowledge |
 | `cyber_raid` | Cyber Raid | Information Age | 30 | — | 45t | 0.60 | 200 data, 50 crypto, 500 gold |
@@ -168,9 +180,9 @@ The **Soldier Cost** column is now spent from the `soldiers` resource at launch 
 
 That's **16 expeditions** in total.
 
-**`scout_party` — the pre-iron expedition.** Before the Iron Age there is no military worker domain and no `soldiers` resource, so the soldier-driven expeditions above aren't available. `scout_party` fills that gap: *"A small band of foragers scouts nearby territory for resources."* It costs **30 food + 30 wood**, needs **0 soldiers**, runs ~20 ticks, and rewards roughly **60 food / 60 wood / 20 stone** — a net resource gain that's worth running on repeat through the Primitive, Stone, and Bronze ages. It has a `MaxAge` of Bronze Age and disappears once you reach the Iron Age and graduate to soldier-backed expeditions.
+**Scouting — the soldier-free expeditions.** Before the Iron Age there is no military worker domain and no `soldiers` resource, so the military campaigns aren't available. The **scouting** expeditions fill that gap — `scout_party` (primitive → bronze) and then `scout_ruins` (bronze age) are available without soldiers, charging only resources. `scout_party`: *"A small band of foragers scouts nearby territory for resources."* It costs **30 food + 30 wood**, needs **0 soldiers**, runs ~20 ticks, and rewards roughly **60 food / 60 wood / 20 stone** — a net resource gain worth running on repeat through the Primitive, Stone, and Bronze ages. It has a `MaxAge` of Bronze Age and disappears once you reach the Iron Age. `scout_ruins` (Bronze Age, 0 soldiers, 40 food + 30 wood) carries scouting forward, and `naval_expedition` (Renaissance Age, 0 soldiers, 150 food + 100 wood) is the late scouting option.
 
-**Tip:** `scout_ruins` and `trade_escort` are the workhorses of early *soldier* play — low difficulty, short duration, and they can be chained rapidly for consistent loot.
+**Tip:** `trade_escort` (Iron Age, 3 soldiers, 12t, 0.30 difficulty) is the workhorse of early *soldier* play — cheap, short, and chainable for consistent gold. For soldier-free resource throughput, chain the scouting expeditions (`scout_party`, then `scout_ruins`) — low difficulty, short duration, and no soldiers required.
 
 ---
 
@@ -269,7 +281,7 @@ The five military milestones form a chain. Completing the full chain grants a pe
 ### Mid game (Classical to Industrial Age)
 
 - Push `iron_legion` (300 soldiers + 5 Barracks) — the +0.10 bonus noticeably improves expedition success on harder missions.
-- `conquer_territory` (10 soldiers, 25t, 0.60 difficulty) and `naval_expedition` (10 soldiers, 35t, 0.50 difficulty) are the best bang-for-tick in this range.
+- `conquer_territory` (10 soldiers, 25t, 0.60 difficulty) is the best soldier-spend bang-for-tick in this range. `naval_expedition` is now a **scouting** option — 0 soldiers, just 150 food + 100 wood (Renaissance Age, 35t, 0.50 difficulty) — so you can run it without dipping into your soldier stockpile.
 - Build **Legion Forts** and **Military Academies** to raise your soldier ceiling. The capacity doubling per tier means each new building unlocks dramatically more troops.
 - Research military-flavored techs as they appear — even +0.2 military_power makes a visible difference against 0.6-difficulty expeditions.
 

--- a/ui/input.go
+++ b/ui/input.go
@@ -845,7 +845,36 @@ func cmdExpeditionList(engine *game.GameEngine) CommandResult {
 	var lines []string
 	lines = append(lines, "[gold]Available Expeditions:[-]")
 
-	for _, exp := range state.Military.Expeditions {
+	// Group by category: Scouting first, then Military Campaigns. Headers are
+	// omitted for empty subsections.
+	appendExpeditionGroup(&lines, "Scouting", state.Military.Expeditions, game.ExpeditionScouting)
+	appendExpeditionGroup(&lines, "Military Campaigns", state.Military.Expeditions, game.ExpeditionMilitary)
+
+	if state.Military.ActiveExpedition != nil {
+		lines = append(lines, fmt.Sprintf("\n[yellow]Active: %s (%d ticks left)[-]",
+			state.Military.ActiveExpedition.Name, state.Military.ActiveExpedition.TicksLeft))
+	}
+
+	if len(state.Military.Expeditions) == 0 {
+		lines = append(lines, "  [gray]No expeditions available yet[-]")
+	}
+
+	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+}
+
+// appendExpeditionGroup appends the subset of exps matching category to lines,
+// under a labeled header (e.g. "Scouting"). The header is omitted when no
+// expedition matches, so empty subsections produce no output.
+func appendExpeditionGroup(lines *[]string, label string, exps []game.ExpeditionInfo, category string) {
+	first := true
+	for _, exp := range exps {
+		if exp.Category != category {
+			continue
+		}
+		if first {
+			*lines = append(*lines, fmt.Sprintf("[yellow]%s:[-]", label))
+			first = false
+		}
 		canStr := "[red]✗[-]"
 		if exp.CanLaunch {
 			canStr = "[green]✓[-]"
@@ -858,19 +887,8 @@ func cmdExpeditionList(engine *game.GameEngine) CommandResult {
 		if !exp.CanLaunch && exp.LaunchBlockReason != "" {
 			line += fmt.Sprintf(" [red]— %s[-]", exp.LaunchBlockReason)
 		}
-		lines = append(lines, line)
+		*lines = append(*lines, line)
 	}
-
-	if state.Military.ActiveExpedition != nil {
-		lines = append(lines, fmt.Sprintf("\n[yellow]Active: %s (%d ticks left)[-]",
-			state.Military.ActiveExpedition.Name, state.Military.ActiveExpedition.TicksLeft))
-	}
-
-	if len(state.Military.Expeditions) == 0 {
-		lines = append(lines, "  [gray]No expeditions available yet[-]")
-	}
-
-	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
 }
 
 func cmdTrade(args []string, engine *game.GameEngine) CommandResult {

--- a/ui/overlay_military.go
+++ b/ui/overlay_military.go
@@ -68,34 +68,11 @@ func militaryProvider(state game.GameState, _ int) string {
 		sb.WriteString(" [gray]Reach Bronze Age and recruit soldiers[-]\n")
 		sb.WriteString(" [gray]to unlock expeditions.[-]\n")
 	} else {
-		for _, exp := range mil.Expeditions {
-			statusIcon := "[red]▸[-]"
-			if exp.CanLaunch {
-				statusIcon = "[green]▸[-]"
-			}
-
-			diffColor := "green"
-			if exp.Difficulty > 0.5 {
-				diffColor = "red"
-			} else if exp.Difficulty > 0.3 {
-				diffColor = "yellow"
-			}
-
-			fmt.Fprintf(&sb, " %s [cyan]%s[-]\n", statusIcon, exp.Name)
-			fmt.Fprintf(&sb, "   [gray]%s[-]\n", exp.Description)
-			fmt.Fprintf(&sb, "   Soldiers: %d  Duration: %d ticks  Difficulty: [%s]%.0f%%[-]\n",
-				exp.SoldiersNeeded, exp.Duration, diffColor, exp.Difficulty*100)
-			if cost := formatExpeditionCost(exp.Cost); cost != "" {
-				fmt.Fprintf(&sb, "   Cost: %s\n", cost)
-			}
-
-			if exp.CanLaunch {
-				fmt.Fprintf(&sb, "   [green]expedition %s[-]\n", exp.Key)
-			} else {
-				fmt.Fprintf(&sb, "   [red]%s[-]\n", exp.LaunchBlockReason)
-			}
-			sb.WriteString("\n")
-		}
+		// Group available expeditions by category: Scouting first (resource cost,
+		// no soldiers, available early), then Military Campaigns (cost soldiers).
+		// A subsection header is omitted when it has no available entries.
+		writeExpeditionGroup(&sb, "Scouting", mil.Expeditions, game.ExpeditionScouting)
+		writeExpeditionGroup(&sb, "Military Campaigns", mil.Expeditions, game.ExpeditionMilitary)
 	}
 
 	// === Loot History ===
@@ -119,6 +96,49 @@ func militaryProvider(state game.GameState, _ int) string {
 	sb.WriteString("\n [gray]Commands: expedition <key>[-]\n")
 
 	return sb.String()
+}
+
+// writeExpeditionGroup renders the subset of exps matching category under a
+// labeled header (e.g. "Scouting"). If no expedition matches, nothing is
+// written — the header is omitted for empty subsections.
+func writeExpeditionGroup(sb *strings.Builder, label string, exps []game.ExpeditionInfo, category string) {
+	first := true
+	for _, exp := range exps {
+		if exp.Category != category {
+			continue
+		}
+		if first {
+			fmt.Fprintf(sb, " [yellow]── %s ──[-]\n\n", label)
+			first = false
+		}
+
+		statusIcon := "[red]▸[-]"
+		if exp.CanLaunch {
+			statusIcon = "[green]▸[-]"
+		}
+
+		diffColor := "green"
+		if exp.Difficulty > 0.5 {
+			diffColor = "red"
+		} else if exp.Difficulty > 0.3 {
+			diffColor = "yellow"
+		}
+
+		fmt.Fprintf(sb, " %s [cyan]%s[-]\n", statusIcon, exp.Name)
+		fmt.Fprintf(sb, "   [gray]%s[-]\n", exp.Description)
+		fmt.Fprintf(sb, "   Soldiers: %d  Duration: %d ticks  Difficulty: [%s]%.0f%%[-]\n",
+			exp.SoldiersNeeded, exp.Duration, diffColor, exp.Difficulty*100)
+		if cost := formatExpeditionCost(exp.Cost); cost != "" {
+			fmt.Fprintf(sb, "   Cost: %s\n", cost)
+		}
+
+		if exp.CanLaunch {
+			fmt.Fprintf(sb, "   [green]expedition %s[-]\n", exp.Key)
+		} else {
+			fmt.Fprintf(sb, "   [red]%s[-]\n", exp.LaunchBlockReason)
+		}
+		sb.WriteString("\n")
+	}
 }
 
 // formatExpeditionCost renders an expedition's resource cost in a readable,


### PR DESCRIPTION
## Phase 1 of the Scouting/Army split — model + grouping

Foundation only: no command/panel split yet, no active-slot or Defense changes.

- **`Category`** field on `ExpeditionDef` (`ExpeditionScouting` | `ExpeditionMilitary`). All 16 classified — **scouting:** `scout_party`, `scout_ruins`, `naval_expedition` ("explore distant lands"); **military:** the 13 raid/conquer/siege/invasion runs.
- **Scouting is now soldier-free** — it has to be, since scouting predates the Iron-Age soldiers resource. This fixes a real bug: **`scout_ruins` was Bronze Age but required 2 soldiers that can't exist yet**, so it was never launchable. Now 0 soldiers + a modest food/wood cost; `naval` likewise.
- `GetAvailableExpeditionsByCategory()` filter helper; the Military overlay and `expedition list` now group **Scouting** vs **Military Campaigns**.

### Tests
Category validity, scouting-is-soldier-free, the scout_ruins launchable-with-zero-soldiers bug-fix guard, and at-least-one-military-still-needs-soldiers. `go build/vet/test` green. Wiki (military.md, commands.md) updated.

### Next
- **Phase 2** — `scout` command + Scouting panel; `army` = military only; concurrent scout + army active slots.
- **Phase 3** — wire the dead Defense Rating into real mitigation.

Trello: https://trello.com/c/qPhJ5YxH
