### PR TITLE
feat(military): concurrent scout + military expeditions, per-category slots (phase 2a)

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -848,16 +848,18 @@ func (ge *GameEngine) processExpeditions() {
 	wonderBonuses := ge.getWonderBonuses()
 	militaryBonus := ge.Research.GetBonus("military_power") + ge.permanentBonuses["military_power"] + prestigeBonuses["military_power"] + wonderBonuses["military_power"]
 	expeditionBonus := ge.Research.GetBonus("expedition_reward") + ge.permanentBonuses["expedition_reward"] + prestigeBonuses["expedition_reward"] + wonderBonuses["expedition_reward"]
-	if ge.Military.active != nil {
-		ge.addLog("debug", fmt.Sprintf("Expedition: %s %d ticks left", ge.Military.active.Name, ge.Military.active.TicksLeft))
+	for _, cat := range []string{ExpeditionScouting, ExpeditionMilitary} {
+		if active := ge.Military.ActiveByCategory(cat); active != nil {
+			ge.addLog("debug", fmt.Sprintf("Expedition: %s %d ticks left", active.Name, active.TicksLeft))
+		}
 	}
-	rewards, message := ge.Military.Tick(militaryBonus, expeditionBonus)
-	if message != "" {
-		ge.addLog("debug", fmt.Sprintf("Expedition resolved (rewards: %d types)", len(rewards)))
-		ge.addLog("event", message)
+	// Tick all active expeditions (one per category); each may resolve this tick.
+	for _, res := range ge.Military.Tick(militaryBonus, expeditionBonus) {
+		ge.addLog("debug", fmt.Sprintf("Expedition resolved (rewards: %d types)", len(res.Rewards)))
+		ge.addLog("event", res.Message)
 		// Add rewards to resources
-		for res, amount := range rewards {
-			ge.Resources.Add(res, amount)
+		for resource, amount := range res.Rewards {
+			ge.Resources.Add(resource, amount)
 		}
 	}
 }
@@ -2574,8 +2576,8 @@ func (ge *GameEngine) LaunchExpedition(key string) error {
 		ge.Resources.Remove(res, amount)
 	}
 
-	ge.addLog("debug", fmt.Sprintf("Expedition start: %s (soldiers spent: %d)", ge.Military.active.Name, def.SoldiersNeeded))
-	ge.addLog("info", fmt.Sprintf("Expedition launched: %s", ge.Military.active.Name))
+	ge.addLog("debug", fmt.Sprintf("Expedition start: %s (soldiers spent: %d)", def.Name, def.SoldiersNeeded))
+	ge.addLog("info", fmt.Sprintf("Expedition launched: %s", def.Name))
 	return nil
 }
 

--- a/game/expedition_test.go
+++ b/game/expedition_test.go
@@ -85,7 +85,7 @@ func TestLaunchExpedition_InsufficientSoldiers_NoDeduction(t *testing.T) {
 	if got := ge.Resources.Get("soldiers"); got != 4 {
 		t.Errorf("soldiers after failed launch = %v, want 4 (unchanged)", got)
 	}
-	if ge.Military.active != nil {
+	if ge.Military.HasActive() {
 		t.Errorf("expedition should not be active after a failed launch")
 	}
 }
@@ -111,7 +111,7 @@ func TestLaunchExpedition_InsufficientCost_NoDeduction(t *testing.T) {
 	if wood := ge.Resources.Get("wood"); wood != 10 {
 		t.Errorf("wood after failed launch = %v, want 10 (unchanged)", wood)
 	}
-	if ge.Military.active != nil {
+	if ge.Military.HasActive() {
 		t.Errorf("expedition should not be active after a failed launch")
 	}
 }
@@ -144,7 +144,7 @@ func TestScoutParty_LaunchableInStoneAge_RejectedPastBronze(t *testing.T) {
 	if food := ge2.Resources.Get("food"); food != 100 {
 		t.Errorf("food after rejected past-MaxAge launch = %v, want 100 (unchanged)", food)
 	}
-	if ge2.Military.active != nil {
+	if ge2.Military.HasActive() {
 		t.Errorf("expedition should not be active after a rejected launch")
 	}
 }
@@ -168,13 +168,13 @@ func TestExpedition_ResolvesWithoutWorkerLoss(t *testing.T) {
 	}
 
 	// Drive the expedition to resolution.
-	for i := 0; i < 40 && ge.Military.active != nil; i++ {
+	for i := 0; i < 40 && ge.Military.HasActive(); i++ {
 		ge.mu.Lock()
 		ge.processExpeditions()
 		ge.mu.Unlock()
 	}
 
-	if ge.Military.active != nil {
+	if ge.Military.HasActive() {
 		t.Fatalf("expedition did not resolve within tick budget")
 	}
 	if popAfter := ge.Workers.TotalPop(); popAfter != popBefore {

--- a/game/military.go
+++ b/game/military.go
@@ -38,14 +38,17 @@ type ActiveExpedition struct {
 }
 
 // MilitaryManager handles military expeditions and defense ratings.
-// Only one expedition can be active at a time (active pointer). Soldiers are a
-// real resource (config/resources.go): launching an expedition spends
-// SoldiersNeeded of the soldiers resource plus any Cost, validated and deducted
-// by the engine before LaunchExpedition is called. Soldiers are spent at launch
-// (win or lose); success vs failure differs only in reward, not soldier loss.
+//
+// One expedition per CATEGORY can be active at a time: a scouting expedition and
+// a military expedition may run concurrently. activeByCat is keyed by
+// ExpeditionScouting / ExpeditionMilitary. Soldiers are a real resource
+// (config/resources.go): launching an expedition spends SoldiersNeeded of the
+// soldiers resource plus any Cost, validated and deducted by the engine before
+// LaunchExpedition is called. Soldiers are spent at launch (win or lose);
+// success vs failure differs only in reward, not soldier loss.
 type MilitaryManager struct {
 	expeditions    []ExpeditionDef
-	active         *ActiveExpedition
+	activeByCat    map[string]*ActiveExpedition
 	completedCount int
 	totalLoot      map[string]float64
 	defenseRating  float64
@@ -54,7 +57,8 @@ type MilitaryManager struct {
 // NewMilitaryManager creates a military manager
 func NewMilitaryManager() *MilitaryManager {
 	return &MilitaryManager{
-		totalLoot: make(map[string]float64),
+		totalLoot:   make(map[string]float64),
+		activeByCat: make(map[string]*ActiveExpedition),
 		expeditions: []ExpeditionDef{
 			{
 				Name: "Scout Party", Key: "scout_party",
@@ -202,18 +206,20 @@ func (mm *MilitaryManager) ExpeditionDefByKey(key string) *ExpeditionDef {
 	return nil
 }
 
-// LaunchExpedition validates age + active status and sets up the active
-// expedition. Resource costs (soldiers + Cost) are validated and deducted by
-// the engine BEFORE this is called — this method assumes the player can afford
-// the launch and only enforces age range and the single-active-expedition rule.
+// LaunchExpedition validates age + per-category active status and sets up the
+// active expedition for its category. Resource costs (soldiers + Cost) are
+// validated and deducted by the engine BEFORE this is called — this method
+// assumes the player can afford the launch and only enforces age range and the
+// one-active-per-category rule (a scouting and a military expedition may run
+// concurrently, but not two of the same category).
 func (mm *MilitaryManager) LaunchExpedition(key, currentAge string, ageOrder map[string]int) error {
-	if mm.active != nil {
-		return fmt.Errorf("expedition '%s' already in progress (%d ticks left)", mm.active.Name, mm.active.TicksLeft)
-	}
-
 	def := mm.ExpeditionDefByKey(key)
 	if def == nil {
 		return fmt.Errorf("unknown expedition: %s", key)
+	}
+
+	if existing := mm.activeByCat[def.Category]; existing != nil {
+		return fmt.Errorf("a %s expedition is already in progress (%d ticks left)", categoryLabel(def.Category), existing.TicksLeft)
 	}
 
 	if ageOrder[def.MinAge] > ageOrder[currentAge] {
@@ -223,7 +229,7 @@ func (mm *MilitaryManager) LaunchExpedition(key, currentAge string, ageOrder map
 		return fmt.Errorf("%s is no longer available past the %s age", def.Name, def.MaxAge)
 	}
 
-	mm.active = &ActiveExpedition{
+	mm.activeByCat[def.Category] = &ActiveExpedition{
 		Key:       key,
 		Name:      def.Name,
 		Soldiers:  def.SoldiersNeeded,
@@ -232,28 +238,81 @@ func (mm *MilitaryManager) LaunchExpedition(key, currentAge string, ageOrder map
 	return nil
 }
 
-// Tick advances the active expedition by one tick. Returns non-empty rewards
-// and a message only on the tick when the expedition resolves.
+// categoryLabel returns a short player-facing word for an expedition category.
+func categoryLabel(category string) string {
+	switch category {
+	case ExpeditionScouting:
+		return "scouting"
+	case ExpeditionMilitary:
+		return "military"
+	default:
+		return category
+	}
+}
+
+// ActiveByCategory returns the active expedition for a category, or nil. Used by
+// the engine/tests; the returned pointer is the live manager state.
+func (mm *MilitaryManager) ActiveByCategory(category string) *ActiveExpedition {
+	return mm.activeByCat[category]
+}
+
+// HasActive reports whether any expedition (any category) is currently running.
+func (mm *MilitaryManager) HasActive() bool {
+	for _, exp := range mm.activeByCat {
+		if exp != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// ExpeditionResult holds the rewards + player-facing message for one expedition
+// that resolved this tick.
+type ExpeditionResult struct {
+	Rewards map[string]float64
+	Message string
+}
+
+// Tick advances every active expedition (one per category) by one tick and
+// returns a result for each that resolved this tick. Categories tick down and
+// complete independently — a scouting and a military expedition resolve on their
+// own schedules.
 //
-// Success probability: successRoll > (DifficultyBase - militaryBonus×0.3).
+// Success probability per expedition: successRoll > (DifficultyBase - militaryBonus×0.3).
 // militaryBonus reduces effective difficulty; expeditionBonus scales reward amounts.
 // Soldiers are spent at launch (win or lose); success vs failure differs only in
 // reward (full vs 30%), not in any extra soldier loss.
-func (mm *MilitaryManager) Tick(militaryBonus, expeditionBonus float64) (rewards map[string]float64, message string) {
-	if mm.active == nil {
-		return nil, ""
+func (mm *MilitaryManager) Tick(militaryBonus, expeditionBonus float64) []ExpeditionResult {
+	// Iterate categories in a stable order so resolution logs/results are
+	// deterministic regardless of map iteration order.
+	cats := []string{ExpeditionScouting, ExpeditionMilitary}
+	var results []ExpeditionResult
+	for _, cat := range cats {
+		if res, ok := mm.tickCategory(cat, militaryBonus, expeditionBonus); ok {
+			results = append(results, res)
+		}
+	}
+	return results
+}
+
+// tickCategory advances one category's active expedition. ok is true only on the
+// tick the expedition resolves (carrying its rewards + message).
+func (mm *MilitaryManager) tickCategory(category string, militaryBonus, expeditionBonus float64) (ExpeditionResult, bool) {
+	active := mm.activeByCat[category]
+	if active == nil {
+		return ExpeditionResult{}, false
 	}
 
-	mm.active.TicksLeft--
-	if mm.active.TicksLeft > 0 {
-		return nil, ""
+	active.TicksLeft--
+	if active.TicksLeft > 0 {
+		return ExpeditionResult{}, false
 	}
 
 	// Expedition complete - calculate results
-	def := mm.ExpeditionDefByKey(mm.active.Key)
+	def := mm.ExpeditionDefByKey(active.Key)
 	if def == nil {
-		mm.active = nil
-		return nil, ""
+		mm.activeByCat[category] = nil
+		return ExpeditionResult{}, false
 	}
 
 	// Success calculation: military bonus reduces difficulty
@@ -265,7 +324,8 @@ func (mm *MilitaryManager) Tick(militaryBonus, expeditionBonus float64) (rewards
 	successRoll := rand.Float64()
 	success := successRoll > difficulty
 
-	rewards = make(map[string]float64)
+	rewards := make(map[string]float64)
+	var message string
 	if success {
 		// Apply expedition reward bonus
 		rewardMult := 1.0 + expeditionBonus
@@ -285,8 +345,8 @@ func (mm *MilitaryManager) Tick(militaryBonus, expeditionBonus float64) (rewards
 	}
 
 	mm.completedCount++
-	mm.active = nil
-	return rewards, message
+	mm.activeByCat[category] = nil
+	return ExpeditionResult{Rewards: rewards, Message: message}, true
 }
 
 // GetAvailableExpeditions returns expeditions available for the current age,
@@ -323,8 +383,8 @@ func (mm *MilitaryManager) GetAvailableExpeditionsByCategory(category, currentAg
 // soldierCount is the current soldiers amount; resources is the live resource
 // map (nil → Cost treated as unaffordable).
 func (mm *MilitaryManager) launchability(def ExpeditionDef, soldierCount int, resources map[string]float64) (bool, string) {
-	if mm.active != nil {
-		return false, "expedition already in progress"
+	if mm.activeByCat[def.Category] != nil {
+		return false, fmt.Sprintf("a %s expedition is already in progress", categoryLabel(def.Category))
 	}
 	if soldierCount < def.SoldiersNeeded {
 		return false, fmt.Sprintf("need %d soldiers", def.SoldiersNeeded)
@@ -361,14 +421,8 @@ func (mm *MilitaryManager) CalculateDefense(soldierCount int, militaryBonus floa
 // currentResources may be nil, in which case Cost affordability is treated as
 // unmet (defensive; the engine always passes a real map).
 func (mm *MilitaryManager) Snapshot(currentAge string, ageOrder map[string]int, soldierCount, soldierCap int, soldierRate float64, currentResources map[string]float64, militaryBonus, expeditionBonus float64) MilitaryState {
-	var activeExp *ExpeditionSnapshot
-	if mm.active != nil {
-		activeExp = &ExpeditionSnapshot{
-			Name:      mm.active.Name,
-			Soldiers:  mm.active.Soldiers,
-			TicksLeft: mm.active.TicksLeft,
-		}
-	}
+	activeScout := snapshotActive(mm.activeByCat[ExpeditionScouting])
+	activeMilitary := snapshotActive(mm.activeByCat[ExpeditionMilitary])
 
 	available := mm.GetAvailableExpeditions(currentAge, ageOrder)
 	var expList []ExpeditionInfo
@@ -398,29 +452,75 @@ func (mm *MilitaryManager) Snapshot(currentAge string, ageOrder map[string]int, 
 		SoldierCap:       soldierCap,
 		SoldierRate:      soldierRate,
 		DefenseRating:    mm.CalculateDefense(soldierCount, militaryBonus),
-		MilitaryBonus:    militaryBonus,
-		ExpeditionBonus:  expeditionBonus,
-		ActiveExpedition: activeExp,
-		Expeditions:      expList,
-		CompletedCount:   mm.completedCount,
-		TotalLoot:        loot,
+		MilitaryBonus:   militaryBonus,
+		ExpeditionBonus: expeditionBonus,
+		ActiveScout:     activeScout,
+		ActiveMilitary:  activeMilitary,
+		Expeditions:     expList,
+		CompletedCount:  mm.completedCount,
+		TotalLoot:       loot,
 	}
 }
 
-// LoadState restores military state from save
-func (mm *MilitaryManager) LoadState(active *ActiveExpedition, completedCount int, totalLoot map[string]float64) {
-	mm.active = active
+// snapshotActive converts a live ActiveExpedition into a UI snapshot, or nil.
+func snapshotActive(active *ActiveExpedition) *ExpeditionSnapshot {
+	if active == nil {
+		return nil
+	}
+	return &ExpeditionSnapshot{
+		Name:      active.Name,
+		Soldiers:  active.Soldiers,
+		TicksLeft: active.TicksLeft,
+	}
+}
+
+// LoadState restores military state from save. scout and military are the
+// per-category active expeditions (either may be nil). Legacy single-active
+// saves are migrated by the caller (see save.go) before reaching this point.
+func (mm *MilitaryManager) LoadState(scout, military *ActiveExpedition, completedCount int, totalLoot map[string]float64) {
+	if mm.activeByCat == nil {
+		mm.activeByCat = make(map[string]*ActiveExpedition)
+	}
+	mm.activeByCat[ExpeditionScouting] = scout
+	mm.activeByCat[ExpeditionMilitary] = military
 	mm.completedCount = completedCount
 	if totalLoot != nil {
 		mm.totalLoot = totalLoot
 	}
 }
 
-// GetActiveForSave returns active expedition for saving
-func (mm *MilitaryManager) GetActiveForSave() *ActiveExpedition {
-	if mm.active == nil {
+// GetActiveForSave returns deep copies of the active scouting and military
+// expeditions for saving. Either may be nil.
+func (mm *MilitaryManager) GetActiveForSave() (scout, military *ActiveExpedition) {
+	return copyActive(mm.activeByCat[ExpeditionScouting]), copyActive(mm.activeByCat[ExpeditionMilitary])
+}
+
+// copyActive returns a deep copy of an ActiveExpedition, or nil.
+func copyActive(active *ActiveExpedition) *ActiveExpedition {
+	if active == nil {
 		return nil
 	}
-	copy := *mm.active
-	return &copy
+	c := *active
+	return &c
+}
+
+// migrateActives resolves the per-category active expeditions from a MilitarySave,
+// migrating pre-Phase-2a saves. If the new ActiveScout/ActiveMilitary fields are
+// present they win. Otherwise a legacy single-active ActiveExpedition is routed to
+// the scout or military slot by its def's Category (unknown keys default to the
+// military slot, matching pre-2a semantics where expeditions were "military").
+func (mm *MilitaryManager) migrateActives(save MilitarySave) (scout, military *ActiveExpedition) {
+	scout = save.ActiveScout
+	military = save.ActiveMilitary
+	if scout != nil || military != nil {
+		return scout, military
+	}
+	if save.ActiveExpedition == nil {
+		return nil, nil
+	}
+	legacy := save.ActiveExpedition
+	if def := mm.ExpeditionDefByKey(legacy.Key); def != nil && def.Category == ExpeditionScouting {
+		return legacy, nil
+	}
+	return nil, legacy
 }

--- a/game/military_rework_test.go
+++ b/game/military_rework_test.go
@@ -323,3 +323,184 @@ func TestMilitaryExpeditions_RequireSoldiers(t *testing.T) {
 		t.Error("no military expedition requires soldiers — classification likely broken")
 	}
 }
+
+// === Scouting / Army split (Phase 2a): concurrent per-category actives ===
+
+// TestConcurrentExpeditions_ScoutAndMilitary verifies a scouting expedition and
+// a military expedition can be active simultaneously (one per category).
+func TestConcurrentExpeditions_ScoutAndMilitary(t *testing.T) {
+	ge := NewGameEngine()
+	setAge(ge, "bronze_age")
+	setResource(ge, "food", 200)
+	setResource(ge, "wood", 200)
+	setSoldiers(ge, 20)
+
+	// scout_party is scouting (food+wood, no soldiers); raid_bandits is military
+	// (5 soldiers). Both available in bronze_age.
+	if err := ge.LaunchExpedition("scout_party"); err != nil {
+		t.Fatalf("LaunchExpedition(scout_party) error: %v", err)
+	}
+	if err := ge.LaunchExpedition("raid_bandits"); err != nil {
+		t.Fatalf("LaunchExpedition(raid_bandits) error: %v", err)
+	}
+
+	if ge.Military.ActiveByCategory(ExpeditionScouting) == nil {
+		t.Error("scouting slot empty after launching scout_party")
+	}
+	if ge.Military.ActiveByCategory(ExpeditionMilitary) == nil {
+		t.Error("military slot empty after launching raid_bandits")
+	}
+
+	// Snapshot should surface both as active.
+	state := ge.GetState()
+	if state.Military.ActiveScout == nil {
+		t.Error("Snapshot ActiveScout nil, want scout_party active")
+	}
+	if state.Military.ActiveMilitary == nil {
+		t.Error("Snapshot ActiveMilitary nil, want raid_bandits active")
+	}
+}
+
+// TestPerCategorySingleActive verifies a second expedition of the SAME category
+// is rejected while one is running, but the OTHER category is still launchable.
+func TestPerCategorySingleActive(t *testing.T) {
+	ge := NewGameEngine()
+	setAge(ge, "bronze_age")
+	setResource(ge, "food", 500)
+	setResource(ge, "wood", 500)
+	setSoldiers(ge, 50)
+
+	// Launch a scouting expedition. A second scouting one must be rejected, but a
+	// military one is allowed.
+	if err := ge.LaunchExpedition("scout_party"); err != nil {
+		t.Fatalf("LaunchExpedition(scout_party) error: %v", err)
+	}
+	if err := ge.LaunchExpedition("scout_party"); err == nil {
+		t.Error("launching a second scouting expedition should be rejected")
+	}
+	if err := ge.LaunchExpedition("raid_bandits"); err != nil {
+		t.Fatalf("military expedition should be launchable alongside scouting: %v", err)
+	}
+	// Now the military slot is occupied: a second military one must be rejected.
+	if err := ge.LaunchExpedition("raid_bandits"); err == nil {
+		t.Error("launching a second military expedition should be rejected")
+	}
+}
+
+// TestExpeditionsTickIndependently verifies both active expeditions tick down and
+// complete on their own schedules.
+func TestExpeditionsTickIndependently(t *testing.T) {
+	ge := NewGameEngine()
+	setAge(ge, "bronze_age")
+	setResource(ge, "food", 200)
+	setResource(ge, "wood", 200)
+	setSoldiers(ge, 20)
+
+	// scout_party Duration=20; raid_bandits Duration=15. The military one should
+	// finish first while the scouting one is still running.
+	if err := ge.LaunchExpedition("scout_party"); err != nil {
+		t.Fatalf("LaunchExpedition(scout_party) error: %v", err)
+	}
+	if err := ge.LaunchExpedition("raid_bandits"); err != nil {
+		t.Fatalf("LaunchExpedition(raid_bandits) error: %v", err)
+	}
+
+	// Tick 15 times: military (15) resolves, scouting (20) still has 5 left.
+	for i := 0; i < 15; i++ {
+		ge.mu.Lock()
+		ge.processExpeditions()
+		ge.mu.Unlock()
+	}
+	if ge.Military.ActiveByCategory(ExpeditionMilitary) != nil {
+		t.Error("military expedition (Duration 15) should have resolved after 15 ticks")
+	}
+	if ge.Military.ActiveByCategory(ExpeditionScouting) == nil {
+		t.Error("scouting expedition (Duration 20) should still be running after 15 ticks")
+	}
+
+	// 5 more ticks: scouting resolves too.
+	for i := 0; i < 5; i++ {
+		ge.mu.Lock()
+		ge.processExpeditions()
+		ge.mu.Unlock()
+	}
+	if ge.Military.ActiveByCategory(ExpeditionScouting) != nil {
+		t.Error("scouting expedition should have resolved after 20 ticks total")
+	}
+	if ge.Military.HasActive() {
+		t.Error("no expedition should remain active after both resolved")
+	}
+}
+
+// TestConcurrentExpeditions_SaveRoundTrip verifies both active expeditions
+// survive GetActiveForSave + LoadState.
+func TestConcurrentExpeditions_SaveRoundTrip(t *testing.T) {
+	ge := NewGameEngine()
+	setAge(ge, "bronze_age")
+	setResource(ge, "food", 200)
+	setResource(ge, "wood", 200)
+	setSoldiers(ge, 20)
+
+	if err := ge.LaunchExpedition("scout_party"); err != nil {
+		t.Fatalf("LaunchExpedition(scout_party) error: %v", err)
+	}
+	if err := ge.LaunchExpedition("raid_bandits"); err != nil {
+		t.Fatalf("LaunchExpedition(raid_bandits) error: %v", err)
+	}
+
+	scout, military := ge.Military.GetActiveForSave()
+	if scout == nil || scout.Key != "scout_party" {
+		t.Fatalf("GetActiveForSave scout = %+v, want scout_party", scout)
+	}
+	if military == nil || military.Key != "raid_bandits" {
+		t.Fatalf("GetActiveForSave military = %+v, want raid_bandits", military)
+	}
+
+	// Restore into a fresh manager and confirm both slots come back.
+	mm := NewMilitaryManager()
+	mm.LoadState(scout, military, 0, nil)
+	if got := mm.ActiveByCategory(ExpeditionScouting); got == nil || got.Key != "scout_party" {
+		t.Errorf("after LoadState scouting slot = %+v, want scout_party", got)
+	}
+	if got := mm.ActiveByCategory(ExpeditionMilitary); got == nil || got.Key != "raid_bandits" {
+		t.Errorf("after LoadState military slot = %+v, want raid_bandits", got)
+	}
+}
+
+// TestLegacyActiveExpedition_MigratesByCategory verifies a pre-Phase-2a save with
+// only the deprecated ActiveExpedition field is routed to the correct slot by the
+// expedition's Category.
+func TestLegacyActiveExpedition_MigratesByCategory(t *testing.T) {
+	mm := NewMilitaryManager()
+
+	// Legacy military key → military slot.
+	milSave := MilitarySave{ActiveExpedition: &ActiveExpedition{Key: "raid_bandits", Name: "Raid Bandit Camp", Soldiers: 5, TicksLeft: 7}}
+	scout, military := mm.migrateActives(milSave)
+	if scout != nil {
+		t.Errorf("legacy military expedition leaked into scouting slot: %+v", scout)
+	}
+	if military == nil || military.Key != "raid_bandits" {
+		t.Errorf("legacy military expedition not routed to military slot: %+v", military)
+	}
+
+	// Legacy scouting key → scouting slot.
+	scoutSave := MilitarySave{ActiveExpedition: &ActiveExpedition{Key: "scout_party", Name: "Scout Party", Soldiers: 0, TicksLeft: 11}}
+	scout, military = mm.migrateActives(scoutSave)
+	if military != nil {
+		t.Errorf("legacy scouting expedition leaked into military slot: %+v", military)
+	}
+	if scout == nil || scout.Key != "scout_party" {
+		t.Errorf("legacy scouting expedition not routed to scouting slot: %+v", scout)
+	}
+
+	// New fields present → legacy ignored.
+	bothSave := MilitarySave{
+		ActiveScout:      &ActiveExpedition{Key: "scout_party", TicksLeft: 3},
+		ActiveMilitary:   &ActiveExpedition{Key: "raid_bandits", TicksLeft: 4},
+		ActiveExpedition: &ActiveExpedition{Key: "conquer_territory", TicksLeft: 99},
+	}
+	scout, military = mm.migrateActives(bothSave)
+	if scout == nil || scout.Key != "scout_party" || military == nil || military.Key != "raid_bandits" {
+		t.Errorf("new fields should win over legacy: scout=%+v military=%+v", scout, military)
+	}
+}

--- a/game/save.go
+++ b/game/save.go
@@ -169,9 +169,18 @@ type ResearchSave struct {
 	TotalTicks  int      `json:"total_ticks"`
 }
 
-// MilitarySave holds military state for save
+// MilitarySave holds military state for save.
+//
+// ActiveScout / ActiveMilitary are the per-category active expeditions (Phase 2a:
+// a scouting and a military expedition can run concurrently). ActiveExpedition is
+// the deprecated single-active field from pre-2a saves, kept read-only for
+// migration — on load it is routed to the correct category slot by its def's
+// Category (see migrateLegacyActive). It is never written by new saves.
 type MilitarySave struct {
-	ActiveExpedition *ActiveExpedition  `json:"active_expedition"`
+	ActiveScout    *ActiveExpedition `json:"active_scout,omitempty"`
+	ActiveMilitary *ActiveExpedition `json:"active_military,omitempty"`
+	// Deprecated: pre-Phase-2a single-active field, read-only for migration.
+	ActiveExpedition *ActiveExpedition  `json:"active_expedition,omitempty"`
 	CompletedCount   int                `json:"completed_count"`
 	TotalLoot        map[string]float64 `json:"total_loot"`
 }
@@ -286,6 +295,9 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 		totalLoot[k] = v
 	}
 
+	// Per-category active expeditions (Phase 2a: scouting + military concurrent).
+	activeScout, activeMilitary := ge.Military.GetActiveForSave()
+
 	// Deep copy prestige upgrades
 	upgrades := make(map[string]int, len(ge.Prestige.upgrades))
 	for k, v := range ge.Prestige.upgrades {
@@ -347,9 +359,10 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 			TotalTicks:  ge.Research.totalTicks,
 		},
 		Military: MilitarySave{
-			ActiveExpedition: ge.Military.GetActiveForSave(),
-			CompletedCount:   ge.Military.completedCount,
-			TotalLoot:        totalLoot,
+			ActiveScout:    activeScout,
+			ActiveMilitary: activeMilitary,
+			CompletedCount: ge.Military.completedCount,
+			TotalLoot:      totalLoot,
 		},
 		Events: EventSave{
 			LastFired:     ge.Events.GetLastFired(),
@@ -499,7 +512,8 @@ func (ge *GameEngine) LoadGame(filename string) error {
 
 	// Restore Phase 3 systems
 	ge.Research.LoadState(save.Research.Researched, save.Research.CurrentTech, save.Research.TicksLeft, save.Research.TotalTicks)
-	ge.Military.LoadState(save.Military.ActiveExpedition, save.Military.CompletedCount, save.Military.TotalLoot)
+	scoutActive, militaryActive := ge.Military.migrateActives(save.Military)
+	ge.Military.LoadState(scoutActive, militaryActive, save.Military.CompletedCount, save.Military.TotalLoot)
 	ge.Events.LoadState(save.Events.LastFired, save.Events.Active, save.Events.NextEventTick, save.Events.GoodStreak, save.Events.BadStreak)
 	ge.Milestones.LoadState(save.Milestones, save.ChainsCompleted, save.CurrentTitle)
 	// Reconstruct chains and title for old saves that don't have them

--- a/game/types.go
+++ b/game/types.go
@@ -237,13 +237,17 @@ type MilitaryState struct {
 	// production rate (net). Both are populated from the soldiers resource.
 	SoldierCap       int
 	SoldierRate      float64
-	DefenseRating    float64
-	MilitaryBonus    float64
-	ExpeditionBonus  float64
-	ActiveExpedition *ExpeditionSnapshot
-	Expeditions      []ExpeditionInfo
-	CompletedCount   int
-	TotalLoot        map[string]float64
+	DefenseRating   float64
+	MilitaryBonus   float64
+	ExpeditionBonus float64
+	// ActiveScout / ActiveMilitary are the per-category active expeditions. A
+	// scouting and a military expedition can run concurrently, so either, both,
+	// or neither may be non-nil.
+	ActiveScout    *ExpeditionSnapshot
+	ActiveMilitary *ExpeditionSnapshot
+	Expeditions    []ExpeditionInfo
+	CompletedCount int
+	TotalLoot      map[string]float64
 }
 
 // ExpeditionSnapshot represents an active expedition for UI

--- a/site/docs/military.md
+++ b/site/docs/military.md
@@ -65,7 +65,7 @@ Spent or lost soldiers are simply removed from the stockpile. To replenish, keep
 army
 ```
 
-Opens the army overlay showing current soldier count, defense rating, active expedition (if any), and completed expedition count.
+Opens the army overlay showing current soldier count, defense rating, active expeditions (a scouting and a military expedition can run concurrently, one of each kind), and completed expedition count.
 
 ---
 
@@ -115,7 +115,7 @@ Expeditions are timed missions launched from your stockpiles. They come in **two
 - **Scouting** (`scout_party`, `scout_ruins`, `naval_expedition`) — cost only a resource `Cost`, **0 soldiers**. These are available early, before the `soldiers` resource exists at the Iron Age.
 - **Military campaigns** (everything else — 13 of them) — **spend the soldiers resource** to launch, plus any additional resource `Cost`.
 
-Whatever the kind, the cost is deducted from your stockpiles the moment you launch — there's no refund. After a set number of ticks, the expedition resolves. **Success and failure differ only in the size of the reward, not the cost:** the soldiers and/or resources are spent either way. A successful run pays full loot; a failed run pays a reduced amount. Only **one expedition can be active at a time**.
+Whatever the kind, the cost is deducted from your stockpiles the moment you launch — there's no refund. After a set number of ticks, the expedition resolves. **Success and failure differ only in the size of the reward, not the cost:** the soldiers and/or resources are spent either way. A successful run pays full loot; a failed run pays a reduced amount. **One expedition of each kind can be active at a time:** a scouting expedition and a military campaign can run concurrently, but you can't launch a second of the same kind while one is still in progress.
 
 ### Cost, gating, and rewards
 

--- a/ui/input.go
+++ b/ui/input.go
@@ -850,9 +850,14 @@ func cmdExpeditionList(engine *game.GameEngine) CommandResult {
 	appendExpeditionGroup(&lines, "Scouting", state.Military.Expeditions, game.ExpeditionScouting)
 	appendExpeditionGroup(&lines, "Military Campaigns", state.Military.Expeditions, game.ExpeditionMilitary)
 
-	if state.Military.ActiveExpedition != nil {
-		lines = append(lines, fmt.Sprintf("\n[yellow]Active: %s (%d ticks left)[-]",
-			state.Military.ActiveExpedition.Name, state.Military.ActiveExpedition.TicksLeft))
+	// A scouting and a military expedition can run concurrently (one per kind).
+	if state.Military.ActiveScout != nil {
+		lines = append(lines, fmt.Sprintf("\n[yellow]Active scouting: %s (%d ticks left)[-]",
+			state.Military.ActiveScout.Name, state.Military.ActiveScout.TicksLeft))
+	}
+	if state.Military.ActiveMilitary != nil {
+		lines = append(lines, fmt.Sprintf("\n[yellow]Active military: %s (%d ticks left)[-]",
+			state.Military.ActiveMilitary.Name, state.Military.ActiveMilitary.TicksLeft))
 	}
 
 	if len(state.Military.Expeditions) == 0 {

--- a/ui/overlay_military.go
+++ b/ui/overlay_military.go
@@ -49,15 +49,14 @@ func militaryProvider(state game.GameState, _ int) string {
 		}
 	}
 
-	// === Active Expedition ===
-	sb.WriteString("\n [gold]═══ Active Expedition ═══[-]\n\n")
-	if mil.ActiveExpedition != nil {
-		exp := mil.ActiveExpedition
-		fmt.Fprintf(&sb, " [yellow]Name:[-]     %s\n", exp.Name)
-		fmt.Fprintf(&sb, " [yellow]Soldiers:[-] %d deployed\n", exp.Soldiers)
-		fmt.Fprintf(&sb, " [yellow]Remaining:[-] %d ticks\n", exp.TicksLeft)
+	// === Active Expeditions ===
+	// A scouting and a military expedition can run concurrently (one per kind).
+	sb.WriteString("\n [gold]═══ Active Expeditions ═══[-]\n\n")
+	if mil.ActiveScout == nil && mil.ActiveMilitary == nil {
+		sb.WriteString(" [gray]No active expeditions[-]\n")
 	} else {
-		sb.WriteString(" [gray]No active expedition[-]\n")
+		writeActiveExpedition(&sb, "Scouting", mil.ActiveScout)
+		writeActiveExpedition(&sb, "Military", mil.ActiveMilitary)
 	}
 	fmt.Fprintf(&sb, "\n [gray]Completed: %d expedition(s)[-]\n", mil.CompletedCount)
 
@@ -96,6 +95,20 @@ func militaryProvider(state game.GameState, _ int) string {
 	sb.WriteString("\n [gray]Commands: expedition <key>[-]\n")
 
 	return sb.String()
+}
+
+// writeActiveExpedition renders one active expedition under a kind label
+// (e.g. "Scouting"). Nothing is written when exp is nil, so the section only
+// lists kinds that are actually running.
+func writeActiveExpedition(sb *strings.Builder, label string, exp *game.ExpeditionSnapshot) {
+	if exp == nil {
+		return
+	}
+	fmt.Fprintf(sb, " [yellow]%s:[-] %s", label, exp.Name)
+	if exp.Soldiers > 0 {
+		fmt.Fprintf(sb, " — %d deployed", exp.Soldiers)
+	}
+	fmt.Fprintf(sb, " (%d ticks left)\n", exp.TicksLeft)
 }
 
 // writeExpeditionGroup renders the subset of exps matching category under a


### PR DESCRIPTION
## Phase 2a — backend: concurrent scout + military expeditions

A scouting expedition and a military expedition can now run **at the same time** (one active per category). No `scout` command or panel split yet — that's 2b.

- `MilitaryManager.active` (single) → `activeByCat` map keyed by category. Launch + launchability enforce single-active **per category**, so a scout no longer blocks a campaign and vice-versa. `Tick()` drives both slots independently and returns `[]ExpeditionResult`.
- **Save migration:** state splits into `active_scout` + `active_military`; a legacy single `active_expedition` is routed to its category's slot via `ExpeditionDefByKey().Category` (scouting → scout, else military). Old saves load cleanly.
- `MilitaryState` exposes `ActiveScout` + `ActiveMilitary`; the overlay and `expedition list` show both.

### Tests
Concurrent scout+military active, per-category single-active (a scout doesn't block a campaign), independent tick/complete, save round-trip with both active, legacy migration by category. `go build/vet/test` green.

### Next
**2b** — the `scout` command + Scouting panel; `army` panel reduced to military only.

Trello: https://trello.com/c/qPhJ5YxH
