### PR TITLE
feat(military): split into Expeditions (scouting) + Army campaigns (phase 2b)

### DIFF
--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -75,22 +75,32 @@ Tech keys are shown in the **Research** overlay (`research`) (dim grey when lock
 
 ---
 
-## Military
+## Expeditions & Army
 
 | Command | Description |
 |---|---|
-| `expedition list` | List expeditions available in your current age (shorthand: `exp list`) |
-| `expedition <key>` | Launch an expedition — spends its soldier cost (shorthand: `exp <key>`) |
+| `expedition` | Open the **Expeditions** panel — scouting missions (shorthand: `exp`) |
+| `expedition list` | List scouting expeditions available in your current age (shorthand: `exp list`) |
+| `expedition <key>` | Send a scouting expedition — costs resources, never soldiers (e.g. `expedition scout_ruins`; shorthand: `exp <key>`) |
+| `army` | Open the **Army** panel — soldier overview and military campaigns |
+| `campaign list` | List military campaigns available in your current age (`campaign` alone does the same) |
+| `campaign <key>` | Wage a military campaign — spends soldiers, plus any resource cost (e.g. `campaign raid_bandits`) |
 | `speed [multiplier]` | Set game speed (1.0, 1.5, 2.0 … +0.5 per wonder built) |
 
 ```
+expedition
 expedition list
 expedition scout_party
 expedition scout_ruins
+army
+campaign list
+campaign raid_bandits
 speed 1.5
 ```
 
-Expeditions come in two kinds. **Scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) cost only resources — **0 soldiers** — and are available early, before the `soldiers` resource exists at the Iron Age. **Military campaigns** (everything else) **spend the `soldiers` resource** at launch, plus any resource cost. Either way the cost is deducted whether the run succeeds or fails; only the reward differs, and only one expedition can be active at a time. The **Military** overlay (`army`) groups available expeditions under **Scouting** and **Military Campaigns** headers (display grouping only — the commands above are unchanged).
+Timed missions come in two kinds, split across two panels. **Scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) cost only resources — **0 soldiers** — and are available early, before the `soldiers` resource exists at the Iron Age. You go on these with `expedition <key>` from the **Expeditions** panel. **Military campaigns** (everything else) **spend the `soldiers` resource** at launch, plus any resource cost. You wage these with `campaign <key>` from the **Army** panel. Either way the cost is deducted whether the run succeeds or fails; only the reward differs. One scouting expedition **and** one military campaign can run at the same time (one of each category), but not two of the same category.
+
+Keys with underscores can be typed with spaces: `expedition scout ruins` is equivalent to `expedition scout_ruins`. If you run a campaign key through `expedition` the game refuses and points you to `campaign <key>`; likewise running a scouting key through `campaign` redirects you to `expedition <key>`.
 
 ---
 

--- a/site/docs/military.md
+++ b/site/docs/military.md
@@ -8,7 +8,7 @@ The military system is one of AgeForge's primary engines of wealth. Soldiers def
 
 The military system does four things:
 
