### PR TITLE
feat(account): boot wiring + lazy save attribution (phase 2)

### DIFF
--- a/game/account.go
+++ b/game/account.go
@@ -72,6 +72,13 @@ type Account struct {
 	// file's signature does not match (accounts.md §3.4). It mirrors the save
 	// CheaterBadge: signalling, not a lockout. json:"-" keeps it off disk.
 	Tampered bool `json:"-"`
+
+	// FreshlyCreated is the in-memory, non-persisted signal that LoadOrCreate just
+	// minted this account on its fresh-create path (no file existed). Boot code reads
+	// it to surface a one-time, non-blocking first-run notice (accounts.md §6) without
+	// changing LoadOrCreate's signature. json:"-" keeps it off disk; it is false for
+	// any account loaded from an existing file.
+	FreshlyCreated bool `json:"-"`
 }
 
 // newAccountID returns a fresh, stable account ID: 16 random bytes from crypto/rand,
@@ -189,6 +196,10 @@ func LoadOrCreate() (*Account, error) {
 			if err := acct.Save(); err != nil {
 				return nil, err
 			}
+			// First genuine run: no file existed. Flag it so boot code can surface a
+			// one-time non-blocking notice (accounts.md §6). The corrupt-recovery path
+			// below is NOT a first run — it leaves FreshlyCreated false.
+			acct.FreshlyCreated = true
 			return acct, nil
 		}
 		return nil, fmt.Errorf("failed to read account: %w", err)

--- a/game/account_save_test.go
+++ b/game/account_save_test.go
@@ -1,0 +1,179 @@
+package game
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// Phase 2 (accounts.md §6) — startup wiring + lazy save attribution.
+//
+// These tests exercise the migration invariant from §3.5/§6: a save gains its
+// account_id ONLY by being re-written through SaveGame (which re-signs _sig over
+// the new payload), never by an in-place JSON edit. They use isolateAccountDir
+// (see account_test.go) so both the account file and the saves directory resolve
+// inside a temp dir — no real ./data is read or clobbered.
+
+// TestLegacySaveWithoutAccountIDLoadsClean covers the backward-compat path: a save
+// written with NO account set must load fine, verify clean (sig valid), and pick up
+// no spurious CheaterBadge. This is the "legacy save loads unchanged" guarantee.
+func TestLegacySaveWithoutAccountIDLoadsClean(t *testing.T) {
+	isolateAccountDir(t)
+
+	name := "phase2_legacy_no_account"
+	ge := NewGameEngine() // no SetAccount → AccountID() == ""
+	if got := ge.AccountID(); got != "" {
+		t.Fatalf("AccountID() = %q on an engine with no account, want \"\"", got)
+	}
+	if err := ge.SaveGame(name); err != nil {
+		t.Fatalf("SaveGame(%q): %v", name, err)
+	}
+
+	// Read the bytes back: omitempty must keep account_id out of the file entirely.
+	data, err := os.ReadFile(savePath(name))
+	if err != nil {
+		t.Fatalf("read save: %v", err)
+	}
+	var onDisk map[string]any
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("unmarshal save: %v", err)
+	}
+	if _, present := onDisk["account_id"]; present {
+		t.Errorf("account_id present in a no-account save; omitempty should drop it")
+	}
+
+	// Parse + verify as the loader would: unsigned/valid sig, no cheater badge.
+	var save GameSave
+	if err := json.Unmarshal(data, &save); err != nil {
+		t.Fatalf("parse save: %v", err)
+	}
+	if save.AccountID != "" {
+		t.Errorf("legacy save AccountID = %q, want empty", save.AccountID)
+	}
+	sigValid, _ := verifySave(&save)
+	if !sigValid {
+		t.Error("legacy no-account save failed signature verification")
+	}
+
+	// And the full load path must not flag a cheater badge.
+	loaded := NewGameEngine()
+	if err := loaded.LoadGame(name); err != nil {
+		t.Fatalf("LoadGame(%q): %v", name, err)
+	}
+	if loaded.GetState().CheaterBadge {
+		t.Error("legacy no-account save wrongly flagged CheaterBadge on load")
+	}
+}
+
+// TestSaveStampsAccountIDAndStaysSigned covers the core Phase 2 behavior: with an
+// account set on the engine, SaveGame stamps account_id into the save AND the file
+// still verifies — proving _sig was recomputed over the new field (the §6 invariant
+// that stamping rides SaveGame, not an in-place edit).
+func TestSaveStampsAccountIDAndStaysSigned(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	if acct.AccountID == "" {
+		t.Fatal("created account has empty AccountID")
+	}
+
+	name := "phase2_stamped"
+	ge := NewGameEngine()
+	ge.SetAccount(acct)
+	if got := ge.AccountID(); got != acct.AccountID {
+		t.Fatalf("AccountID() = %q, want %q", got, acct.AccountID)
+	}
+	if err := ge.SaveGame(name); err != nil {
+		t.Fatalf("SaveGame(%q): %v", name, err)
+	}
+
+	// Reload the file from disk: account_id must be present and equal the account's ID.
+	data, err := os.ReadFile(savePath(name))
+	if err != nil {
+		t.Fatalf("read save: %v", err)
+	}
+	var save GameSave
+	if err := json.Unmarshal(data, &save); err != nil {
+		t.Fatalf("parse save: %v", err)
+	}
+	if save.AccountID != acct.AccountID {
+		t.Errorf("stamped save AccountID = %q, want %q", save.AccountID, acct.AccountID)
+	}
+
+	// The signature must still verify — it covers account_id because the stamp went
+	// through SaveGame's sign step, not an after-the-fact JSON splice.
+	sigValid, _ := verifySave(&save)
+	if !sigValid {
+		t.Error("stamped save failed signature verification — _sig did not cover account_id")
+	}
+	if save.CheaterBadge {
+		t.Error("stamped save carries a CheaterBadge — stale signature?")
+	}
+
+	// Full load path: no cheater badge stamped on a legitimately attributed save.
+	loaded := NewGameEngine()
+	if err := loaded.LoadGame(name); err != nil {
+		t.Fatalf("LoadGame(%q): %v", name, err)
+	}
+	if loaded.GetState().CheaterBadge {
+		t.Error("attributed save wrongly flagged CheaterBadge on load")
+	}
+	// Loading a save must NOT switch the active account (it is set once at boot).
+	if loaded.Account() != nil {
+		t.Error("LoadGame populated the engine account from the save; load must be informational only")
+	}
+}
+
+// TestResetPreservesAccount asserts the account is player-level and survives a new
+// game / Reset, per accounts.md §6 ("the account is player-level and must survive
+// new-game/reset"). Reset reinitializes managers but must leave ge.account intact.
+func TestResetPreservesAccount(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	ge := NewGameEngine()
+	ge.SetAccount(acct)
+
+	ge.Reset()
+
+	got := ge.Account()
+	if got == nil {
+		t.Fatal("Reset cleared the account; it must survive a new game")
+	}
+	if got.AccountID != acct.AccountID {
+		t.Errorf("account changed across Reset: %q != %q", got.AccountID, acct.AccountID)
+	}
+	if got != acct {
+		t.Error("Reset swapped the account pointer; it should be the same instance")
+	}
+}
+
+// TestFreshlyCreatedFlagOnlyOnFirstRun confirms the first-run signal: LoadOrCreate
+// sets FreshlyCreated only when it mints a brand-new account (no file present), and
+// a subsequent load of the existing file leaves it false. Boot code keys the
+// one-time welcome notice off this (accounts.md §6).
+func TestFreshlyCreatedFlagOnlyOnFirstRun(t *testing.T) {
+	isolateAccountDir(t)
+
+	first, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (first): %v", err)
+	}
+	if !first.FreshlyCreated {
+		t.Error("first LoadOrCreate did not set FreshlyCreated on a genuine first run")
+	}
+
+	second, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (second): %v", err)
+	}
+	if second.FreshlyCreated {
+		t.Error("second LoadOrCreate set FreshlyCreated on an existing-file load")
+	}
+}

