### PR TITLE
feat(account): storage substrate — signed account.json (phase 1)

### DIFF
--- a/game/account.go
+++ b/game/account.go
@@ -1,0 +1,219 @@
+package game
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// accountSchemaVersion is the on-disk schema version of account.json. Bumped only
+// for migrations; readers default unknown/older fields to zero (accounts.md §3.3).
+const accountSchemaVersion = 1
+
+// accountFileName is the fixed base name of the account file under the data dir.
+// v1 resolves a single account.json — no multi-profile layout yet (accounts.md §3.1).
+const accountFileName = "account.json"
+
+// AccountUnlocks holds account-wide cosmetic unlocks (DATA, accounts.md §3.3).
+// Phase 1 only round-trips these; the unlock API lands in Phase 3.
+type AccountUnlocks struct {
+	Themes []string `json:"themes,omitempty"`
+}
+
+// AccountStats holds lifetime, cross-save aggregates (DATA, accounts.md §3.3).
+// Phase 1 only round-trips these; the engine hooks land in Phase 6.
+type AccountStats struct {
+	TotalPrestiges       int    `json:"total_prestiges,omitempty"`
+	HighestAge           string `json:"highest_age,omitempty"`
+	CivilizationsStarted int    `json:"civilizations_started,omitempty"`
+	SavesCompleted       int    `json:"saves_completed,omitempty"`
+}
+
+// AccountPrefs holds preferences that travel with the account (accounts.md §3.3).
+// Phase 1 only round-trips these; SetActiveTheme et al. land in Phase 3.
+type AccountPrefs struct {
+	ActiveTheme string `json:"active_theme,omitempty"`
+}
+
+// Account is the per-player identity + meta-progression record, persisted to
+// data/account.json. It is the single source of truth for identity (account ID,
+// display name) and DATA (unlocks, lifetime stats, achievements, prefs).
+//
+// Integrity mirrors saves: Signature is the HMAC-SHA256 of the payload (with
+// Signature zeroed) under saveHMACKey. A tampered file still loads — Tampered is
+// set instead, the cosmetic analogue of the save CheaterBadge (accounts.md §3.4).
+// The schema follows accounts.md §3.3; all DATA fields are present so the file
+// round-trips, but the unlock/stats/prefs APIs that mutate them arrive in later
+// phases.
+type Account struct {
+	Version     int       `json:"version"`
+	AccountID   string    `json:"account_id"`
+	DisplayName string    `json:"display_name,omitempty"`
+	Created     time.Time `json:"created"`
+	LastSeen    time.Time `json:"last_seen,omitempty"`
+
+	// --- meta-progression (DATA) ---
+	Unlocks      AccountUnlocks `json:"unlocks,omitempty"`
+	Stats        AccountStats   `json:"stats,omitempty"`
+	Achievements []string       `json:"achievements,omitempty"`
+
+	// --- preferences (travel with the account) ---
+	Prefs AccountPrefs `json:"prefs,omitempty"`
+
+	// --- integrity (same scheme as saves) ---
+	Signature string `json:"_sig,omitempty"`
+
+	// Tampered is the in-memory, non-persisted cosmetic flag set when a loaded
+	// file's signature does not match (accounts.md §3.4). It mirrors the save
+	// CheaterBadge: signalling, not a lockout. json:"-" keeps it off disk.
+	Tampered bool `json:"-"`
+}
+
+// newAccountID returns a fresh, stable account ID: 16 random bytes from crypto/rand,
+// hex-encoded (accounts.md §3.3 — 128 random bits, not a v4 UUID specifically).
+func newAccountID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to generate account id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// newAccount builds a fresh, unsigned Account with a new ID and Created/LastSeen
+// set to now. The caller is responsible for calling Save to sign and persist it.
+func newAccount() (*Account, error) {
+	id, err := newAccountID()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	return &Account{
+		Version:   accountSchemaVersion,
+		AccountID: id,
+		Created:   now,
+		LastSeen:  now,
+	}, nil
+}
+
+// accountPath resolves the full path to account.json, mirroring savePath's
+// resolution: prefer the binary-relative data/account.json; if that is absent,
+// fall back to a CWD-relative data/account.json (legacy/dev-run); default to the
+// binary-relative path for new writes (accounts.md §3.1).
+func accountPath() string {
+	primary := filepath.Join(dataDirectory(), accountFileName)
+	if _, err := os.Stat(primary); err == nil {
+		return primary
+	}
+	legacy := filepath.Join("data", accountFileName)
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy
+	}
+	return primary // default to canonical for new writes
+}
+
+// signAccount returns the HMAC-SHA256 hex of the account payload with Signature
+// zeroed, so the signature covers the data only — identical construction to
+// signSave, sharing the hmacSign helper (accounts.md §3.4).
+func signAccount(a Account) string {
+	a.Signature = ""
+	a.Tampered = false // json:"-" already excludes it, but keep the payload pristine
+	data, _ := json.Marshal(a)
+	return hmacSign(data, saveHMACKey)
+}
+
+// verifyAccount reports whether a's stored Signature matches a freshly computed
+// one. An unsigned file (empty Signature) is treated as legacy/benign-valid, the
+// same benefit-of-the-doubt verifySave grants unsigned saves (accounts.md §3.4).
+func verifyAccount(a *Account) bool {
+	if a.Signature == "" {
+		return true
+	}
+	return hmac.Equal([]byte(a.Signature), []byte(signAccount(*a)))
+}
+
+// Save signs the account with the shared HMAC helper and writes it atomically
+// (temp file + os.Rename), creating the data dir if missing. Mirrors SaveGame's
+// write discipline (accounts.md §3.4).
+func (a *Account) Save() error {
+	dir := dataDirectory()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	a.Signature = signAccount(*a)
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal account: %w", err)
+	}
+
+	// Write to the resolved path (canonical, or the legacy CWD location if that is
+	// where the existing file lives) so we don't orphan a dev-run account.json.
+	path := accountPath()
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write account: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to finalize account: %w", err)
+	}
+	return nil
+}
+
+// LoadOrCreate resolves data/account.json and returns the live Account, creating
+// one transparently when needed (accounts.md §6/§7). Behavior by file state:
+//
+//   - Absent: generate a fresh account (new ID, Created=now), Save it, return it.
+//   - Present + parses + signature valid (or unsigned/legacy): return it.
+//   - Present + parses + signature INVALID: return it with Tampered=true set —
+//     a cosmetic flag, not a lockout. The file is NOT deleted.
+//   - Present but UNPARSEABLE: back the bad file up to account.json.corrupt, then
+//     create + Save a fresh account and return it.
+//
+// Note: this phase does not stamp LastSeen on load (that is Phase 2 startup
+// wiring); LoadOrCreate's contract here is read-or-create, leaving the on-disk
+// file untouched on the valid/tampered paths.
+func LoadOrCreate() (*Account, error) {
+	path := accountPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			acct, err := newAccount()
+			if err != nil {
+				return nil, err
+			}
+			if err := acct.Save(); err != nil {
+				return nil, err
+			}
+			return acct, nil
+		}
+		return nil, fmt.Errorf("failed to read account: %w", err)
+	}
+
+	var acct Account
+	if err := json.Unmarshal(data, &acct); err != nil {
+		// Corrupt / unparseable → back it up, then start fresh (accounts.md §7).
+		backup := path + ".corrupt"
+		if renameErr := os.Rename(path, backup); renameErr != nil {
+			return nil, fmt.Errorf("account file is corrupt and could not be backed up: %w", renameErr)
+		}
+		fresh, newErr := newAccount()
+		if newErr != nil {
+			return nil, newErr
+		}
+		if saveErr := fresh.Save(); saveErr != nil {
+			return nil, saveErr
+		}
+		return fresh, nil
+	}
+
+	if !verifyAccount(&acct) {
+		// Signature present but mismatched → tampered. Flag it, still load it.
+		acct.Tampered = true
+	}
+	return &acct, nil
+}