-- **Expeditions** — spend stockpiled soldiers on timed missions that return resources, gold, and knowledge on success.
+- **Campaigns** — spend stockpiled soldiers on timed military missions that return resources, gold, and knowledge on success (waged with `campaign <key>`). Soldier-free **scouting expeditions** (`expedition <key>`) cover the same ground without troops — see [§4](#4-expeditions).
 - **Defense rating** — a passive stat derived from soldier count and military bonuses that reduces damage from hostile epoch events.
 - **Milestones** — five military milestones grant permanent `military_power` bonuses and chain into a title reward.
 - **Prestige** — prestige upgrades `military_power` and `expedition_loot` carry over through resets, compounding across runs.
@@ -26,11 +26,11 @@ Expeditions come in **two kinds**:
 
 ### What soldiers are
 
-Soldiers are a stockpiled **resource** (`soldiers`), unlocked at the **Iron Age**. You don't count heads in a worker pool — you bank soldiers the way you bank food or wood, then spend them launching expeditions.
+Soldiers are a stockpiled **resource** (`soldiers`), unlocked at the **Iron Age**. You don't count heads in a worker pool — you bank soldiers the way you bank food or wood, then spend them waging campaigns.
 
 - **Production:** Military buildings produce soldiers every tick when military-domain workers are assigned to them. Production is worker-scaled — a fully-staffed military building produces roughly its **soldier cap ÷ 50** soldiers per tick (minimum 0.1/tick). Assign more military workers, build more military buildings → soldiers accrue faster.
 - **Storage:** Your soldier cap equals the **sum of every military building's soldier cap**. Building or upgrading military buildings is the *only* way to raise the ceiling — the Storage lineage does not hold soldiers.
-- **Spending:** Expeditions deduct their soldier cost from your stockpile at launch (see [§4](#4-expeditions)).
+- **Spending:** Military campaigns deduct their soldier cost from your stockpile at launch (see [§4](#4-expeditions)).
 
 ### Producing soldiers
 
@@ -65,7 +65,7 @@ Spent or lost soldiers are simply removed from the stockpile. To replenish, keep
 army
 ```
 
-Opens the army overlay showing current soldier count, defense rating, active expeditions (a scouting and a military expedition can run concurrently, one of each kind), and completed expedition count.
+Opens the **Army** panel showing current soldier count, defense rating, the active military **campaign** (if any), and completed campaign count. The active scouting expedition lives in the separate **Expeditions** panel (`expedition`) — one scouting expedition and one military campaign can run concurrently, one of each category.
 
 ---
 
@@ -115,7 +115,7 @@ Expeditions are timed missions launched from your stockpiles. They come in **two
 - **Scouting** (`scout_party`, `scout_ruins`, `naval_expedition`) — cost only a resource `Cost`, **0 soldiers**. These are available early, before the `soldiers` resource exists at the Iron Age.
 - **Military campaigns** (everything else — 13 of them) — **spend the soldiers resource** to launch, plus any additional resource `Cost`.
 
-Whatever the kind, the cost is deducted from your stockpiles the moment you launch — there's no refund. After a set number of ticks, the expedition resolves. **Success and failure differ only in the size of the reward, not the cost:** the soldiers and/or resources are spent either way. A successful run pays full loot; a failed run pays a reduced amount. **One expedition of each kind can be active at a time:** a scouting expedition and a military campaign can run concurrently, but you can't launch a second of the same kind while one is still in progress.
+Whatever the kind, the cost is deducted from your stockpiles the moment you launch — there's no refund. After a set number of ticks, the mission resolves. **Success and failure differ only in the size of the reward, not the cost:** the soldiers and/or resources are spent either way. A successful run pays full loot; a failed run pays a reduced amount. **One mission of each category can be active at a time:** a scouting expedition and a military campaign can run concurrently, but you can't launch a second of the same category while one is still in progress.
 
 ### Cost, gating, and rewards
 
@@ -126,16 +126,23 @@ Whatever the kind, the cost is deducted from your stockpiles the moment you laun
 
 ### Commands
 
+Scouting and military missions live on two separate command surfaces:
+
 ```
-expedition list         # Show all expeditions available in your current age
-expedition <key>        # Launch an expedition (e.g., expedition scout_ruins)
+expedition list         # Show scouting expeditions available in your current age
+expedition <key>        # Send a scouting expedition (e.g., expedition scout_ruins) — costs resources, never soldiers
 exp list                # Shorthand
 exp <key>               # Shorthand
+
+campaign list           # Show military campaigns available in your current age
+campaign <key>          # Wage a military campaign (e.g., campaign raid_bandits) — spends soldiers
 ```
 
-Keys with underscores can be typed with spaces and are joined: `expedition scout ruins` is equivalent to `expedition scout_ruins`.
+`expedition` with no args opens the **Expeditions** panel; `campaign` (or `campaign list`) lists the available campaigns; `army` opens the **Army** panel. Keys with underscores can be typed with spaces and are joined: `expedition scout ruins` is equivalent to `expedition scout_ruins`.
 
-The **Military** overlay (`army`) groups the expeditions available in your current age into two subsections — **Scouting** and **Military Campaigns** — so you can see at a glance which ones need soldiers and which are resource-only. This is a display grouping; the commands are unchanged (`expedition list`, `expedition <key>`).
+The two surfaces are kept distinct, and the game cross-redirects if you mix them up: running a military key through `expedition` (e.g. `expedition raid_bandits`) is refused with a note to use `campaign <key>` instead, and running a scouting key through `campaign` redirects you to `expedition <key>`.
+
+The **Expeditions** panel (`expedition`) lists only the **scouting** expeditions available in your current age — the resource-only missions. The **Army** panel (`army`) lists only the **military campaigns** — the ones that spend soldiers — alongside your soldier count and defense rating. So you can see at a glance which missions are which: scouting on the Expeditions panel, campaigns on the Army panel.
 
 ### Success probability formula
 
@@ -157,7 +164,7 @@ The soldier (and resource) cost is already spent at launch, so the outcome only 
 
 ### Full expedition table
 
-The **Soldier Cost** column is spent from the `soldiers` resource at launch (not a soldier headcount requirement). The three **scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) show **0** in that column and instead charge a resource `Cost`; the **military campaigns** spend soldiers plus any resource `Cost`. Both are noted in the table.
+This is a reference table of **all** missions, scouting and campaigns alike. The three **scouting** expeditions (`scout_party`, `scout_ruins`, `naval_expedition`) are launched with `expedition <key>`; every other mission is a **campaign**, launched with `campaign <key>`. The **Soldier Cost** column is spent from the `soldiers` resource at launch (not a soldier headcount requirement). The scouting rows show **0** in that column and instead charge a resource `Cost`; the campaigns spend soldiers plus any resource `Cost`.
 
 | Key | Name | Min Age | Soldier Cost | Resource Cost | Duration | Difficulty | Rewards on Success |
 |-----|------|---------|--------------|---------------|----------|------------|-------------------|
@@ -178,11 +185,11 @@ The **Soldier Cost** column is spent from the `soldiers` resource at launch (not
 | `galactic_conquest` | Galactic Conquest | Galactic Age | 80 | — | 80t | 0.80 | 30 antimatter, 100 dark matter, 5,000 gold |
 | `quantum_incursion` | Quantum Incursion | Quantum Age | 100 | — | 90t | 0.85 | 20 quantum flux, 50 antimatter, 5,000 knowledge |
 
-That's **16 expeditions** in total.
+That's **16 missions** in total — 3 scouting expeditions and 13 military campaigns.
 
 **Scouting — the soldier-free expeditions.** Before the Iron Age there is no military worker domain and no `soldiers` resource, so the military campaigns aren't available. The **scouting** expeditions fill that gap — `scout_party` (primitive → bronze) and then `scout_ruins` (bronze age) are available without soldiers, charging only resources. `scout_party`: *"A small band of foragers scouts nearby territory for resources."* It costs **30 food + 30 wood**, needs **0 soldiers**, runs ~20 ticks, and rewards roughly **60 food / 60 wood / 20 stone** — a net resource gain worth running on repeat through the Primitive, Stone, and Bronze ages. It has a `MaxAge` of Bronze Age and disappears once you reach the Iron Age. `scout_ruins` (Bronze Age, 0 soldiers, 40 food + 30 wood) carries scouting forward, and `naval_expedition` (Renaissance Age, 0 soldiers, 150 food + 100 wood) is the late scouting option.
 
-**Tip:** `trade_escort` (Iron Age, 3 soldiers, 12t, 0.30 difficulty) is the workhorse of early *soldier* play — cheap, short, and chainable for consistent gold. For soldier-free resource throughput, chain the scouting expeditions (`scout_party`, then `scout_ruins`) — low difficulty, short duration, and no soldiers required.
+**Tip:** `campaign trade_escort` (Iron Age, 3 soldiers, 12t, 0.30 difficulty) is the workhorse of early *soldier* play — cheap, short, and chainable for consistent gold. For soldier-free resource throughput, chain the scouting expeditions (`expedition scout_party`, then `expedition scout_ruins`) — low difficulty, short duration, and no soldiers required.
 
 ---
 
@@ -272,23 +279,23 @@ The five military milestones form a chain. Completing the full chain grants a pe
 
 ### Early game (Iron Age to Classical Age)
 
-- Before Iron Age, run `scout_party` on repeat — 0 soldiers, just 30 food + 30 wood for a ~60 food / 60 wood / 20 stone payout. It's free resource throughput while you wait for the military domain.
+- Before Iron Age, run `expedition scout_party` on repeat — 0 soldiers, just 30 food + 30 wood for a ~60 food / 60 wood / 20 stone payout. It's free resource throughput while you wait for the military domain.
 - Build a **War Camp** in the Stone Age even though soldiers aren't possible yet — it prepares your soldier storage and starts producing the moment the domain unlocks.
 - Your first soldiers become available in **Iron Age** via the Hunting Lodge. Stockpile 5 quickly to land `first_soldiers` for the free +0.05 bonus.
-- `trade_escort` (spends 3 soldiers, Iron Age) is your best early soldier expedition — cheap, fast duration (12t), reasonable gold reward.
+- `campaign trade_escort` (spends 3 soldiers, Iron Age) is your best early campaign — cheap, fast duration (12t), reasonable gold reward.
 - Keep food workers prioritised. Military workers eat 2.0 food/tick each at this stage — a 10-soldier army demands 20 food/tick just to sustain itself.
 
 ### Mid game (Classical to Industrial Age)
 
 - Push `iron_legion` (300 soldiers + 5 Barracks) — the +0.10 bonus noticeably improves expedition success on harder missions.
-- `conquer_territory` (10 soldiers, 25t, 0.60 difficulty) is the best soldier-spend bang-for-tick in this range. `naval_expedition` is now a **scouting** option — 0 soldiers, just 150 food + 100 wood (Renaissance Age, 35t, 0.50 difficulty) — so you can run it without dipping into your soldier stockpile.
+- `campaign conquer_territory` (10 soldiers, 25t, 0.60 difficulty) is the best soldier-spend bang-for-tick in this range. `expedition naval_expedition` is a **scouting** option — 0 soldiers, just 150 food + 100 wood (Renaissance Age, 35t, 0.50 difficulty) — so you can run it without dipping into your soldier stockpile.
 - Build **Legion Forts** and **Military Academies** to raise your soldier ceiling. The capacity doubling per tier means each new building unlocks dramatically more troops.
 - Research military-flavored techs as they appear — even +0.2 military_power makes a visible difference against 0.6-difficulty expeditions.
 
 ### Late game (Modern Age onward)
 
-- `world_domination` spends 50 soldiers but pays 1,000 gold — worth the queue for gold-hungry ages once your soldier production can refill the cost.
-- `cyber_raid` and `neon_heist` are the best value in the digital/cyberpunk range. `neon_heist` (0.55 difficulty) is easier than `cyber_raid` (0.60) for comparable loot.
+- `campaign world_domination` spends 50 soldiers but pays 1,000 gold — worth the queue for gold-hungry ages once your soldier production can refill the cost.
+- `campaign cyber_raid` and `campaign neon_heist` are the best value in the digital/cyberpunk range. `neon_heist` (0.55 difficulty) is easier than `cyber_raid` (0.60) for comparable loot.
 - Buy `expedition_loot` prestige upgrades across resets — at tier 5 (+25% rewards) stacked with research bonuses, expedition returns scale dramatically.
 - The `military_superpower` milestone (+0.15 bonus) combined with late-game research can push effective difficulty on most expeditions to the 0.05 floor.
 
@@ -329,7 +336,7 @@ See [Morale](morale.md) for the full banded system.
 
 **Don't recruit past your food income.** A food deficit stalls all production (workers can't work when starving). Calculate the drain before `recruit max`.
 
-**Don't launch high-difficulty expeditions without military power.** `siege_castle` (0.70) and `world_domination` (0.80) fail frequently with zero bonus. Research a few military techs first and watch the success probability change.
+**Don't wage high-difficulty campaigns without military power.** `campaign siege_castle` (0.70) and `campaign world_domination` (0.80) fail frequently with zero bonus. Research a few military techs first and watch the success probability change.
 
 **Expedition failure still costs the launch.** The soldiers (and any resource cost) are spent the moment you launch — failure doesn't refund them, it only shrinks the reward. Don't launch a high-difficulty run unless you can afford to lose the soldier cost for a reduced payout.
 

--- a/ui/autocomplete.go
+++ b/ui/autocomplete.go
@@ -24,6 +24,7 @@ var commands = []string{
 	"sell",
 	"research", "res",
 	"expedition", "exp",
+	"campaign",
 	"trade", "t",
 	"diplomacy", "dip",
 	"catastrophe", "cat",
@@ -134,7 +135,12 @@ func suggestArg(cmd string, completed []string, partial string, prefix string, e
 		return filterPrefix(keys, partial, prefix)
 
 	case "expedition", "exp":
-		keys := availableExpeditionKeys(state)
+		keys := expeditionKeysByCategory(state, game.ExpeditionScouting)
+		keys = append(keys, "list")
+		return filterPrefix(keys, partial, prefix)
+
+	case "campaign":
+		keys := expeditionKeysByCategory(state, game.ExpeditionMilitary)
 		keys = append(keys, "list")
 		return filterPrefix(keys, partial, prefix)
 
@@ -356,13 +362,16 @@ func availableTechKeys(state game.GameState) []string {
 	return keys
 }
 
-// availableExpeditionKeys returns all expedition keys visible in the military state.
-// Unlike tech/building keys, this includes both launchable and locked expeditions —
-// the engine enforces eligibility on launch.
-func availableExpeditionKeys(state game.GameState) []string {
+// expeditionKeysByCategory returns the visible expedition keys for a single
+// category (game.ExpeditionScouting or game.ExpeditionMilitary), sorted. Used so
+// `expedition <key>` completes to scouting keys and `campaign <key>` to military
+// keys. This includes locked entries — the engine enforces eligibility on launch.
+func expeditionKeysByCategory(state game.GameState, category string) []string {
 	var keys []string
 	for _, exp := range state.Military.Expeditions {
-		keys = append(keys, exp.Key)
+		if exp.Category == category {
+			keys = append(keys, exp.Key)
+		}
 	}
 	sort.Strings(keys)
 	return keys

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -92,7 +92,8 @@ func NewDashboard(app *tview.Application, engine *game.GameEngine, pages *tview.
 	})
 	d.overlayMgr.Register("milestones", "Milestones", milestonesProvider)
 	d.overlayMgr.Register("techs", "Research", researchProvider)
-	d.overlayMgr.Register("army", "Military", militaryProvider)
+	d.overlayMgr.Register("army", "Army", militaryProvider)
+	d.overlayMgr.Register("expedition", "Expeditions", expeditionsProvider)
 	d.overlayMgr.Register("trade", "Trade", tradeProvider)
 	d.overlayMgr.Register("stats", "Statistics", statsProvider)
 	d.overlayMgr.Register("wonders", "Wonders", wondersProvider)
@@ -387,7 +388,7 @@ func (d *Dashboard) updateSidebar(activeOverlay string) {
 }
 
 func buildSidebarText(active string) string {
-	commands := []string{"milestones", "research", "army", "trade", "stats", "wonders", "workers", "logs", "epoch", "history", "map", "help"}
+	commands := []string{"milestones", "research", "expedition", "army", "trade", "stats", "wonders", "workers", "logs", "epoch", "history", "map", "help"}
 	var sb strings.Builder
 	sb.WriteString("\n")
 	for _, cmd := range commands {

--- a/ui/expedition_cmd_test.go
+++ b/ui/expedition_cmd_test.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// newExpeditionTestEngine spins up a fresh engine in the Bronze Age, stocked
+// with enough food/wood/soldiers to launch the early scouting/military
+// expeditions used by these tests. scout_party (scouting) and raid_bandits
+// (military) both unlock by the Bronze Age. The age jump uses the dev console
+// (/age applies the age's unlocks); resource amounts are set via LoadAmounts so
+// they bypass nominal storage caps.
+func newExpeditionTestEngine(t *testing.T) *game.GameEngine {
+	t.Helper()
+
+	prevDev := game.DevModeActive
+	game.DevModeActive = true
+	t.Cleanup(func() { game.DevModeActive = prevDev })
+
+	engine := game.NewGameEngine()
+	if msg := game.DevExecCommand("/age bronze_age", engine); msg != "jumped to bronze_age" {
+		t.Fatalf("dev /age bronze_age failed: %q", msg)
+	}
+	engine.Resources.LoadAmounts(map[string]float64{
+		"food":     500,
+		"wood":     500,
+		"soldiers": 50,
+	})
+	return engine
+}
+
+// TestCmdExpeditionNoArgsOpensPanel verifies bare `expedition` opens the
+// Expeditions panel rather than launching anything.
+func TestCmdExpeditionNoArgsOpensPanel(t *testing.T) {
+	engine := newExpeditionTestEngine(t)
+
+	res := cmdExpedition(nil, engine)
+	if res.OverlayName != "expedition" {
+		t.Errorf("cmdExpedition(nil) OverlayName = %q, want %q", res.OverlayName, "expedition")
+	}
+}
+
+// TestCmdExpeditionMilitaryKeyRedirects verifies a MILITARY key passed to
+// `expedition` returns the redirect-to-campaign info message and does NOT
+// launch (no active scout, no active military).
+func TestCmdExpeditionMilitaryKeyRedirects(t *testing.T) {
+	engine := newExpeditionTestEngine(t)
+
+	res := cmdExpedition([]string{"raid", "bandits"}, engine)
+	if res.Type != "info" {
+		t.Errorf("cmdExpedition(raid_bandits) Type = %q, want %q", res.Type, "info")
+	}
+	if !strings.Contains(res.Message, "campaign raid_bandits") {
+		t.Errorf("cmdExpedition(raid_bandits) message = %q, want it to redirect to 'campaign raid_bandits'", res.Message)
+	}
+	st := engine.GetState()
+	if st.Military.ActiveScout != nil || st.Military.ActiveMilitary != nil {
+		t.Errorf("redirect should not launch anything; got scout=%v military=%v", st.Military.ActiveScout, st.Military.ActiveMilitary)
+	}
+}
+
+// TestCmdExpeditionScoutingKeyLaunches verifies a SCOUTING key launches and
+// sets the active scout.
+func TestCmdExpeditionScoutingKeyLaunches(t *testing.T) {
+	engine := newExpeditionTestEngine(t)
+
+	res := cmdExpedition([]string{"scout", "party"}, engine)
+	if res.Type != "success" {
+		t.Fatalf("cmdExpedition(scout_party) Type = %q (msg %q), want %q", res.Type, res.Message, "success")
+	}
+	if st := engine.GetState(); st.Military.ActiveScout == nil {
+		t.Errorf("after launching scout_party, ActiveScout is nil; expected a running scouting expedition")
+	}
+}
+
+// TestCmdCampaignScoutingKeyRedirects verifies a SCOUTING key passed to
+// `campaign` returns the redirect-to-expedition info message and does NOT
+// launch.
+func TestCmdCampaignScoutingKeyRedirects(t *testing.T) {
+	engine := newExpeditionTestEngine(t)
+
+	res := cmdCampaign([]string{"scout", "party"}, engine)
+	if res.Type != "info" {
+		t.Errorf("cmdCampaign(scout_party) Type = %q, want %q", res.Type, "info")
+	}
+	if !strings.Contains(res.Message, "expedition scout_party") {
+		t.Errorf("cmdCampaign(scout_party) message = %q, want it to redirect to 'expedition scout_party'", res.Message)
+	}
+	st := engine.GetState()
+	if st.Military.ActiveScout != nil || st.Military.ActiveMilitary != nil {
+		t.Errorf("redirect should not launch anything; got scout=%v military=%v", st.Military.ActiveScout, st.Military.ActiveMilitary)
+	}
+}
+
+// TestCmdCampaignMilitaryKeyLaunches verifies a MILITARY key launches and sets
+// the active military campaign.
+func TestCmdCampaignMilitaryKeyLaunches(t *testing.T) {
+	engine := newExpeditionTestEngine(t)
+
+	res := cmdCampaign([]string{"raid", "bandits"}, engine)
+	if res.Type != "success" {
+		t.Fatalf("cmdCampaign(raid_bandits) Type = %q (msg %q), want %q", res.Type, res.Message, "success")
+	}
+	if st := engine.GetState(); st.Military.ActiveMilitary == nil {
+		t.Errorf("after launching raid_bandits, ActiveMilitary is nil; expected a running campaign")
+	}
+}
+
+// TestCmdCampaignListReturnsCampaigns verifies bare `campaign` returns the
+// campaign list (info), naming a military campaign and not opening a panel.
+func TestCmdCampaignListReturnsCampaigns(t *testing.T) {
+	engine := newExpeditionTestEngine(t)
+
+	res := cmdCampaign(nil, engine)
+	if res.Type != "info" {
+		t.Errorf("cmdCampaign(nil) Type = %q, want %q", res.Type, "info")
+	}
+	if res.OverlayName != "" {
+		t.Errorf("cmdCampaign(nil) OverlayName = %q, want empty (list, not panel)", res.OverlayName)
+	}
+	if !strings.Contains(res.Message, "Campaigns") {
+		t.Errorf("cmdCampaign(nil) message = %q, want a campaign list", res.Message)
+	}
+}

--- a/ui/input.go
+++ b/ui/input.go
@@ -60,6 +60,8 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 		return cmdResearch(args, engine)
 	case "expedition", "exp":
 		return cmdExpedition(args, engine)
+	case "campaign":
+		return cmdCampaign(args, engine)
 	case "trade", "t":
 		return cmdTrade(args, engine)
 	case "diplomacy", "dip":
@@ -718,22 +720,73 @@ func cmdResearchList(engine *game.GameEngine) CommandResult {
 	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
 }
 
+// cmdExpedition handles the `expedition`/`exp` command — the civilian SCOUTING
+// surface. No args opens the Expeditions panel; "list" prints the scouting list;
+// a key launches a scouting expedition. Military keys are redirected to the
+// `campaign` command rather than launched here.
 func cmdExpedition(args []string, engine *game.GameEngine) CommandResult {
 	if len(args) < 1 {
-		return cmdExpeditionList(engine)
+		return CommandResult{OverlayName: "expedition"}
 	}
 	subcmd := strings.ToLower(args[0])
 	if subcmd == "list" {
-		return cmdExpeditionList(engine)
+		return cmdScoutingList(engine)
 	}
 
-	// Launch expedition
 	expKey := strings.Join(args, "_")
+
+	// Reject military keys here — they belong to `campaign`.
+	if def := engine.Military.ExpeditionDefByKey(expKey); def != nil && def.Category != game.ExpeditionScouting {
+		return CommandResult{
+			Message: fmt.Sprintf("%s is a military campaign — wage it with 'campaign %s'.", def.Name, expKey),
+			Type:    "info",
+		}
+	}
+
 	if err := engine.LaunchExpedition(expKey); err != nil {
 		return CommandResult{Message: err.Error(), Type: "error"}
 	}
+	name := expKey
+	if def := engine.Military.ExpeditionDefByKey(expKey); def != nil {
+		name = def.Name
+	}
 	return CommandResult{
-		Message: fmt.Sprintf("Expedition launched: %s!", expKey),
+		Message: fmt.Sprintf("Expedition launched: %s!", name),
+		Type:    "success",
+	}
+}
+
+// cmdCampaign handles the `campaign` command — the MILITARY surface. No args or
+// "list" prints the campaign list; a key wages a military campaign (costs
+// soldiers). Scouting keys are redirected to the `expedition` command.
+func cmdCampaign(args []string, engine *game.GameEngine) CommandResult {
+	if len(args) < 1 {
+		return cmdCampaignList(engine)
+	}
+	subcmd := strings.ToLower(args[0])
+	if subcmd == "list" {
+		return cmdCampaignList(engine)
+	}
+
+	expKey := strings.Join(args, "_")
+
+	// Reject scouting keys here — they belong to `expedition`.
+	if def := engine.Military.ExpeditionDefByKey(expKey); def != nil && def.Category != game.ExpeditionMilitary {
+		return CommandResult{
+			Message: fmt.Sprintf("%s is a scouting expedition — send it with 'expedition %s'.", def.Name, expKey),
+			Type:    "info",
+		}
+	}
+
+	if err := engine.LaunchExpedition(expKey); err != nil {
+		return CommandResult{Message: err.Error(), Type: "error"}
+	}
+	name := expKey
+	if def := engine.Military.ExpeditionDefByKey(expKey); def != nil {
+		name = def.Name
+	}
+	return CommandResult{
+		Message: fmt.Sprintf("Campaign launched: %s!", name),
 		Type:    "success",
 	}
 }
@@ -840,31 +893,56 @@ func cmdPrestigeShop(engine *game.GameEngine) CommandResult {
 	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
 }
 
-func cmdExpeditionList(engine *game.GameEngine) CommandResult {
+// cmdScoutingList prints only the available SCOUTING expeditions, with the
+// active scout (if any) as a footer. This backs `expedition list`.
+func cmdScoutingList(engine *game.GameEngine) CommandResult {
 	state := engine.GetState()
 	var lines []string
 	lines = append(lines, "[gold]Available Expeditions:[-]")
 
-	// Group by category: Scouting first, then Military Campaigns. Headers are
-	// omitted for empty subsections.
 	appendExpeditionGroup(&lines, "Scouting", state.Military.Expeditions, game.ExpeditionScouting)
-	appendExpeditionGroup(&lines, "Military Campaigns", state.Military.Expeditions, game.ExpeditionMilitary)
 
-	// A scouting and a military expedition can run concurrently (one per kind).
 	if state.Military.ActiveScout != nil {
-		lines = append(lines, fmt.Sprintf("\n[yellow]Active scouting: %s (%d ticks left)[-]",
+		lines = append(lines, fmt.Sprintf("\n[yellow]Active expedition: %s (%d ticks left)[-]",
 			state.Military.ActiveScout.Name, state.Military.ActiveScout.TicksLeft))
 	}
-	if state.Military.ActiveMilitary != nil {
-		lines = append(lines, fmt.Sprintf("\n[yellow]Active military: %s (%d ticks left)[-]",
-			state.Military.ActiveMilitary.Name, state.Military.ActiveMilitary.TicksLeft))
-	}
 
-	if len(state.Military.Expeditions) == 0 {
+	if !hasCategory(state.Military.Expeditions, game.ExpeditionScouting) {
 		lines = append(lines, "  [gray]No expeditions available yet[-]")
 	}
 
 	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+}
+
+// cmdCampaignList prints only the available MILITARY campaigns, with the active
+// campaign (if any) as a footer. This backs `campaign` and `campaign list`.
+func cmdCampaignList(engine *game.GameEngine) CommandResult {
+	state := engine.GetState()
+	var lines []string
+	lines = append(lines, "[gold]Available Campaigns:[-]")
+
+	appendExpeditionGroup(&lines, "Campaigns", state.Military.Expeditions, game.ExpeditionMilitary)
+
+	if state.Military.ActiveMilitary != nil {
+		lines = append(lines, fmt.Sprintf("\n[yellow]Active campaign: %s (%d ticks left)[-]",
+			state.Military.ActiveMilitary.Name, state.Military.ActiveMilitary.TicksLeft))
+	}
+
+	if !hasCategory(state.Military.Expeditions, game.ExpeditionMilitary) {
+		lines = append(lines, "  [gray]No campaigns available yet[-]")
+	}
+
+	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+}
+
+// hasCategory reports whether any expedition in exps matches the given category.
+func hasCategory(exps []game.ExpeditionInfo, category string) bool {
+	for _, exp := range exps {
+		if exp.Category == category {
+			return true
+		}
+	}
+	return false
 }
 
 // appendExpeditionGroup appends the subset of exps matching category to lines,
@@ -884,10 +962,17 @@ func appendExpeditionGroup(lines *[]string, label string, exps []game.Expedition
 		if exp.CanLaunch {
 			canStr = "[green]✓[-]"
 		}
-		reqs := fmt.Sprintf("%d soldiers, %d ticks", exp.SoldiersNeeded, exp.Duration)
-		if cost := formatExpeditionCost(exp.Cost); cost != "" {
-			reqs = fmt.Sprintf("%d soldiers, %s, %d ticks", exp.SoldiersNeeded, cost, exp.Duration)
+		// Soldier-free scouting expeditions omit the soldier prefix; military
+		// campaigns lead with their soldier requirement.
+		var reqParts []string
+		if exp.SoldiersNeeded > 0 {
+			reqParts = append(reqParts, fmt.Sprintf("%d soldiers", exp.SoldiersNeeded))
 		}
+		if cost := formatExpeditionCost(exp.Cost); cost != "" {
+			reqParts = append(reqParts, cost)
+		}
+		reqParts = append(reqParts, fmt.Sprintf("%d ticks", exp.Duration))
+		reqs := strings.Join(reqParts, ", ")
 		line := fmt.Sprintf("  %s [cyan]%s[-] - %s (%s)", canStr, exp.Key, exp.Name, reqs)
 		if !exp.CanLaunch && exp.LaunchBlockReason != "" {
 			line += fmt.Sprintf(" [red]— %s[-]", exp.LaunchBlockReason)

--- a/ui/overlay_expeditions.go
+++ b/ui/overlay_expeditions.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// expeditionsProvider generates the Expeditions overlay text — the civilian
+// SCOUTING surface. It shows ONLY scouting: the active scouting expedition and
+// the available scouting expeditions (resource cost / rewards / age). No
+// soldiers, no defense, no military bonuses live here — those belong to the
+// Army panel. Formatting mirrors the militaryProvider sections.
+func expeditionsProvider(state game.GameState, _ int) string {
+	var sb strings.Builder
+	mil := state.Military
+
+	fmt.Fprintf(&sb, " [gold]═══ Expeditions ═══[-]\n\n")
+	sb.WriteString(" [gray]Send scouts to explore. Expeditions cost resources,[-]\n")
+	sb.WriteString(" [gray]not soldiers, and run alongside Army campaigns.[-]\n")
+
+	if mil.ExpeditionBonus > 0 {
+		fmt.Fprintf(&sb, "\n [green]Expedition Bonus: +%.0f%%[-]\n", mil.ExpeditionBonus*100)
+	}
+
+	// === Active Expedition ===
+	sb.WriteString("\n [gold]═══ Active Expedition ═══[-]\n\n")
+	if mil.ActiveScout == nil {
+		sb.WriteString(" [gray]No active expedition[-]\n")
+	} else {
+		writeActiveExpedition(&sb, "Scouting", mil.ActiveScout)
+	}
+
+	// === Available Expeditions ===
+	sb.WriteString("\n [gold]═══ Available Expeditions ═══[-]\n\n")
+	if !hasCategory(mil.Expeditions, game.ExpeditionScouting) {
+		sb.WriteString(" [gray]No expeditions available yet[-]\n")
+		sb.WriteString(" [gray]Reach Bronze Age to unlock more scouting.[-]\n")
+	} else {
+		writeExpeditionGroup(&sb, "Scouting", mil.Expeditions, game.ExpeditionScouting)
+	}
+
+	sb.WriteString(" [gray]Commands: expedition <key>[-]\n")
+
+	return sb.String()
+}

--- a/ui/overlay_help.go
+++ b/ui/overlay_help.go
@@ -26,12 +26,16 @@ func helpProvider(_ game.GameState, _ int) string {
 	sb.WriteString("  [cyan]unassign[-] <building> [n|all]   - Unassign workers from a building\n")
 	sb.WriteString("  [cyan]dismiss[-] <building> [n|all]    - Fire workers from a building (removes from pool)\n")
 
-	sb.WriteString("\n[gold]═══ Research & Military ═══[-]\n")
+	sb.WriteString("\n[gold]═══ Research, Expeditions & Army ═══[-]\n")
 	sb.WriteString("  [cyan]research[-] <tech_key>          - Research a technology\n")
 	sb.WriteString("  [cyan]research[-] cancel             - Cancel current research\n")
 	sb.WriteString("  [cyan]research[-] list               - List available techs\n")
-	sb.WriteString("  [cyan]expedition[-] <key>            - Launch a military expedition\n")
+	sb.WriteString("  [cyan]expedition[-]                  - Open the Expeditions (scouting) panel\n")
+	sb.WriteString("  [cyan]expedition[-] <key>            - Send a scouting expedition (costs resources)\n")
 	sb.WriteString("  [cyan]expedition[-] list             - List available expeditions\n")
+	sb.WriteString("  [cyan]army[-]                        - Open the Army (military) panel\n")
+	sb.WriteString("  [cyan]campaign[-] <key>             - Wage a military campaign (costs soldiers)\n")
+	sb.WriteString("  [cyan]campaign[-] list              - List available campaigns\n")
 
 	sb.WriteString("\n[gold]═══ Trade & Diplomacy ═══[-]\n")
 	sb.WriteString("  [cyan]trade[-] <from> <to> <amount>  - Exchange resources\n")
@@ -70,7 +74,8 @@ func helpProvider(_ game.GameState, _ int) string {
 	for _, p := range []struct{ cmd, desc string }{
 		{"milestones", "Milestone goals & rewards"},
 		{"research", "Technology tree & progress"},
-		{"army", "Military overview & expeditions"},
+		{"expedition", "Scouting expeditions (resource cost)"},
+		{"army", "Army overview & military campaigns"},
 		{"trade", "Exchange rates & trade routes"},
 		{"stats", "Empire statistics"},
 		{"wonders", "Wonder bank & built wonders"},

--- a/ui/overlay_military.go
+++ b/ui/overlay_military.go
@@ -14,8 +14,8 @@ func militaryProvider(state game.GameState, _ int) string {
 	var sb strings.Builder
 	mil := state.Military
 
-	// === Military Overview ===
-	fmt.Fprintf(&sb, " [gold]═══ Military Overview ═══[-]\n\n")
+	// === Army Overview ===
+	fmt.Fprintf(&sb, " [gold]═══ Army Overview ═══[-]\n\n")
 	fmt.Fprintf(&sb, " [gold]Soldiers:[-]  %d / %d\n", mil.SoldierCount, mil.SoldierCap)
 	fmt.Fprintf(&sb, " [gold]Training:[-]  %s/tick\n", FormatRate(mil.SoldierRate))
 	fmt.Fprintf(&sb, " [gold]Defense:[-]   %.1f\n", mil.DefenseRating)
@@ -49,29 +49,26 @@ func militaryProvider(state game.GameState, _ int) string {
 		}
 	}
 
-	// === Active Expeditions ===
-	// A scouting and a military expedition can run concurrently (one per kind).
-	sb.WriteString("\n [gold]═══ Active Expeditions ═══[-]\n\n")
-	if mil.ActiveScout == nil && mil.ActiveMilitary == nil {
-		sb.WriteString(" [gray]No active expeditions[-]\n")
+	// === Active Campaign ===
+	// Only the military campaign lives here; the active scout shows in the
+	// Expeditions panel (the two run concurrently, one per category).
+	sb.WriteString("\n [gold]═══ Active Campaign ═══[-]\n\n")
+	if mil.ActiveMilitary == nil {
+		sb.WriteString(" [gray]No active campaign[-]\n")
 	} else {
-		writeActiveExpedition(&sb, "Scouting", mil.ActiveScout)
-		writeActiveExpedition(&sb, "Military", mil.ActiveMilitary)
+		writeActiveExpedition(&sb, "Campaign", mil.ActiveMilitary)
 	}
 	fmt.Fprintf(&sb, "\n [gray]Completed: %d expedition(s)[-]\n", mil.CompletedCount)
 
-	// === Available Expeditions ===
-	sb.WriteString("\n [gold]═══ Available Expeditions ═══[-]\n\n")
-	if len(mil.Expeditions) == 0 {
-		sb.WriteString(" [gray]No expeditions available yet[-]\n")
+	// === Campaigns ===
+	// The Army panel lists only military campaigns (they cost soldiers).
+	sb.WriteString("\n [gold]═══ Campaigns ═══[-]\n\n")
+	if !hasCategory(mil.Expeditions, game.ExpeditionMilitary) {
+		sb.WriteString(" [gray]No campaigns available yet[-]\n")
 		sb.WriteString(" [gray]Reach Bronze Age and recruit soldiers[-]\n")
-		sb.WriteString(" [gray]to unlock expeditions.[-]\n")
+		sb.WriteString(" [gray]to unlock campaigns.[-]\n")
 	} else {
-		// Group available expeditions by category: Scouting first (resource cost,
-		// no soldiers, available early), then Military Campaigns (cost soldiers).
-		// A subsection header is omitted when it has no available entries.
-		writeExpeditionGroup(&sb, "Scouting", mil.Expeditions, game.ExpeditionScouting)
-		writeExpeditionGroup(&sb, "Military Campaigns", mil.Expeditions, game.ExpeditionMilitary)
+		writeExpeditionGroup(&sb, "Campaigns", mil.Expeditions, game.ExpeditionMilitary)
 	}
 
 	// === Loot History ===
@@ -92,7 +89,7 @@ func militaryProvider(state game.GameState, _ int) string {
 		}
 	}
 
-	sb.WriteString("\n [gray]Commands: expedition <key>[-]\n")
+	sb.WriteString("\n [gray]Commands: campaign <key>[-]\n")
 
 	return sb.String()
 }
@@ -145,8 +142,14 @@ func writeExpeditionGroup(sb *strings.Builder, label string, exps []game.Expedit
 			fmt.Fprintf(sb, "   Cost: %s\n", cost)
 		}
 
+		// Launch hint uses the command that owns this category: scouting →
+		// `expedition`, military → `campaign`.
+		launchCmd := "expedition"
+		if exp.Category == game.ExpeditionMilitary {
+			launchCmd = "campaign"
+		}
 		if exp.CanLaunch {
-			fmt.Fprintf(sb, "   [green]expedition %s[-]\n", exp.Key)
+			fmt.Fprintf(sb, "   [green]%s %s[-]\n", launchCmd, exp.Key)
 		} else {
 			fmt.Fprintf(sb, "   [red]%s[-]\n", exp.LaunchBlockReason)
 		}


### PR DESCRIPTION
## Phase 2b — the visible split: Expeditions vs Army campaigns

Two panels, two verbs — both nouns you go *on*:

| | Opens | List | Launch |
|---|---|---|---|
| **Expeditions** (scouting) | `expedition` / `exp` | `expedition list` | `expedition <key>` |
| **Army** (military) | `army` | `campaign list` | `campaign <key>` |

- New **Expeditions** panel (`overlay_expeditions.go`) — scouting only, no soldiers/defense. The civilian exploration surface.
- **Army** panel trimmed to military: soldiers, defense, "Campaigns", and only the active campaign.
- **Cross-redirects:** `expedition <military_key>` points you to `campaign`, and vice-versa — no more silently launching the wrong kind.
- Autocomplete routes `expedition <key>` to scouting keys, `campaign <key>` to military keys; help overlay updated.

Engine launch/deduct untouched; Defense is still inert — **Phase 3** gives it a real job (and gives "wage a campaign, conquer or lose" its teeth).

### Tests
`expedition` no-arg opens the panel; military key → redirect (no launch); scouting key launches; `campaign` mirror (scouting key redirects, military launches, list works). `go build/vet/test` green.

### Worth a playtest
`expedition` opens Expeditions (try `scout_ruins` — soldier-free now); `army` opens Army with Campaigns; `campaign raid_bandits` wages one; and a scout + a campaign can run at once.

Trello: https://trello.com/c/qPhJ5YxH