--- a/game/engine.go
+++ b/game/engine.go
@@ -129,6 +129,13 @@ type GameEngine struct {
 	// History collector — periodic metric samples for the history overlay.
 	History *HistoryCollector
 
+	// account is the per-player identity + meta-progression record, loaded once at
+	// boot (accounts.md §2/§8) and held here so the UI/dashboard — already sharing
+	// this engine — can reach it via Account(). It is player-level, NOT per-save, so
+	// Reset() must NOT clear it (a new game keeps the same player). May be nil if
+	// LoadOrCreate failed at boot — account state is non-critical, the game runs anyway.
+	account *Account
+
 	// Morale system — a managed two-way dial. Range [0.10, moraleCap()];
 	// starts at moraleNeutral (0.50). Drives production via moraleMultiplier().
 	morale          float64 // 0.10–moraleCap(); starts at moraleNeutral (0.50)
@@ -595,6 +602,35 @@ func (ge *GameEngine) SetActiveParentName(name string) {
 	ge.mu.Lock()
 	defer ge.mu.Unlock()
 	ge.activeParentName = name
+}
+
+// SetAccount installs the per-player account, loaded once at boot. May be nil.
+// The account is player-level state and survives Reset (new game / succumb), so it
+// is set here rather than in NewGameEngine or Reset (accounts.md §6).
+func (ge *GameEngine) SetAccount(a *Account) {
+	ge.mu.Lock()
+	defer ge.mu.Unlock()
+	ge.account = a
+}
+
+// Account returns the per-player account, or nil if none was loaded at boot.
+// Future phases (unlocks, themes, lifetime stats) read it through here.
+func (ge *GameEngine) Account() *Account {
+	ge.mu.RLock()
+	defer ge.mu.RUnlock()
+	return ge.account
+}
+
+// AccountID returns the current account's ID, or "" if no account is held. Used by
+// buildSaveSnapshot to lazy-stamp the save's account_id on the next write — the
+// stamp rides the normal SaveGame path so _sig re-signs over it (accounts.md §6).
+func (ge *GameEngine) AccountID() string {
+	ge.mu.RLock()
+	defer ge.mu.RUnlock()
+	if ge.account == nil {
+		return ""
+	}
+	return ge.account.AccountID
 }
 
 // StartNewNamedGame resets to a fresh game, makes `name` the active root save,

--- a/game/save.go
+++ b/game/save.go
@@ -77,8 +77,15 @@ type GameSave struct {
 	// Legacy saves lack the field → "" → a root. omitempty keeps current saves
 	// byte-identical when empty.
 	ParentName string `json:"parent_name,omitempty"`
-	Signature  string `json:"_sig,omitempty"`
-	Proof      string `json:"_proof,omitempty"`
+	// AccountID attributes this save to a player account (accounts.md §5/§6). It is
+	// additive and optional: empty on legacy/no-account saves, where omitempty keeps
+	// the bytes identical. It is lazy-stamped — a save gains it the NEXT time it is
+	// written through SaveGame, which re-signs _sig over the new payload (the §3.5
+	// invariant: stamp only via SaveGame, never an in-place JSON edit). On load it is
+	// informational only and does NOT switch the active account (set once at boot).
+	AccountID string `json:"account_id,omitempty"`
+	Signature string `json:"_sig,omitempty"`
+	Proof     string `json:"_proof,omitempty"`
 }
 
 // hmacSign returns the HMAC-SHA256 of payload under key, hex-encoded. This is the
@@ -434,7 +441,21 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 		CatastropheHistory: append([]string(nil), ge.catastropheHistory...),
 		Morale:             ge.morale,
 		History:            ge.History,
+		AccountID:          ge.accountIDLocked(),
 	}
