### PR TITLE
fix(ui): readable contrast for the save-name modal input

### DIFF
--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -38,7 +38,11 @@ func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageNa
 	input := tview.NewInputField().
 		SetLabel("Name: ").
 		SetText(game.GenerateSaveName()).
-		SetFieldWidth(40)
+		SetFieldWidth(40).
+		// Dark slate field with white text — tview's default light field
+		// background renders the white name near-invisible on the dark modal.
+		SetFieldBackgroundColor(tcell.NewRGBColor(48, 54, 61)).
+		SetFieldTextColor(tcell.ColorWhite)
 
 	hintTV := tview.NewTextView().
 		SetDynamicColors(true).


### PR DESCRIPTION
Small nitpick fix: the Branch/New-Game name field used tview's default light field background with near-white text, so the name was barely legible on the dark modal. Set the field to a dark slate (`#30363d`, the existing chip color) with white text for clear contrast.

One-line render fix; `go build/vet` clean. (The earlier bleed-through is already gone via #63's sizing fix.)

Trello: https://trello.com/c/viJn1q9D