### PR TITLE
docs: design specs for Theme system + persistent Account identity

### DIFF
--- a/design-and-architecture/accounts.md
+++ b/design-and-architecture/accounts.md
@@ -1,0 +1,374 @@
+# Accounts & Player Identity
+
+**Status:** Design proposal (implementation-ready)
+**Author:** engineering
+**Related:** `theming.md` (theme unlocks are the first consumer of this system), `game/save.go`, `game/devmode.go`
+
+---
+
+## 0. TL;DR — the recommendation up front
+
+Build a **local account file as the single source of truth, plus a short human-readable recovery code that encodes ONLY the identity.** Concretely:
+
+- `data/account.json` — small, signed, identity + meta-progression state (theme unlocks, lifetime stats, achievements). One per machine, auto-created on first run.
+- A **recovery code** (e.g. `AGEF-7Q2K-9X4M-ZJ31`) that encodes the account ID + a checksum + optional display name. This is the *only* thing a player needs to write down to keep their **identity** stable across machines/reinstalls. It is tiny because it carries identity, not data.
+- **Progress data** (unlocks/stats) is exported/imported as a separate signed blob (`account-export.json` or a long base64 string), because — with no server — data cannot be reconstituted from nothing.
+- Reuse the **existing HMAC + atomic-write patterns** from `game/save.go`. Do not invent a new integrity scheme.
+
+The hard truth, stated once and honestly: **there is no server, so genuine cross-machine recovery requires the player to keep a backup.** We can make that backup small (a code for identity) and easy (one-button export for data). We cannot make data appear from nothing.
+
+---
+
+## 1. Problem statement
+
+### 1.1 What we have today
+
+AgeForge is a **local** terminal idle game. Everything lives on the player's machine. There is no backend, no network identity, no login. On disk we have exactly two things (confirmed by inspecting the tree and the code):
+
+- `data/saves/*.json` — one file per run. Resolved by `saveDirectory()` in `game/save.go`: binary-relative `data/saves/` via `os.Executable()` + `EvalSymlinks`, with a CWD-relative `data/saves` legacy fallback in `savePath()`.
+- `data/logs/` — log dumps (CWD-relative `data/logs`, created ad hoc in `ui/input.go`).
+
+There is **no** `settings.json`, `account.json`, `preferences`, or `profile` file, and no loader for one. Verified by grep across `*.go`. This is greenfield.
+
+Each save (`GameSave` in `game/save.go`) is self-contained: it carries its own resources, buildings, workers, prestige, badges, lineage parent (`ParentName`), etc. State is **per-save**, not **per-player**. There is no concept of "the player" that spans saves.
+
+### 1.2 Why we now need a per-player identity
+
+`theming.md` introduces **theme unlocks** as meta-progression: a player unlocks a theme by reaching some milestone, and that theme should then be available in **every** save — new games, branches, all of them. The same shape applies to the meta-progression we already know is coming:
+
+- **Cosmetics** (themes, palettes, splash variants)
+- **Lifetime / cross-save stats** ("total prestiges across all civilizations", "highest age ever reached")
+- **Achievements** (one-time, account-wide, not per-run)
+
+None of these belong in a `GameSave`. If theme unlocks lived in the save, then:
+
+- Starting a new game would reset your unlocks (wrong — they're earned once).
+- A player with three civilizations would have three divergent unlock sets (wrong — there's one player).
+- Deleting a save would delete cosmetics you earned (wrong).
+
+So we need a persistent **player identity** that all saves attach to, with a per-player state bag that the rest of the game reads from.
+
+### 1.3 Constraints (non-negotiable)
+
+1. **Local-only.** No server, no network calls, no cloud dependency for core function.
+2. **Low friction.** First run must "just work" — no forced login, no mandatory naming wall before the player can play.
+3. **Consistent with existing patterns.** Reuse HMAC signing + atomic temp-file+rename. Do not break the cheater/elite badge system or the `forgeMasterKey` easter egg.
+4. **Backward compatible.** Existing players have no account; the game must create one transparently and adopt their existing saves.
+
+---
+
+## 2. Evaluation — A vs B vs Hybrid
+
+The crux of this whole design is one distinction, so name it explicitly:
+
+> **IDENTITY** is *who you are* — a small, stable token (an account ID, maybe a display name). It is cheap to back up and cheap to derive.
+>
+> **DATA** is *what you've earned* — unlock state, lifetime stats, achievements. It grows over time, is not derivable from anything, and must physically live somewhere.
+
+Every approach below succeeds or fails on how it treats these two things. The recurring trap is conflating them — trying to make identity carry data, or assuming data is recoverable just because identity is.
+
+### 2.1 Option A — local account-ID file
+
+**Shape:** On first run, generate a stable ID (UUIDv4). Write it to `data/account.json`. Key all unlocks/prefs to it. Done.
+
+```jsonc
+// data/account.json (Option A, minimal)
+{
+  "account_id": "a1b2c3d4-...-uuid",
+  "display_name": "Adam",
+  "created": "2026-06-27T12:00:00Z",
+  "unlocks": { "themes": ["amber_crt", "obsidian"] },
+  "_sig": "hmac-sha256-hex"
+}
+```
+
+**First-run creation:** Auto-generate silently. Optionally offer a display-name prompt, but never block on it — default to a generated name (we already have a cosmetic name generator in `game/savenames.go`) or empty.
+
+**Backup/restore:** Copy the file. Restore = drop it back.
+
+**Machine transfer:** Copy `data/account.json` to the new machine's data dir.
+
+**Tamper:** Sign it with HMAC (same `saveHMACKey` scheme). On mismatch, we *don't* brick the player — we flag it (mirrors the cheater badge: cosmetic consequence, not a lockout), because the unlock state is not security-critical.
+
+**Failure modes — and this is where A hurts:**
+- **File deleted → identity AND unlocks both gone.** There is no backup of either. The player is a brand-new account; every theme is re-locked. This is the worst property of pure A: a single file is the only copy of *both* halves, and losing it loses everything at once.
+- **Multi-machine:** No story at all. Copying the file by hand works but is undiscoverable and error-prone (wrong directory, overwrites the new machine's progress). There's no compact thing to "write down."
+- **Multiple profiles on one machine:** Possible (multiple account files), but the file is a fixed path, so you'd need a profile-switcher. Out of scope for v1 but the schema shouldn't preclude it.
+
+**Verdict:** A is the right *storage substrate* — a local signed file is exactly what we want for DATA. But as the *whole* solution it has no backup story beyond "copy this file," which is precisely the friction we're trying to avoid and the failure mode we're trying to soften.
+
+### 2.2 Option B — seed / passphrase-derived identity
+
+**Shape:** Player picks a name + passphrase. We derive a deterministic account ID: `account_id = KDF(passphrase, salt)`. Backup = "remember your passphrase." On a new machine, re-enter it and your ID regenerates.
+
+**This addresses the user's instinct that "cramming all the data into a seed is bad" — and it's correct to be suspicious. Here's the precise reasoning:**
+
+A seed can only ever derive things that are *pure functions of the seed*. An account ID is exactly that: `id = KDF(seed)`. Deterministic, tiny, reproducible anywhere. **So a seed can carry IDENTITY perfectly.**
+
+But unlocks/stats/achievements are **not** a function of the seed — they're a function of *everything you did over months of play*. There is no `KDF` that turns "amber_crt, obsidian, 14 prestiges, highest age = bronze" back out of a passphrase. So:
+
+- **Can the seed carry only identity?** Yes, cleanly. But then on a fresh machine you get your *ID* back and **all your DATA is gone** — same data-loss problem as A's deleted file, just relocated. Re-deriving the identity doesn't re-derive the unlocks, because the unlocks were never in the seed.
+- **What would it take to make a seed restore actual progress?** You'd have to *encode the data into the exportable code itself* — turn the "seed" into an export blob: `base64(compress(unlock_state + stats + checksum))`. The moment you do that, it stops being a memorable passphrase and becomes a **long opaque string that grows with progress.** A handful of theme unlocks is maybe 40–80 chars; add lifetime stats and achievements and you're at hundreds of characters of base64. Nobody writes that on a sticky note. You've reinvented "export a file" but worse, because you've disguised a data blob as a "seed" and set the expectation that it's memorable.
+
+**Other B problems:**
+- **Collisions / security:** A weak passphrase = a guessable/duplicable account ID. To resist this you need a real KDF (argon2/scrypt) and ideally a per-install salt — but a per-install salt that lives only on the machine reintroduces the "lose the machine, lose the salt" problem, and a *fixed* salt makes the whole namespace brute-forceable. For a cosmetic-unlock system this is a lot of crypto ceremony for low stakes, and it pushes friction onto the player (choose and remember a strong passphrase up front).
+- **Friction:** B forces an identity decision *before* the player has any reason to care, violating constraint #2.
+
+**Verdict:** B is genuinely good at the *identity* half and genuinely bad at the *data* half, and pretending otherwise (by stuffing data into the seed) is the anti-pattern the user already smelled. The useful kernel of B — "a small derivable/portable identity token" — survives into the hybrid as the **recovery code**.
+
+### 2.3 Option C — Hybrid (recommended), plus rejected alternatives
+
+**The hybrid takes the best half of each:**
+
+- From A: a **local signed file** as the source of truth for DATA (and the live identity). Zero friction, works offline, fits our existing patterns.
+- From B: a **small, portable identity token** — but instead of deriving the ID *from* a passphrase, we generate the ID and *encode it into* a short recovery code. The code is small precisely because it carries identity only.
+
+So:
+
+| Concern | Lives where | Backup mechanism |
+|---|---|---|
+| **Identity** (account ID, display name) | `data/account.json` (live copy) | **Recovery code** — short, write-downable |
+| **Data** (unlocks, stats, achievements) | `data/account.json` (live copy) | **Export blob/file** — explicit, larger, one-button |
+
+This keeps the user's IDENTITY-vs-DATA separation honest: the *small* backup (recovery code) restores identity; the *bigger* backup (export) restores data; and we never lie about a passphrase magically restoring progress.
+
+**Rejected alternatives (judged honestly):**
+
+- **Cloud / GitHub Gist sync.** Tempting — it's the only thing that gives true automatic cross-machine recovery. Rejected for v1 because it breaks constraint #1 (local-only), adds auth/secrets/network-failure handling, and turns a cosmetic-unlock feature into an infrastructure project. Worth keeping as a *future* opt-in layered on top of the export blob (the export format becomes the sync payload), but not now.
+- **Plain file export/import with no recovery code.** This is the hybrid minus the small identity token. It works, but the only backup is "copy a JSON file," which is the same undiscoverable friction as A. The recovery code is cheap to add and is what makes "I reinstalled / new laptop" not feel hostile. Keep both.
+- **Tie identity into save HMAC as the *only* mechanism.** We *will* attribute saves to an account (§5), but identity can't live solely inside saves — that's the per-save trap from §1.2.
+
+> **v1 caveat — one fixed `account.json` path means no multi-profile.** Because v1 resolves a single `data/account.json`, two players sharing one install (or two OS users on one machine pointed at the same data dir) **collide on the same account file and merge progress — last writer wins.** There is no per-player separation in v1. True multi-profile (`data/accounts/<id>.json` + a switcher) is deferred future work (see §7 and §9); the `version` field leaves room for it without a breaking change.
+
+---
+
+## 3. Recommended design
+
+**Decision: Hybrid (Option C).** Local signed account file as source of truth + short recovery code for identity backup + explicit export/import for data backup. Cloud sync explicitly deferred.
+
+### 3.1 Where it lives
+
+A new **account directory**, resolved exactly like saves are. We factor the binary-relative resolution out of `saveDirectory()` into a shared `dataDirectory()` so accounts, saves, and (eventually) logs share one root and one fallback rule:
+
+```
+<dir-of-binary>/data/
+  ├── account.json        ← NEW: identity + meta-progression (signed, atomic)
+  ├── saves/*.json
+  └── logs/
+```
+
+Resolution rule (mirrors `savePath`): prefer binary-relative `data/account.json`; if absent, check CWD-relative `data/account.json` (legacy/dev-run fallback); default to binary-relative for new writes.
+
+### 3.2 Unified file vs split file
+
+We considered `account.json` (identity) + `settings.json` (prefs/unlocks) as two files. **Recommendation: one file, `data/account.json`,** with internal sections. Rationale:
+
+- One file = one signature, one atomic write, one backup unit. Two files doubles the integrity surface and invites a half-restored state (identity from machine A, unlocks from machine B).
+- Prefs and unlocks are both "per-player," so they share a lifecycle.
+- If non-account-scoped *machine* prefs ever appear (e.g. terminal-specific render tweaks that should NOT travel with the account), *those* get their own unsigned `data/prefs.json`. Until such a pref exists, don't create the file.
+
+### 3.3 Schema
+
+```jsonc
+// data/account.json
+{
+  "version": 1,                         // schema version, for migrations
+  "account_id": "f3a1c9e2b7d44a18...", // 128-bit random, hex (16 bytes)
+  "display_name": "Adam",               // optional; "" is valid
+  "created": "2026-06-27T12:00:00Z",
+  "last_seen": "2026-06-27T18:30:00Z",
+
+  // --- meta-progression (DATA) ---
+  "unlocks": {
+    "themes": ["amber_crt", "obsidian"] // theme keys; see theming.md
+    // future: "palettes": [...], "splash_variants": [...]
+  },
+  "stats": {                            // lifetime, cross-save aggregates
+    "total_prestiges": 14,
+    "highest_age": "bronze_age",
+    "civilizations_started": 7,
+    "saves_completed": 2
+  },
+  "achievements": ["first_prestige", "reached_iron"],
+
+  // --- preferences (travel with the account) ---
+  "prefs": {
+    "active_theme": "obsidian"
+  },
+
+  // --- integrity (same scheme as saves) ---
+  "_sig": "hmac-sha256-hex"
+}
+```
+
+Notes:
+- `account_id` is **16 random bytes (crypto/rand) as hex**, not a v4 UUID specifically — but UUIDv4 is fine if a dep is already present. 128 bits makes collisions a non-issue and is what the recovery code encodes.
+- All new fields are optional / zero-valued on read, so schema additions stay backward compatible (same discipline as `GameSave`).
+- `version` lets us migrate the file later without guessing.
+
+### 3.4 Integrity — reuse, don't reinvent
+
+Sign with the **same HMAC-SHA256 construction** as saves:
+
+- Zero `_sig`, `json.Marshal`, HMAC with `saveHMACKey`, hex-encode, store in `_sig`. (Identical to `signSave` — factor it into a shared helper, e.g. `hmacSign(payload []byte, key string)`, so saves and accounts call one function.)
+- On load: if `_sig` is empty → treat as legacy/benign (don't punish). If present and mismatched → set a cosmetic `tampered` flag on the in-memory account (mirrors `cheaterBadge`), but **still load it** — unlock state is not security-critical, and a hard failure would be a worse experience than a tampered-themes notice.
+- We deliberately do **not** add a `forgeMasterKey` proof to the account file. The elite easter egg is a *save* concept; it stays in saves untouched. (See §5.)
+
+Write with the **same atomic pattern**: temp file + `os.Rename`, `0644`, `MkdirAll(dir, 0755)` — copy `SaveGame`'s body.
+
+### 3.5 The recovery code (identity backup)
+
+Encode `account_id` + a checksum (+ optional truncated display-name hint) into a grouped, human-readable string:
+
+```
+AGEF-7Q2K-9X4M-ZJ31-...   (Crockford base32, dash-grouped, uppercase)
+```
+
+- **Payload:** 16-byte `account_id` + 2-byte CRC-ish checksum. Base32 of 18 bytes ≈ 29 chars + dashes. Short enough to write down, long enough to not collide.
+- **Crockford base32** avoids ambiguous chars (no `I/L/O/U`), so transcription is robust.
+- The checksum lets import reject a typo'd code with a clear message instead of silently creating a wrong account.
+- **What it does:** re-creates an `account.json` with the *same account_id* on a new machine (or after deletion). Identity restored. Saves signed/attributed to that ID re-associate (§5).
+- **What it does NOT do:** restore unlocks/stats. Those are DATA — see §3.6. We must say this plainly in the UI when showing the code: *"This restores your identity, not your progress. Export your progress separately to keep it."*
+
+> **INVARIANT — re-association goes through `SaveGame`, never an in-place JSON edit.**
+> "Saves re-associate" sounds innocent, but the naive implementation is dangerous. When a restored identity re-claims its saves, **the new `account_id` must be written by re-marshalling and re-saving the save through the normal `SaveGame` path** so the HMAC `_sig` recomputes over the new payload. **Never** open a save file, splice `account_id` into the JSON, and write it back: `verifySave` re-hashes the *entire* payload, so a save with a freshly-edited `account_id` but a stale `_sig` fails verification → `sigValid=false` → `CheaterBadge=true`. That stamps a false "⚠ modified" badge on a legitimately-imported save. Same invariant applies to migration stamping (§6). One door in: `SaveGame`.
+
+- **The recovery code is a convenience identifier, not a credential.** `account.json` is signed with `saveHMACKey`, a *constant compiled into every binary*. Anyone can therefore craft a validly-signed `account.json` for *any* account ID they like — the signature proves "this file came from an AgeForge build," not "this file belongs to you." The checksum in the code guards against *typos*, not *forgery*. This is acceptable precisely because account state is **cosmetic, not security-critical**: there is nothing to steal and no advantage to forging someone's ID. We do not pretend otherwise, and we never build a feature that assumes the code is a secret.
+
+### 3.6 Progress export / import (data backup)
+
+A one-button **Export Progress** writes a signed blob — either a file (`account-export-<date>.json`, byte-for-byte an `account.json` minus the live timestamps) or a copyable long base64 string for the "paste it somewhere" crowd.
+
+- Import validates the signature, then either *merges* (union of unlocks, max of stats) or *replaces* (prompt). Merge is the safer default — re-importing an old backup shouldn't *remove* a theme you've since unlocked.
+- This is honest about size: the export grows with your progress. That's fine — it's a *file/blob*, not something you memorize. This is exactly the thing Option B got wrong by disguising it as a "seed."
+
+---
+
+## 4. Backup / restore / machine-transfer UX
+
+| Scenario | Player does | Result |
+|---|---|---|
+| **Same machine, normal play** | nothing | `account.json` is the live source of truth; auto-updated. |
+| **Back up identity** | copies the **recovery code** (one screen, ~29 chars) | Can re-create the same account ID anywhere. |
+| **Back up progress** | clicks **Export Progress** → saves a file / copies a blob | Can restore unlocks + stats anywhere. |
+| **New machine (full transfer)** | enters recovery code → imports export blob | Identity + data both restored. |
+| **New machine (identity only)** | enters recovery code | Same account ID; **unlocks start empty** — re-earnable, and re-importing later will merge. |
+| **Reinstall, kept nothing** | — | Fresh account. Honest loss. |
+
+**The honest line, in the doc and in the UI:** with no server, *identity* recovery is a 29-char code, but *progress* recovery requires you to have exported it. We make export one click and remind the player to do it after big unlocks; we cannot resurrect data that was never backed up.
+
+---
+
+## 5. Anti-tamper stance & relationship to existing systems
+
+- **Cheater/elite badges (saves) are untouched.** The account file gets its *own* cosmetic `tampered` flag using the *same* HMAC helper, but with no `forgeMasterKey` proof and no lockout. We are consistent with the existing philosophy stated in `save.go`: the HMAC is integrity signalling, *"cosmetic, not security-critical."*
+- **The `forgeMasterKey` easter egg stays a save-only concept.** We do not extend it to accounts, do not move the key, do not change `verifySave`. An elite save remains elite regardless of account.
+- **Optional save→account attribution.** We can add an optional `AccountID string \`json:"account_id,omitempty"\`` to `GameSave`, stamped on save and covered by the existing save signature automatically (it's part of the marshalled payload `signSave` already hashes). This lets the Load Game browser show "this save belongs to account X" and lets a restored identity re-claim its saves. It is *additive and optional*: empty on legacy saves (`omitempty` keeps bytes identical), and a mismatch is informational, never blocking. No change to the signing/verifying logic is required — just a new field.
+- **The stamp must go through `SaveGame`, full stop.** Whether the `account_id` is written by migration (§6) or by recovery re-association (§3.5), it MUST be applied by re-saving through the normal `SaveGame` path so `_sig` recomputes — **never** by editing the save's JSON in place. See the called-out invariant in §3.5: a stale signature flips `sigValid=false` → `CheaterBadge=true` → a false "⚠ modified" badge on a legitimate save.
+- **Elite saves survive stamping — but only because stamping goes through `SaveGame`.** A save carrying an elite `_proof` (the `forgeMasterKey` easter egg) is re-signed when `account_id` is stamped onto it. Because the same `SaveGame` flow that recomputes `_sig` also recomputes the elite proof, elite status is preserved across attribution. This is *another* reason the in-place-edit shortcut is forbidden: editing the JSON directly would leave `_proof` stale and silently strip the elite badge.
+- **The forged-account caveat (A4) applies here too.** Save attribution is informational, not authoritative: because `saveHMACKey` is a known constant (see §3.5), an `account_id` on a save proves nothing about ownership. Treat it as a hint for the Load browser, never as access control.
+
+---
+
+## 6. Migration — existing players
+
+Existing players have saves but no account. On startup:
+
+1. `LoadOrCreateAccount()` resolves `data/account.json`.
+2. **Absent →** generate a new `account_id`, write a fresh signed `account.json`. Silent; no prompt. The player keeps playing; a non-blocking toast can mention "your account was created — back up your recovery code in Settings" but must not gate play (constraint #2).
+3. **Present →** load + verify; set `tampered` flag on mismatch; update `last_seen`; rewrite atomically.
+4. **Attaching existing saves:** when an un-attributed save (`account_id == ""`) is *next saved*, stamp it with the current account ID. We do **not** mass-rewrite all saves on first run (that would invalidate nothing — the sig recomputes — but it's needless I/O and churns mtimes the Load browser sorts on). Lazy attribution on next write is enough; the browser treats `""` as "this account" by default.
+
+> **INVARIANT (restated for migration) — stamp via `SaveGame`, never edit JSON in place.** Lazy stamp-on-save is safe *only because the stamp rides the normal `SaveGame` write*, which re-marshals the payload and recomputes `_sig` (and the elite `_proof`, §5). The lazy timing is what makes it cheap; the `SaveGame` path is what makes it correct. Do not "optimize" this by reading a save, splicing in `account_id`, and writing the bytes back — `verifySave` re-hashes the whole payload, so a stale `_sig` yields `sigValid=false` → `CheaterBadge=true` → a false "⚠ modified" badge. This is the single most important implementation rule in this doc. Full statement in §3.5.
+
+No existing save format field is removed or repurposed. The only save-side change is the additive optional `account_id`.
+
+---
+
+## 7. Failure modes & how the design handles each
+
+| Failure | Without this design | With the hybrid |
+|---|---|---|
+| **`account.json` deleted** | (n/a today) | Identity lost *unless* recovery code kept; unlocks lost *unless* export kept. Auto-creates a fresh account so the game still runs. We mitigate by surfacing the recovery code prominently and nudging export after unlocks. |
+| **Multi-machine** | none | Recovery code re-creates identity; export blob carries data. Manual but small and discoverable. |
+| **Multiple profiles, one machine** | none | v1: single `account.json`. Schema/`version` field leaves room for a future `data/accounts/<id>.json` layout + switcher without a breaking change. Not built in v1. |
+| **Tampered account file** | (n/a) | Loads with a cosmetic `tampered` flag (mirrors cheater badge); no lockout. |
+| **Corrupt / unparseable account file** | (n/a) | Treat like a corrupt save: don't crash. Back up the bad file to `account.json.corrupt`, create a fresh account, log it. Player can recover via code+export. |
+| **Two machines edit then both `account.json` copied around** | none | Last-write-wins on the file; import *merges* unlocks (union) and *maxes* stats to limit accidental loss. |
+
+---
+
+## 8. Integration API — how the rest of the game uses it
+
+A small package (e.g. `account`) owns the file and exposes a narrow surface. The UI and theming code talk only to this — they never touch the file directly. Mirrors how `game` owns saves.
+
+```go
+package account
+
+// Loaded once at startup; held by the app, passed explicitly (no globals — per CLAUDE.md).
+type Account struct { /* fields from §3.3 */ }
+
+func LoadOrCreate() (*Account, error)        // §6 startup path
+func (a *Account) Save() error               // signed + atomic, reuses save helpers
+
+// Unlocks (theming.md is the first caller)
+func (a *Account) HasTheme(key string) bool
+func (a *Account) UnlockTheme(key string) (newly bool, err error) // persists; returns true if it wasn't already unlocked
+func (a *Account) UnlockedThemes() []string
+
+// Prefs
+func (a *Account) ActiveTheme() string
+func (a *Account) SetActiveTheme(key string) error
+
+// Lifetime stats (engine calls these at prestige/age-up; debounce writes)
+func (a *Account) RecordPrestige()
+func (a *Account) RecordAgeReached(ageKey string)
+
+// Identity backup / restore
+func (a *Account) RecoveryCode() string                 // §3.5
+func ImportRecoveryCode(code string) (*Account, error)  // re-creates identity
+func (a *Account) ExportProgress() ([]byte, error)      // §3.6 signed blob
+func ImportProgress(blob []byte, merge bool) error
+```
+
+**Theming hook:** the theme picker calls `HasTheme`/`UnlockedThemes` to decide what's selectable, and the engine calls `UnlockTheme` when an unlock condition is met (the condition logic lives in `theming.md`). Because the account is loaded once and passed explicitly, no lock-acquiring call leaks into a Bus handler (respects the documented Bus deadlock rule).
+
+**Write cadence:** `Save()` after meaningful state changes (an unlock, a prefs change, a prestige), not every tick. Like autosave, the file write happens outside any engine lock.
+
+---
+
+## 9. Phased implementation plan
+
+Each phase is independently shippable and testable. Sized for one self-contained subagent each per project conventions.
+
+- **Phase 1 — Storage substrate.**
+  Factor `dataDirectory()` out of `saveDirectory()`. New `account` package: `Account` struct, `LoadOrCreate`, `Save` (reusing a shared `hmacSign` helper extracted from `signSave`, plus the temp+rename write). Tamper/corrupt handling. Tests: create → load → verify sig → tamper → flag set; corrupt → fresh account + `.corrupt` backup.
+
+- **Phase 2 — Startup wiring + migration.**
+  Call `LoadOrCreate` at app boot; thread the `*Account` through to the UI. Add optional `account_id` to `GameSave`; lazy-stamp on next save. Non-blocking first-run toast. Tests: legacy save loads unchanged; next save gains `account_id`; sig still valid.
+
+- **Phase 3 — Unlock API + theming integration.**
+  `HasTheme`/`UnlockTheme`/`UnlockedThemes`/`ActiveTheme`/`SetActiveTheme` (signatures in §8). Wire the theme picker (per `theming.md`) to the account. Tests: unlock persists across restart and across a *new* save.
+  **Cross-doc dependency:** this phase *unblocks* `theming.md` Phase 2 (account-wide persistence), which is gated on exactly this unlock API. `theming.md` Phase 1 deliberately ships against a *stub* of this API and has **no** dependency on the account system, so the two tracks can proceed in parallel and only converge here. Named in both plans (`theming.md` §10) so neither can be scheduled to deadlock the other.
+
+- **Phase 4 — Recovery code.**
+  Crockford base32 encode/decode of `account_id` + checksum; `RecoveryCode()` / `ImportRecoveryCode`. Settings screen shows the code + the honest "identity, not progress" copy. Tests: round-trip; typo → checksum rejection; import re-creates same ID.
+
+- **Phase 5 — Export / import progress.**
+  `ExportProgress` (signed blob/file) + `ImportProgress(merge)`. Settings buttons. Tests: export → wipe unlocks → import(merge) restores; import doesn't drop newer unlocks.
+
+- **Phase 6 — Lifetime stats + achievements.**
+  Engine hooks (`RecordPrestige`, `RecordAgeReached`, …); a small achievements table. Surface lifetime stats in the Stats tab.
+
+- **Deferred / future (not in this plan):** multi-profile switcher (`data/accounts/<id>.json`); opt-in cloud/gist sync built *on top of* the Phase-5 export format. Both are non-breaking thanks to the `version` field and the narrow API.
+
+- **Docs:** every phase updates the wiki per the project rule — at minimum `site/docs/commands.md` (new Settings/account actions) and a new account/recovery page; `theming.md` cross-links the unlock API.
+
+---
+
+## Appendix — grounding notes (code as-built)
+
+- No account/settings/preferences file or loader exists today (grep-confirmed). Greenfield.
+- `game/save.go`: `saveDirectory()` = binary-relative `data/saves` via `os.Executable()`+`EvalSymlinks`; `savePath()` falls back to CWD-relative `data/saves`. `signSave` zeroes `_sig`/`_proof`, marshals, HMAC-SHA256 under `saveHMACKey`, hex. `verifySave` treats unsigned as benign-valid. Atomic writes via temp+`Rename` (`SaveGame`, `reparentSaveFile`, `DuplicateSave`). `GameSave` carries `ParentName` (lineage) and `CheaterBadge`/`EliteBadge`.
+- `game/devmode.go`: `forgeMasterKey` signs the *save signature* for the elite badge (the easter egg). Deliberate; left untouched by this design.
+- Names go through `ValidateSaveName`/`sanitizeSaveName`. Module: `github.com/espresso20/ageforge`, Go 1.24.

--- a/design-and-architecture/theming.md
+++ b/design-and-architecture/theming.md
@@ -1,0 +1,634 @@
+# Theming & Accessibility
+
+Status: design / implementation-ready
+Owner: UI
+Related: `design-and-architecture/accounts.md` (account-wide unlock + settings state — being written in parallel)
+
+A player-selectable theme system for AgeForge's terminal UI. Ships with a default
+"Forge" look plus required accessibility themes (colorblind-safe, high-contrast)
+unlocked from day one, and flavor themes that unlock via milestones. The hard part
+isn't the picker — it's that the UI's color is currently hardcoded across ~957
+sites in two completely different code paths. This doc resolves how to drive all
+of them from a single ~9-role palette, including a definitive feasibility verdict
+on the name-remap trick.
+
+**Don't under-budget Phase 1 from the headline.** The name-remap trick retints the
+~915 *named* inline tags (`[gold]`, `[gray]`, …) with **zero edits** — that part is
+genuinely free. But the ~42 direct `tcell` chrome calls (§2 Path B) and the ~23 hex
+tags (§3.4) are **not** free: they're real, hand-applied edits, and they are the actual
+bulk of Phase-1 work. "Retint 957 sites from one palette" is true as an *outcome*; it is
+not true that all 957 sites cost nothing. Budget Phase 1 for the ~65 edits, not for zero.
+
+---
+
+## 1. Goals / Non-Goals
+
+### Goals
+- One source of truth: every color in the UI derives from a small set of **semantic
+  role colors** (Accent, Dim, Label, Positive, Negative, Highlight, Text, Background,
+  Selection/Border).
+- Ship multiple themes, switchable live without restarting the game.
+- **Accessibility is not optional.** Colorblind-safe (deuteranopia + protanopia) and
+  high-contrast themes ship in the first release and are **never gated** behind
+  milestones.
+- A contrast guard that makes it structurally hard to ship an unreadable theme.
+- Theme choice and unlock state persist **account-wide**, not per-save.
+- Minimal churn on the existing 957 color sites. We do not want to hand-edit every
+  `[gold]` tag — and the feasibility work below shows the ~915 *named* tags need zero
+  edits. The ~42 direct `tcell` calls and ~23 hex tags still require real edits (that's
+  Phase-1 work, not free); "minimal churn" means ~65 sites, not zero.
+
+### Non-Goals
+- Not redesigning the account/settings system. We *depend on*
+  `design-and-architecture/accounts.md` for where unlock + active-theme state lives;
+  we do not specify that layer here.
+- Not a full per-widget styling engine or user-authored custom themes (a stretch,
+  §9). Shipped themes are curated and code-defined.
+- Not touching the map renderer's bespoke RGB terrain palette (`ui/map.go`). The map
+  uses geography-driven colors, not semantic roles; it stays out of scope except for
+  its border/title chrome, which it shares with everything else.
+- Not changing save format semantics. Themes never live in `data/saves/*.json`.
+
+---
+
+## 2. Current State
+
+There is no central theme. Color is hardcoded across two independent paths.
+
+### Path A — inline tview color tags (text content)
+`SetDynamicColors(true)` text carries inline tags like `[gold]TITLE[-]`,
+`[green]+12.5[-]`, `[#8b949e]hint[-]`. Real counts from `grep` over `ui/*.go`
+(42 files):
+
+| Tag | Count | Conventional role |
+|------|------:|-------------------|
+| `[gray]` | 154 | dim / secondary |
+| `[gold]` | 134 | accent / titles / borders-in-text |
+| `[cyan]` | 127 | labels / values |
+| `[green]` | 79 | positive / gains |
+| `[white]` | 66 | primary text |
+| `[red]` | 60 | negative / losses |
+| `[yellow]` | 52 | highlight / numbers |
+| `[lime]` `[aqua]` `[orange]` `[blue]` | 7 total | stray one-offs |
+| `[#8b949e]` | 21 | dim hint (hex) |
+| `[#cc88ff]` `[#ff66cc]` | 2 | one-off accents (hex) |
+
+~915 inline tags total. The named colors are semantic **by convention only** —
+nothing enforces it, but the convention is consistent enough to remap on.
+
+### Path B — direct tcell color calls (widget chrome)
+Borders, modal backgrounds, list selection, input fields, age palettes. ~168
+`tcell.Color*` / `tcell.NewRGBColor` references plus 42 `Set*Color(...)` widget
+calls:
+
+| Call | Count |
+|------|------:|
+| `SetTitleColor` | 16 |
+| `SetBackgroundColor` | 10 |
+| `SetBorderColor` | 9 |
+| `SetFieldBackgroundColor` | 3 |
+| `SetSelectedBackgroundColor` | 2 |
+| `SetFieldTextColor` | 2 |
+
+These do **not** flow through color-name tags. They take `tcell.Color` values
+directly and apply once at widget construction.
+
+### Existing prior art: `ui/theme.go`
+There is already a `ui/theme.go` with global `tcell.Color` vars (`ColorTitle`,
+`ColorAccent`, `ColorSuccess`, …) and an `AgePalette` / `ApplyAgePalette(ageKey)`
+system that mutates those globals as the player advances ages. This is **only Path B
+prior art** — it never touches the inline `[gold]` tags, which is why advancing an
+age recolors some chrome but not the body text. Our design subsumes this: the
+age-palette globals become one consumer of the theme palette, and the
+epoch-adaptive idea (§9) is the generalization of `ApplyAgePalette`.
+
+### tview's own theme
+tview has a global `tview.Styles` (`Theme` struct: `BorderColor`, `TitleColor`,
+`PrimitiveBackgroundColor`, …) read inside `NewBox()` at **construction time**.
+Setting it changes defaults for *newly created* widgets but does not retint existing
+ones. Useful as a baseline but not a live-retint mechanism.
+
+### Persistence today
+None for preferences. `data/` holds only `saves/` and `logs/`. There is no settings
+file. The only cross-save state precedent is `CheaterBadge` / `EliteBadge`, peeked
+from the autosave via `game.PeekSaveBadges`. Account-wide state is new ground, owned
+by `accounts.md`.
+
+---
+
+## 3. Architecture
+
+### 3.1 The Theme model
+
+A theme is ~9 semantic **role** colors plus metadata. Roles, not literal color
+names — `Positive` is "the gains color," whatever hue the active theme picks.
+
+```go
+// package theme
+
+type Role int
+
+const (
+    RoleBackground Role = iota // canvas / primitive background
+    RoleText                   // primary readable text
+    RoleDim                    // secondary / hints / disabled
+    RoleLabel                  // field labels, values
+    RoleAccent                 // titles, borders, brand highlights
+    RoleHighlight              // numbers, attention, "look here"
+    RolePositive               // gains, success, +deltas
+    RoleNegative               // losses, errors, -deltas
+    RoleSelection              // selected list-row background
+    numRoles
+)
+
+type Theme struct {
+    Key         string            // "forge", "deuteranopia", "high_contrast", ...
+    Name        string            // "Forge" — shown in picker
+    Blurb       string            // one-line flavor for the picker detail pane
+    Accessible  bool              // true => never gated, always unlocked
+    Colors      [numRoles]tcell.Color
+    // Signed sentinel for the ± distinction in accessible themes (see §4):
+    GainGlyph   string            // e.g. "▲" / "+"
+    LossGlyph   string            // e.g. "▼" / "-"
+}
+```
+
+`tcell.Color` carries true RGB (`tcell.NewRGBColor(r,g,b)`), so themes are defined as
+explicit RGB and are not at the mercy of the terminal's 16-color palette on
+truecolor-capable terminals.
+
+### 3.2 Retinting Path A (inline tags) — the name-remap strategy
+
+**This is the load-bearing decision, so the verdict is spelled out, not asserted.**
+
+#### Verdict: name-remap is VIABLE for named tags. Caveat: hex tags are not.
+
+I read the dependency source (`rivo/tview@v0.42.0`, `gdamore/tcell/v2@v2.13.10` in
+`$(go env GOMODCACHE)`; no vendor dir).
+
+What actually happens when tview draws `[gold]TEXT[-]`:
+
+1. `TextView.Draw` iterates visible lines and, **for every line on every Draw**,
+   walks the raw text (tags still embedded) via `step()` → `parseTag()` in
+   `tview/strings.go`. The line index caches only each line's *starting* state and
+   byte offset — **not** the resolved per-character colors. Colors are re-resolved
+   from the raw string on each frame.
+
+2. For a **named** foreground tag, `parseTag` resolves the color with a direct map
+   lookup:
+   ```go
+   tStyle = tStyle.Foreground(tcell.ColorNames[name])   // strings.go
+   ```
+   `tcell.ColorNames` is an **exported, mutable** `map[string]tcell.Color`.
+
+3. The named entries already carry true RGB, e.g.
+   `ColorGold = ColorIsRGB | ColorValid | 0xFFD700`. So `[gold]` already paints a
+   real RGB color, not a fragile palette index.
+
+Therefore: **overwrite `tcell.ColorNames["gold"] = <theme RGB>` and, on the next
+draw cycle, every existing `[gold]` tag in the entire UI retints** — no edits to the
+957 sites required for the named path. Because resolution is per-Draw, a theme
+switch followed by `app.Draw()` / `app.QueueUpdateDraw()` retints everything live.
+
+**The caveat (do not over-claim "zero edits"):**
+
+- **Hex tags bypass the map.** A `[#8b949e]` tag resolves via `tcell.GetColor("#8b949e")`,
+  which parses the literal hex and never reads `ColorNames`. The 23 hex tags
+  (`#8b949e`×21, plus two one-offs) are **frozen** under remap. We fix this by
+  converting them to named role tokens (§3.4) — a small, bounded edit.
+- The remap is **global process state, and its blast radius is wider than "inline
+  text tags."** `tcell.ColorNames` is not a tview-tag-only table — `tcell.GetColor("name")`
+  reads the *same* map. So overwriting `ColorNames["gold"]` changes **every** named-color
+  resolution process-wide: not just `[gold]` tags, but any `tcell.GetColor("gold")` call
+  in our code *and* any `tview.Styles` field that was assigned via a named color. Treat
+  this as a process-global side effect, not a text-tag trick. The theme module owns those
+  map keys and must restore/overwrite them atomically on switch. Document it loudly so
+  nobody reaches for `ColorNames["gold"]` expecting tcell's gold.
+  - **Pre-ship implementation step (do this before the first remap lands):** audit every
+    `tcell.GetColor("<word>")` call and every `tview.Styles` field set via a named color
+    (vs a literal `tcell.Color*` / `NewRGBColor`). For each, **decide intentionally**
+    whether it *should* track the theme (leave it reading the remapped name) or *must stay
+    fixed* (switch it to an explicit RGB literal so the remap can't drag it). Colors that
+    silently follow the theme by accident are a bug waiting to surface on the first
+    light-bg theme. This audit is Phase-1 work, not a footnote.
+- We must remap a **fixed, known set** of names and never leave a name pointing at a
+  stale value. The set is exactly the named colors in use:
+  `gold, gray, cyan, green, white, red, yellow` plus the strays we fold in.
+- This is a **deliberate use of a library implementation detail.** Pin the tview /
+  tcell versions (they already are in `go.mod`) and add a tiny guard test (§3.6) so
+  a future bump can't silently break retinting.
+
+**Mapping convention name → role.** A `[name]` tag is just the role color, looked up
+through the role:
+
+| tag name | role it maps to |
+|----------|-----------------|
+| `gold`   | Accent |
+| `gray`   | Dim |
+| `cyan`   | Label |
+| `green`  | Positive |
+| `red`    | Negative |
+| `yellow` | Highlight |
+| `white`  | Text |
+
+On theme switch:
+```go
+tcell.ColorNames["gold"]   = active.Colors[RoleAccent]
+tcell.ColorNames["gray"]   = active.Colors[RoleDim]
+tcell.ColorNames["cyan"]   = active.Colors[RoleLabel]
+tcell.ColorNames["green"]  = active.Colors[RolePositive]
+tcell.ColorNames["red"]    = active.Colors[RoleNegative]
+tcell.ColorNames["yellow"] = active.Colors[RoleHighlight]
+tcell.ColorNames["white"]  = active.Colors[RoleText]
+// ... then app.QueueUpdateDraw(func(){})
+```
+
+#### Fallback if a future tview rewrites this
+If a later tview version caches resolved colors at parse time (so map mutation no
+longer retints live), the fallback is the **semantic-helper cleanup** from §9
+promoted to mandatory: replace inline `[gold]` literals with `theme.Tag(RoleAccent)`
+helpers that emit the active hex at format time. That's the "honest" long-term form
+anyway; remap is the cheap shortcut that lets us ship retinting now without touching
+957 sites. The guard test (§3.6) tells us if/when we're forced onto the fallback.
+
+### 3.3 Routing Path B (direct widget calls) — palette routing
+
+Inline-tag remap does nothing for `SetBorderColor`, `SetBackgroundColor`,
+`SetTitleColor`, list selection, input fields. Those read a `tcell.Color` once at
+construction. We route them through the theme palette instead of literals.
+
+1. The theme module exposes `theme.Color(RoleAccent)` etc., returning the active
+   theme's `tcell.Color`.
+2. Replace literal `tcell.ColorGold` / `tcell.NewRGBColor(...)` chrome calls with
+   `theme.Color(role)`. This is a bounded set: 42 `Set*Color` call sites plus the
+   age-palette globals in `ui/theme.go`.
+3. Because these apply at construction, a **live** theme switch needs widgets to
+   re-pull. Two-tier approach:
+   - **Chrome defaults** also push into `tview.Styles` (BorderColor, TitleColor,
+     PrimitiveBackgroundColor, ContrastBackgroundColor) so *future* widgets are
+     correct.
+   - **Existing** widgets are re-styled by a `Restyle()` pass: a small registry of
+     "restylable" widgets (borders, modal bgs, the dashboard frame, list selection)
+     that the theme module walks and re-applies `Set*Color` on switch, then
+     redraws. The registry is the handful of long-lived chrome widgets, not every
+     text view (text views retint for free via §3.2).
+
+**Registration discipline — a registry someone must *remember* to populate will rot.**
+A bare "add your widget to the slice" registry guarantees that some future widget ships
+unthemed because nobody touched the registry. Make registration the *default path*, not
+an optional afterthought:
+
+- Expose a `theme.Track(widget, roleMap)` helper (and/or thin constructor wrappers like
+  `theme.NewFramedBox(...)`) that both applies the current palette *and* enrolls the
+  widget in the restyle registry in one call. Widget creation and theme enrollment
+  become a single operation, so a new chrome widget can't be created without being
+  tracked.
+- `roleMap` declares which `Set*Color` setter maps to which `Role` (e.g.
+  `{BorderColor: RoleAccent, TitleColor: RoleAccent, BackgroundColor: RoleBackground}`),
+  so `Restyle()` is fully data-driven — it re-applies exactly the roles each widget
+  declared, with no per-widget switch statement to keep in sync.
+- A lint/grep guard in CI (or a code-review checklist item) flags raw `Set*Color`
+  chrome calls outside the `theme` package and the `Track` wrappers, so the
+  "construct-without-tracking" path is caught rather than trusted.
+
+The existing `ui/theme.go` globals (`ColorTitle`, `ColorAccent`, …) become thin
+aliases over `theme.Color(role)` so existing call sites keep compiling while we
+migrate. `ApplyAgePalette` is reframed as an *optional* epoch-adaptive theme (§9),
+not a competing color authority.
+
+### 3.4 Stray hex tags
+
+The 23 hex tags (`#8b949e` dim hints, `#cc88ff`, `#ff66cc`) are frozen under remap.
+Resolve by converting them to **named role tokens**:
+- `[#8b949e]` → `[gray]` (it's already a dim hint; same role).
+- `[#cc88ff]` / `[#ff66cc]` → `[gold]` or `[yellow]` per intent (accent vs
+  highlight) — judgment call at each of the two sites.
+
+This is ~23 targeted edits, all in the same direction (hex → role token), and it
+makes those tags theme-aware for free. The two progress-bar hex constants
+(`BarFillColor = "#9370DB"`, `BarEmptyColor = "#444444"`) become role-derived: fill
+= Accent/Highlight, empty = Dim/Background. After this pass, **zero hex literals
+remain in retintable text** — the only fixed colors left are intentional ones (map
+terrain, splash art accents) which we explicitly accept.
+
+### 3.5 Module shape
+
+```
+theme/
+  theme.go      // Theme struct, Role consts, registry of built-in themes
+  palette.go    // Color(role), Tag(role) helpers; current active theme
+  remap.go      // name-remap apply + restore of tcell.ColorNames
+  restyle.go    // restylable-widget registry + Restyle() pass
+  contrast.go   // luminance + contrast-ratio guard (§8)
+  themes_*.go   // forge.go, accessible.go (deutan/protan/high_contrast), flavor.go
+```
+
+`theme` is a leaf package (depends only on tcell). `ui` depends on `theme`. No
+import cycle; no engine dependency (themes are pure presentation).
+
+### 3.6 Guard test
+A unit test asserts the remap assumption so a dependency bump can't break us
+silently:
+```go
+// Render "[gold]X" to a SimulationScreen, remap ColorNames["gold"] to a sentinel
+// RGB, redraw, and assert the cell's foreground is the sentinel. If tview ever
+// caches at parse time, this fails loudly and we switch to the §9 fallback.
+```
+Plus a contrast test (§8) over every shipped theme.
+
+---
+
+## 4. Shipped Themes
+
+All themes are code-defined RGB. Accessibility themes are `Accessible: true` and
+**unlocked by default, never milestone-gated.**
+
+### Forge (default) — `forge`
+The current dark + gold look, formalized. Dark near-black background, warm gold
+accent, gray dim, cyan labels, green/red for ±, yellow highlights, off-white text.
+This is what ships selected.
+
+### Deuteranopia-safe — `deuteranopia` *(accessible, default-unlocked)*
+### Protanopia-safe — `protanopia` *(accessible, default-unlocked)*
+Critical constraint: in AgeForge **green = gains and red = losses everywhere** —
+resource deltas, rates, combat, trade. Red-green deficiency makes that distinction
+collapse. So the accessible palettes **must not encode ± with red vs green.**
+
+- **Positive → blue** (e.g. `#3B9EFF`), **Negative → orange** (e.g. `#FF8C42`).
+  Blue/orange is the canonical deutan/protan-safe opposition and stays distinct under
+  both simulations.
+- **Belt-and-suspenders: signed glyphs.** Accessible themes set `GainGlyph`/`LossGlyph`
+  (`▲`/`▼`, or `+`/`-`) so the sign is encoded by **shape as well as hue**. Delta
+  formatting helpers consult the active theme's glyphs; non-accessible themes can
+  leave them empty. This is the redundant-encoding principle — never rely on color
+  alone for meaning.
+- Accent/Highlight/Label chosen to stay mutually distinguishable under deutan/protan
+  simulation (favor blue/yellow/white spread; avoid accent≈positive collisions).
+- Deutan and protan ship as separate themes because their safe hues differ slightly;
+  one "colorblind" catch-all under-serves both.
+
+### High Contrast — `high_contrast` *(accessible, default-unlocked)*
+Maximum legibility: pure/near-pure background, white text, saturated unambiguous role
+colors, every role pair comfortably above the WCAG AA contrast floor (§8 enforces
+this). For low-vision players and high-glare terminals.
+
+### Flavor themes (milestone-gated, §5)
+Curated, code-defined, **cosmetic only** — they never alter the ± encoding semantics
+in a way that breaks accessibility expectations (and still pass the contrast guard).
+Candidates:
+- **Parchment** — light sepia background, ink-brown text, wax-red/forest-green ±.
+  (Our first light-background theme; a real contrast-guard exercise.)
+- **Bronze Age** — burnished metallics.
+- **Cyberpunk** — magenta/cyan neon on black (riffs on the existing `cyberpunk_age`
+  age palette).
+- **Monochrome Terminal** — amber-on-black or green-on-black retro CRT.
+- **Cosmic** — deep indigo with starlight accents (riffs on `galactic_age`).
+
+Exact RGB values are filled in during Phase 2 against the contrast guard; the guard
+is the acceptance gate, not a designer's eyeball.
+
+---
+
+## 5. Milestone-Gated Unlocks
+
+Flavor themes unlock through the existing milestone system; accessibility + Forge are
+always available.
+
+- Each gated theme declares an unlock condition: a milestone key or chain key (e.g.
+  Cyberpunk unlocks on reaching `cyberpunk_age`; Parchment on a renaissance
+  milestone). The mapping lives in the theme registry, not scattered in milestone
+  code.
+- **Unlock state is account-wide.** When a milestone/chain completes, the game records
+  the unlock in the **account/settings layer** (`accounts.md`). It is *not* stored in
+  `data/saves/*.json` — earn Cyberpunk on one empire and it's yours on every save and
+  every future new game. This mirrors how badges feel permanent, but lives in the
+  proper account store rather than being peeked from a save.
+- Hook point: `MilestoneManager.CheckMilestones` / `CheckChains` already return
+  newly-completed milestones/chains. On a new completion, the UI layer asks the theme
+  registry "does this unlock a theme?" and, if so, calls `account.UnlockTheme(key)`. That
+  call returns `(newly bool, err)`: **we fire the unlock notification (§7) only when
+  `newly == true`**, so replaying a milestone (or re-running a chain check) never re-toasts
+  an already-owned theme. We add a thin theme-unlock resolver; we do **not** bake theme
+  keys into engine code.
+- This doc treats the account layer as a dependency, and uses **`accounts.md`'s exact
+  names** so the two docs can't drift: `UnlockTheme(key) (newly bool, err error)`,
+  `HasTheme(key) bool`, `UnlockedThemes() []string`, `ActiveTheme() string`,
+  `SetActiveTheme(key) error`. (Earlier drafts of this doc said `IsThemeUnlocked` — the
+  account layer names it `HasTheme`; we use `HasTheme` here too.) `accounts.md` §8 is the
+  authoritative signature list.
+
+---
+
+## 6. Persistence
+
+- **Active theme** and **unlocked-theme set** live in the **account/settings layer**
+  — concretely `data/account.json`, HMAC-signed for consistency with saves. (`accounts.md`
+  §3 makes this a firm decision: one signed `account.json`, not a to-be-decided choice.)
+  **Never** in per-save JSON.
+- Rationale: theme is a player preference and a player-account achievement, not
+  empire state. Loading an old save must not change your theme; starting a new game
+  must not relock your earned themes.
+- The save format (`game/save.go` `GameSave`) is **untouched**. No new fields.
+- On startup the UI reads the account layer, resolves the active theme (default
+  `forge` if unset or if the stored key is unknown), and applies it (remap + restyle)
+  **before** the first Draw, so the splash already wears the chosen theme.
+- Defensive: if the stored active theme is somehow locked or missing, fall back to
+  Forge and don't crash.
+
+---
+
+## 7. UX
+
+### Main-menu Theme picker
+A "Themes" entry on the splash `mainList` (alongside Load / New Game / Quit). Opens a
+picker page modeled directly on the **load-game browser** (`ui/load_game.go`): a list
+on the left, a detail/preview pane on the right.
+
+### `theme` command
+Available from the in-game `>` prompt via `HandleCommand` (`ui/input.go`):
+- `theme` — opens the picker (returns `CommandResult{OverlayName: "theme"}`).
+- `theme list` — prints unlocked vs locked themes (locked ones show their unlock
+  condition, e.g. "Cyberpunk — reach the Cyberpunk Age").
+- `theme <name>` — switches directly to a theme by key/name if unlocked; errors with
+  the unlock hint if locked, errors "unknown theme" otherwise.
+
+Add a `case "theme":` to the dispatch switch returning the above.
+
+### Live preview (apply-on-highlight, revert-on-cancel)
+Exactly the load-game detail-pane pattern: the picker list's `SetChangedFunc` fires
+on highlight. On highlight we **apply the theme for real** (remap + restyle + redraw)
+so the player sees the whole UI in that theme immediately — the picker is itself a
+live sample of the running UI. We remember the theme that was active on open.
+- **Confirm** (Enter / select): persist the highlighted theme as active via the
+  account layer; close.
+- **Cancel** (Esc): re-apply the remembered original theme; close. No persistence.
+
+Because retinting is a global remap, "preview" and "apply" are the same operation —
+the only difference is whether we persist and whether cancel reverts. Clean.
+
+### Palette swatches
+The picker detail pane shows the theme's blurb plus a swatch row — one colored block
+per role rendered with that role's color tag, labeled (Accent / Positive / Negative /
+…). For accessible themes, show the gain/loss **glyphs** next to the ± swatches so the
+redundant encoding is visible in the picker itself. Locked themes show swatches dimmed
+with a lock marker and the unlock condition.
+
+### Unlock notification
+When a milestone grants a theme (§5), surface it through the existing toast/log
+channel (the same path milestone completions already use), e.g. *"New theme unlocked:
+Cyberpunk — switch in Themes (`theme cyberpunk`)."* Non-modal; don't interrupt play.
+**Gate the toast on `account.UnlockTheme` returning `newly == true`** — `UnlockTheme` is
+idempotent (re-unlocking an owned theme is a no-op that returns `newly == false`), so a
+milestone re-fire or a redundant chain check must not produce a duplicate "unlocked!"
+toast. Only a genuinely-new unlock notifies.
+
+---
+
+## 8. Contrast-Safety Guard
+
+No unreadable theme ships. The Parchment (light-bg) theme and the contrast bug we
+already hit are the motivation: a modal input once used a light field background with
+white text and was effectively invisible until we set an explicit dark field bg
+(`ui/newgame_modal.go`). A theme that does that to the whole UI is unacceptable.
+
+### Check: WCAG luminance contrast ratio
+For each theme, compute the contrast ratio between every **foreground role** (Text,
+Dim, Label, Accent, Highlight, Positive, Negative) and the theme's **Background**
+(and, for Selection, against text drawn on the selection bg):
+
+```
+L = relative luminance per WCAG (sRGB linearization, 0.2126 R + 0.7152 G + 0.0722 B)
+ratio = (Llighter + 0.05) / (Ldarker + 0.05)   // 1.0 .. 21.0
+```
+
+Thresholds:
+- Body roles (Text, Label, Positive, Negative, Highlight) vs Background: **>= 4.5**
+  (WCAG AA normal text).
+- Dim vs Background: **>= 3.0** (it's intentionally secondary, AA large-text floor).
+- Accent vs Background: **>= 3.0** (often borders/titles, large glyphs).
+- Text on Selection background: **>= 4.5**.
+
+### Check: colorblind distinguishability (simulation, not luminance)
+
+Luminance contrast and colorblind distinguishability are **different properties** — two
+hues can clear 4.5:1 against the background yet be nearly identical to a deuteranope.
+The accessible palettes (§4) are *designed* to keep Accent/Positive/Negative/Highlight
+mutually distinct under deutan/protan deficiency, but "designed to" must be backed by a
+test, not by a sighted developer's eyeball.
+
+So the guard ALSO runs the accessible palettes through **deuteranopia and protanopia
+simulation** (a standard CVD transform — Brettel/Viénot or Machado — applied to each
+role's RGB), then asserts that the post-simulation role colors stay separated by a
+minimum perceptual distance (e.g. a ΔE floor in a perceptually-uniform space). This is
+what actually catches an **Accent ≈ Positive collision** under simulated deficiency — a
+class of bug luminance contrast is blind to. Run it at least on the accessible themes;
+running it on all themes is cheap and worthwhile.
+
+### Enforcement
+A `theme_contrast_test.go` iterates every shipped theme and fails the build if any
+pair is under its floor. Themes are tuned against the test, not by eye. This is also
+where the §3.6 remap guard lives. Net effect: **on truecolor terminals, an unreadable
+theme cannot reach players** because it can't pass CI.
+
+### The limitation, stated honestly: 256-color terminals can still erode contrast
+
+The guard computes WCAG luminance on the theme's **declared truecolor RGB**. But on a
+256-color (or 16-color) terminal, tcell **down-samples** each declared RGB to the
+nearest palette slot — and a pair that clears 4.5:1 in truecolor can collapse below the
+floor once both ends snap to neighboring palette entries. This is worst for
+**light-background themes like Parchment**, where the foreground/background luminances
+are already close and quantization has more room to flip the ratio. So the strong claim
+("cannot reach players") only holds on truecolor terminals; on 256-color terminals a
+"passing" theme can still be marginal.
+
+We have two honest options, and should pick one rather than wave at it:
+
+- **Scope the guarantee:** state plainly that the contrast guarantee applies to
+  truecolor terminals, and document that 256-color rendering is best-effort. Simplest;
+  acceptable if truecolor is effectively required.
+- **Add a 256-color-quantized check:** for light-background themes (and ideally all
+  themes), quantize each role color through tcell's own 256-color down-sample, then
+  re-run the contrast ratio on the *quantized* values against the same floors. This
+  catches the Parchment-style collapse in CI instead of in a player's terminal.
+
+Recommended: ship the truecolor check for everything *and* the quantized check for
+light-bg themes, since those are where quantization actually bites.
+
+---
+
+## 9. Stretch / Future
+
+- **Epoch-adaptive auto-theme.** Generalize the existing `ApplyAgePalette` into a
+  proper theme: an "Adaptive" pseudo-theme that retints role colors as the player
+  advances epochs (Bronze warmth → Industrial grime → Cosmic indigo). Now that all
+  color flows through one palette, this is "swap the active palette on age-change"
+  rather than the current half-measure that only touches chrome. Must still pass the
+  contrast guard at every age step.
+- **Semantic-token cleanup (also the §3.2 fallback).** Replace inline `[gold]`
+  literals with `theme.Tag(RoleAccent)` helpers that emit the active color at format
+  time. This removes the reliance on the tcell-map-mutation implementation detail
+  entirely and is the honest long-term form. Large but mechanical; do it lineage-area
+  by lineage-area. Mandatory only if a tview bump breaks remap.
+- **User-authored themes.** Read extra themes from `data/themes/*.json`, run them
+  through the same contrast guard at load, reject ones that fail. Lets the community
+  share palettes without code changes.
+
+---
+
+## 10. Phased Implementation Plan
+
+Ordered so something visible lands early. Each phase is independently shippable.
+
+### Phase 1 — Theme spine + Forge + accessibility themes (visible win)
+- Add the `theme` package: `Theme`/`Role` model, palette accessors, the name-remap
+  apply/restore (`remap.go`), the restylable-widget registry (`restyle.go`).
+- Define **Forge**, **Deuteranopia**, **Protanopia**, **High Contrast** (accessible,
+  default-unlocked).
+- Convert the 23 hex tags + the two bar-color constants to role tokens (§3.4).
+- Add the `theme` command + main-menu Themes entry + picker with live preview and
+  swatches.
+- Add the contrast guard test (§8) and the remap guard test (§3.6).
+- **Theme choice persists in-memory / process-local for now** if `accounts.md` isn't
+  landed yet — wire to a stub `ActiveTheme/SetActiveTheme` so the picker works end to
+  end. Visible result: a player can switch between four legible themes live.
+- **Cross-doc dependency: Phase 1 has NO dependency on `accounts.md`.** It ships against a
+  stub account API (`HasTheme`/`UnlockTheme`/`ActiveTheme`/`SetActiveTheme`), so theming
+  Phase 1 can land *before* the account system exists. This is deliberate — it keeps the
+  two tracks from being scheduled into a deadlock.
+
+### Phase 2 — Account-wide persistence
+- **Cross-doc dependency: this phase REQUIRES `accounts.md` Phase 3 (the unlock API).**
+  Theming Phase 2 replaces the Phase-1 stub with the real `account.HasTheme` /
+  `UnlockTheme` / `ActiveTheme` / `SetActiveTheme`, so it cannot start until accounts
+  Phase 3 (`HasTheme`/`UnlockTheme`/`UnlockedThemes`/`ActiveTheme`/`SetActiveTheme`) has
+  landed. Named here and in `accounts.md` §9 so neither plan can be scheduled to block the
+  other.
+- Integrate with the account/settings layer (`accounts.md`): persist active theme +
+  unlocked set; load and apply before first Draw.
+- Default-unlock all accessible themes + Forge; everything flavor starts locked.
+- Migrate the `ui/theme.go` age-palette globals to thin aliases over `theme.Color`.
+
+### Phase 3 — Flavor themes + milestone unlocks
+- Define flavor themes (Parchment, Bronze, Cyberpunk, Monochrome, Cosmic), each
+  tuned to pass the contrast guard.
+- Add the theme-unlock resolver hooked to `CheckMilestones`/`CheckChains`; persist
+  unlocks account-wide; fire the unlock notification.
+- Picker shows locked themes with unlock conditions; `theme list` reflects state.
+
+### Phase 4 — Stretch
+- Epoch-adaptive Adaptive theme (generalize `ApplyAgePalette`).
+- Begin the semantic-token cleanup (`theme.Tag`) — and keep it on the shelf as the
+  hard fallback if a dependency bump ever breaks the remap.
+- Optionally: user-authored `data/themes/*.json` with contrast-gated loading.
+
+---
+
+## Appendix — wiki sync
+
+Per project rules, the shipping change updates `site/`:
+- `site/docs/commands.md` — document the `theme` command (`theme`, `theme list`,
+  `theme <name>`).
+- A new/updated accessibility section in the wiki noting colorblind + high-contrast
+  themes ship unlocked.
+- Any wiki page that asserts "green = gain / red = loss" should note accessible
+  themes use blue/orange + glyphs instead.


### PR DESCRIPTION
Two implementation-ready design docs — researched, adversarially reviewed, and revised against that review.

## design-and-architecture/theming.md
Swappable color themes.
- **Feasibility confirmed against the pinned source:** `tview` re-resolves named colors per-frame through the mutable `tcell.ColorNames` map, so remapping `"gold"` retints all **~915 named tags for free**. The **~42 direct `tcell` calls + ~23 hex tags** are the real Phase-1 edits (via a palette + a *tracked-widget* restyle registry so new widgets can't silently miss theming). One audited caveat: `ColorNames` is process-global (`tcell.GetColor` + `tview.Styles` share it).
- **Disability themes day one, never gated:** deuteranopia/protanopia-safe (blue/orange for ±, *not* red/green) + signed glyphs, plus high-contrast. Contrast guard checks WCAG luminance **and** colorblind-sim separation.
- Milestone unlocks (account-wide), main-menu picker + `theme` command, live preview + swatches. 4 phases; Phase 1 ships against a stubbed account API.

## design-and-architecture/accounts.md
A persistent per-player identity, no server.
- **Recommends a hybrid:** a signed local `account.json` (reusing `save.go`'s HMAC + atomic-write) as source of truth; a short **recovery code** for IDENTITY; an **export blob** for DATA — directly answering the "don't cram data in a seed" worry by separating the two. Honest throughout: no server means recovery needs a backup; we make the backup small, we can't conjure data from nothing.
- **Load-bearing invariant** (the review's top catch): any `account_id` write onto an *existing* save MUST go through `SaveGame` so the HMAC recomputes — otherwise a false "⚠ modified" badge. Called out in §3.5 and §6.
- Recovery code is a convenience identifier, not a credential (shared HMAC key) — stated plainly. Leaves the elite easter egg + signing untouched.

## Process
Drafted by parallel agents grounded in the real code → adversarial critique (verified against tview/tcell source + save.go) → revised to close every gap. No code yet — these define the phased plans.

Trello: Project-Theme + Project-Account epics.