--- a/game/account_test.go
+++ b/game/account_test.go
@@ -1,0 +1,244 @@
+package game
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// isolateAccountDir points the data root at an isolated temp directory for the
+// duration of the test, so we never read or clobber a real ./data/account.json.
+//
+// It sets the package-level dataDirOverride test seam (see save.go) to a fresh
+// t.TempDir() and restores the prior value on cleanup. With the override set,
+// dataDirectory() — and therefore accountPath(), Save(), and LoadOrCreate() —
+// resolve entirely inside the temp dir, deterministically and without depending on
+// CWD or the test binary's location. Go runs tests in a package sequentially unless
+// t.Parallel() is called (none here do), so the shared override is safe.
+func isolateAccountDir(t *testing.T) string {
+	t.Helper()
+	prior := dataDirOverride
+	tmp := t.TempDir()
+	dataDirOverride = tmp
+	t.Cleanup(func() {
+		dataDirOverride = prior
+	})
+	return tmp
+}
+
+// accountFilePath returns the account.json path inside the isolated data root.
+func accountFilePath() string {
+	return filepath.Join(dataDirOverride, accountFileName)
+}
+
+// TestLoadOrCreateCreatesAndSigns covers the absent-file path: a fresh account is
+// created, signed, persisted, and re-loadable with a valid signature.
+func TestLoadOrCreateCreatesAndSigns(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (create): %v", err)
+	}
+	if acct.AccountID == "" {
+		t.Fatal("created account has empty AccountID")
+	}
+	if len(acct.AccountID) != 32 { // 16 bytes hex-encoded
+		t.Errorf("AccountID = %q (len %d), want 32 hex chars", acct.AccountID, len(acct.AccountID))
+	}
+	if acct.Version != accountSchemaVersion {
+		t.Errorf("Version = %d, want %d", acct.Version, accountSchemaVersion)
+	}
+	if acct.Created.IsZero() {
+		t.Error("Created timestamp is zero")
+	}
+	if acct.Signature == "" {
+		t.Error("created account was not signed (empty Signature)")
+	}
+	if acct.Tampered {
+		t.Error("freshly created account flagged Tampered")
+	}
+
+	// File must exist on disk and verify.
+	if _, err := os.Stat(accountFilePath()); err != nil {
+		t.Fatalf("account.json not written: %v", err)
+	}
+	if !verifyAccount(acct) {
+		t.Error("freshly created account fails signature verification")
+	}
+}
+
+// TestLoadOrCreateRoundTrips covers create → load: a second LoadOrCreate returns
+// the same account (same ID), with a valid signature and no tamper flag.
+func TestLoadOrCreateRoundTrips(t *testing.T) {
+	isolateAccountDir(t)
+
+	first, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (first): %v", err)
+	}
+	second, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (second): %v", err)
+	}
+	if first.AccountID != second.AccountID {
+		t.Errorf("ID changed across load: %q != %q", first.AccountID, second.AccountID)
+	}
+	if second.Tampered {
+		t.Error("round-tripped account flagged Tampered")
+	}
+	if !verifyAccount(second) {
+		t.Error("round-tripped account fails signature verification")
+	}
+}
+
+// TestSaveRoundTripsDataFields confirms the DATA fields persist and reload, and the
+// signature still verifies after a Save that mutates them.
+func TestSaveRoundTripsDataFields(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	id := acct.AccountID
+	acct.DisplayName = "Adam"
+	acct.Unlocks.Themes = []string{"amber_crt", "obsidian"}
+	acct.Stats.TotalPrestiges = 14
+	acct.Stats.HighestAge = "bronze_age"
+	acct.Achievements = []string{"first_prestige"}
+	acct.Prefs.ActiveTheme = "obsidian"
+	if err := acct.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reloaded, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (reload): %v", err)
+	}
+	if reloaded.AccountID != id {
+		t.Errorf("ID changed: %q != %q", reloaded.AccountID, id)
+	}
+	if reloaded.DisplayName != "Adam" {
+		t.Errorf("DisplayName = %q, want Adam", reloaded.DisplayName)
+	}
+	if len(reloaded.Unlocks.Themes) != 2 || reloaded.Unlocks.Themes[0] != "amber_crt" {
+		t.Errorf("Unlocks.Themes = %v, want [amber_crt obsidian]", reloaded.Unlocks.Themes)
+	}
+	if reloaded.Stats.TotalPrestiges != 14 || reloaded.Stats.HighestAge != "bronze_age" {
+		t.Errorf("Stats not round-tripped: %+v", reloaded.Stats)
+	}
+	if reloaded.Prefs.ActiveTheme != "obsidian" {
+		t.Errorf("Prefs.ActiveTheme = %q, want obsidian", reloaded.Prefs.ActiveTheme)
+	}
+	if reloaded.Tampered {
+		t.Error("reloaded account flagged Tampered after legitimate Save")
+	}
+	if !verifyAccount(reloaded) {
+		t.Error("reloaded account fails signature verification after legitimate Save")
+	}
+}
+
+// TestLoadOrCreateTamperedSetsFlag covers the tampered path: a field is changed on
+// disk WITHOUT re-signing, so the signature no longer matches. LoadOrCreate must
+// still return the account but with Tampered=true, and must NOT delete the file.
+func TestLoadOrCreateTamperedSetsFlag(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (create): %v", err)
+	}
+	id := acct.AccountID
+
+	// Read the signed file, mutate a field without re-signing, write it back.
+	path := accountFilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read account: %v", err)
+	}
+	var onDisk map[string]any
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("unmarshal account: %v", err)
+	}
+	onDisk["display_name"] = "intruder" // changes payload, stale _sig now mismatches
+	tampered, err := json.Marshal(onDisk)
+	if err != nil {
+		t.Fatalf("re-marshal tampered: %v", err)
+	}
+	if err := os.WriteFile(path, tampered, 0644); err != nil {
+		t.Fatalf("write tampered account: %v", err)
+	}
+
+	loaded, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (tampered): %v", err)
+	}
+	if !loaded.Tampered {
+		t.Error("tampered account not flagged Tampered")
+	}
+	if loaded.AccountID != id {
+		t.Errorf("tampered account ID changed: %q != %q (file should not be recreated)", loaded.AccountID, id)
+	}
+	if loaded.DisplayName != "intruder" {
+		t.Errorf("tampered account loaded with DisplayName = %q, want intruder (still loaded, not discarded)", loaded.DisplayName)
+	}
+	// File must NOT be deleted or backed up — tamper is cosmetic, not a lockout.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("tampered account file was removed: %v", err)
+	}
+	if _, err := os.Stat(path + ".corrupt"); !os.IsNotExist(err) {
+		t.Error("tampered (parseable) account wrongly produced a .corrupt backup")
+	}
+}
+
+// TestLoadOrCreateCorruptBacksUpAndRecreates covers the unparseable path: garbage
+// JSON on disk must be renamed to account.json.corrupt and a fresh account created.
+func TestLoadOrCreateCorruptBacksUpAndRecreates(t *testing.T) {
+	isolateAccountDir(t)
+
+	// Seed a valid account first so the file lives at the resolved path, then
+	// clobber it with non-JSON.
+	first, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (seed): %v", err)
+	}
+	path := accountFilePath()
+	if err := os.WriteFile(path, []byte("this is not json {{{"), 0644); err != nil {
+		t.Fatalf("write corrupt account: %v", err)
+	}
+
+	fresh, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (corrupt): %v", err)
+	}
+	// A brand-new account: valid sig, no tamper flag, and a different ID than the
+	// (now-corrupted) original.
+	if fresh.AccountID == "" {
+		t.Fatal("fresh account after corrupt has empty AccountID")
+	}
+	if fresh.AccountID == first.AccountID {
+		t.Error("fresh account reused the corrupt account's ID (should be regenerated)")
+	}
+	if fresh.Tampered {
+		t.Error("fresh account after corrupt flagged Tampered")
+	}
+	if !verifyAccount(fresh) {
+		t.Error("fresh account after corrupt fails signature verification")
+	}
+
+	// The .corrupt backup must exist and hold the original garbage bytes.
+	backup := path + ".corrupt"
+	got, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("expected .corrupt backup, got: %v", err)
+	}
+	if string(got) != "this is not json {{{" {
+		t.Errorf(".corrupt backup = %q, want the original garbage bytes", string(got))
+	}
+	// And the live file must parse + verify again.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("fresh account.json not written after corrupt recovery: %v", err)
+	}
+}