+}
+
+// accountIDLocked returns the held account's ID, or "" if no account is set. It
+// reads ge.account directly — buildSaveSnapshot already holds the lock, so it must
+// NOT call the lock-acquiring AccountID() accessor (sync.RWMutex is not reentrant
+// and a waiting writer could deadlock). Including this in the snapshot is the entire
+// lazy-stamp mechanism: SaveGame signs the snapshot, so the account_id is covered by
+// _sig automatically — no separate migration pass (accounts.md §6 invariant).
+func (ge *GameEngine) accountIDLocked() string {
+	if ge.account == nil {
+		return ""
+	}
+	return ge.account.AccountID
 }
 
 // BranchSave forks the current run into a NEW save named newName: its parent is

--- a/main.go
+++ b/main.go
@@ -19,6 +19,22 @@ func main() {
 	// Create game engine
 	engine := game.NewGameEngine()
 
+	// Load (or first-run create) the per-player account and hand it to the engine, so
+	// the UI/dashboard — which share this engine — can reach it via engine.Account()
+	// in later phases (accounts.md §6). The account is non-critical: if loading fails,
+	// log to stderr and run without one rather than blocking play.
+	acct, err := game.LoadOrCreate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not load account, continuing without one: %v\n", err)
+	} else if acct != nil {
+		engine.SetAccount(acct)
+		if acct.FreshlyCreated {
+			// Non-blocking first-run notice: surfaces in the in-game log, never gates
+			// play (accounts.md §6). Player-facing, no jargon.
+			engine.AddLog("info", "Welcome! A local account was created on this machine to track your unlocks across all your games.")
+		}
+	}
+
 	// Create UI
 	app := ui.NewApp(engine, version)
 


### PR DESCRIPTION
## Account foundation — Phase 2: boot wiring + lazy save attribution

Per `accounts.md` §9 Phase 2.

- **Boot:** `main.go` calls `LoadOrCreate()`, sets the account on the engine, and on a genuine first run drops a **non-blocking welcome line** in the log. A load error warns to stderr and the game runs accountless (account is non-critical — never gates play).
- **Engine holds the account** (`SetAccount`/`Account`/`AccountID`), and `Reset()` **preserves** it — so new-game / `StartNewNamedGame` keep your account.
- **Save attribution:** `GameSave` gains `account_id` (omitempty), stamped in `buildSaveSnapshot`. Because it rides the normal snapshot, **`SaveGame` re-signs over it** — a legacy save gains `account_id` (validly signed) on its *next* save, with **no in-place JSON edit**. That's the design-review invariant: never stamp a save without re-signing.
- Lock-safe: the snapshot reads the account field directly (`accountIDLocked`) since it already holds the RLock — `sync.RWMutex` isn't reentrant.

### Tests
legacy/no-account save loads clean (no spurious cheater badge) · `SetAccount` → `SaveGame` stamps `account_id` and stays validly signed · `Reset` preserves the account · `FreshlyCreated` only on first run. Full suite (incl. golden/lineage) green.

### Next
**Phase 3** — the unlock API (`HasTheme`/`UnlockTheme`/`UnlockedThemes`/`ActiveTheme`/`SetActiveTheme`), which **unblocks theming.md Phase 2** (account-wide unlock persistence).

Trello: https://trello.com/c/AxjbiTF1