--- a/game/save.go
+++ b/game/save.go
@@ -81,6 +81,17 @@ type GameSave struct {
 	Proof      string `json:"_proof,omitempty"`
 }
 
+// hmacSign returns the HMAC-SHA256 of payload under key, hex-encoded. This is the
+// shared integrity-signing core used by both saves (signSave) and the account file
+// (Account.Save) — one construction, reused, per the accounts.md "reuse, don't
+// reinvent" rule. The key is always saveHMACKey in practice; it stays a parameter
+// so signSave's existing signature is unchanged.
+func hmacSign(payload []byte, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
 // signSave returns the HMAC-SHA256 hex of the save payload.
 // Signature and Proof are zeroed before marshalling so the signature covers
 // the game data only, not a prior signature value.
@@ -88,9 +99,7 @@ func signSave(gs GameSave, key string) string {
 	gs.Signature = ""
 	gs.Proof = ""
 	data, _ := json.Marshal(gs)
-	mac := hmac.New(sha256.New, []byte(key))
-	mac.Write(data)
-	return hex.EncodeToString(mac.Sum(nil))
+	return hmacSign(data, key)
 }
 
 // verifySave checks the save's HMAC signature and optional elite proof.
@@ -201,18 +210,36 @@ type UnlockedState struct {
 	Workers   []string `json:"workers"`
 }
 
-// saveDirectory returns the canonical save directory: data/saves/ next to the binary.
-// Falls back to a CWD-relative path if the binary path cannot be determined.
-func saveDirectory() string {
+// dataDirOverride, when non-empty, forces dataDirectory to return it verbatim.
+// It exists solely so tests can isolate the data root (saves/account) into a temp
+// directory without touching a real ./data. Production code never sets it; it is
+// empty by default, so the binary-relative resolution below is the only path that
+// runs outside tests.
+var dataDirOverride string
+
+// dataDirectory returns the canonical data root: data/ next to the binary, resolved
+// via os.Executable + EvalSymlinks. Falls back to a CWD-relative "data" if the
+// binary path cannot be determined. Saves, accounts, and (eventually) logs share
+// this one root and one fallback rule (accounts.md §3.1).
+func dataDirectory() string {
+	if dataDirOverride != "" {
+		return dataDirOverride
+	}
 	exe, err := os.Executable()
 	if err != nil {
-		return "data/saves"
+		return "data"
 	}
 	exe, err = filepath.EvalSymlinks(exe)
 	if err != nil {
-		return "data/saves"
+		return "data"
 	}
-	return filepath.Join(filepath.Dir(exe), "data", "saves")
+	return filepath.Join(filepath.Dir(exe), "data")
+}
+
+// saveDirectory returns the canonical save directory: data/saves/ next to the binary.
+// Falls back to a CWD-relative path if the binary path cannot be determined.
+func saveDirectory() string {
+	return filepath.Join(dataDirectory(), "saves")
 }
 
 // savePath returns the full path for a named save file.


### PR DESCRIPTION
## Account foundation — Phase 1: storage substrate

Per `design-and-architecture/accounts.md` §3/§9. **Storage only** — no UI, no startup wiring, no save attribution yet (those are Phases 2+).

### Behavior-preserving refactor
- Extracted `dataDirectory()` out of `saveDirectory()` (so saves + account share the binary-relative `data/` dir with the same CWD fallback).
- Extracted a shared `hmacSign()` out of `signSave()`.
- The **full suite stays green — including the golden, lineage, and save tests** — proving signatures and paths are byte-identical.

### New `game/account.go`
- `Account` struct matching the doc's §3.3 schema (version, id, created, display name, forward-compat unlock/stats/prefs data, `_sig`).
- `LoadOrCreate()` handles all four paths: fresh-create · valid-load · **tampered** (loads with a non-persisted `Tampered` flag, never deleted) · **corrupt** (backs up to `account.json.corrupt`, creates fresh).
- `Save()` reuses the HMAC + temp-file/`os.Rename` atomic write from the save system.
- Kept in package `game` (per the build plan) to reuse `saveHMACKey` + dir helpers without exporting internals; a `dataDirOverride` seam isolates tests so they never touch a real `data/account.json`.

### Tests
create→sign→verify · round-trip (same id) · data-field round-trip · tampered→flag set + file preserved · corrupt→fresh + `.corrupt` backup. `go build/vet/test` all green.

### Next
**Phase 2** — `LoadOrCreate` at app boot + lazy `account_id` stamping on saves (through `SaveGame`, so the HMAC recomputes — the invariant from the design review).

Trello: https://trello.com/c/AxjbiTF1
