### PR TITLE
feat(account): persisted theme unlock API (phase 3)

### DIFF
--- a/game/account.go
+++ b/game/account.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"sync"
 	"time"
 )
 
@@ -79,6 +81,15 @@ type Account struct {
 	// changing LoadOrCreate's signature. json:"-" keeps it off disk; it is false for
 	// any account loaded from an existing file.
 	FreshlyCreated bool `json:"-"`
+
+	// mu guards the unlock/prefs reads and writes (and the Save inside the mutating
+	// methods): the account is read from the UI goroutine (HasTheme/ActiveTheme/
+	// UnlockedThemes) while another goroutine writes (UnlockTheme/SetActiveTheme).
+	// This is the account's OWN lock over the account's OWN file — fully independent
+	// of the engine's ge.mu, so there is no engine-deadlock risk. It has no json tag
+	// and is never serialized; a sync.Mutex zero value marshals fine, so signing and
+	// round-trip are unaffected (signAccount marshals the struct verbatim).
+	mu sync.Mutex
 }
 
 // newAccountID returns a fresh, stable account ID: 16 random bytes from crypto/rand,
@@ -126,10 +137,27 @@ func accountPath() string {
 // signAccount returns the HMAC-SHA256 hex of the account payload with Signature
 // zeroed, so the signature covers the data only — identical construction to
 // signSave, sharing the hmacSign helper (accounts.md §3.4).
-func signAccount(a Account) string {
-	a.Signature = ""
-	a.Tampered = false // json:"-" already excludes it, but keep the payload pristine
-	data, _ := json.Marshal(a)
+//
+// It takes a pointer (not a value) so the sync.Mutex field is never copied — a
+// value copy would trip go vet's copylocks. The signed bytes are unchanged from a
+// value-based marshal: json.Marshal already ignores unexported fields (mu) and the
+// json:"-" Tampered/FreshlyCreated fields, and we build the payload from a
+// freshly-constructed struct literal that copies only the serializable fields,
+// with Signature/Tampered zeroed — so the signature covers exactly the on-disk data.
+func signAccount(a *Account) string {
+	payload := Account{
+		Version:      a.Version,
+		AccountID:    a.AccountID,
+		DisplayName:  a.DisplayName,
+		Created:      a.Created,
+		LastSeen:     a.LastSeen,
+		Unlocks:      a.Unlocks,
+		Stats:        a.Stats,
+		Achievements: a.Achievements,
+		Prefs:        a.Prefs,
+		// Signature deliberately zero; Tampered/FreshlyCreated/mu are json:"-"/unexported.
+	}
+	data, _ := json.Marshal(&payload)
 	return hmacSign(data, saveHMACKey)
 }
 
@@ -140,7 +168,7 @@ func verifyAccount(a *Account) bool {
 	if a.Signature == "" {
 		return true
 	}
-	return hmac.Equal([]byte(a.Signature), []byte(signAccount(*a)))
+	return hmac.Equal([]byte(a.Signature), []byte(signAccount(a)))
 }
 
 // Save signs the account with the shared HMAC helper and writes it atomically
@@ -152,7 +180,7 @@ func (a *Account) Save() error {
 		return fmt.Errorf("failed to create data directory: %w", err)
 	}
 
-	a.Signature = signAccount(*a)
+	a.Signature = signAccount(a)
 	data, err := json.MarshalIndent(a, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal account: %w", err)
@@ -227,4 +255,72 @@ func LoadOrCreate() (*Account, error) {
 		acct.Tampered = true
 	}
 	return &acct, nil
+}
+
+// --- Unlock API (accounts.md §8; theming.md §5 is the first caller) ---
+//
+// The account is key-agnostic: it stores and reports unlocked-theme keys and the
+// active-theme key without judging which are valid or always-unlocked. Theming
+// owns that policy (the always-unlocked accessibility + Forge set, and unknown-key
+// fallback). Accounts is the persisted store underneath it.
+
+// HasTheme reports whether key is in the account's unlocked-theme set.
+func (a *Account) HasTheme(key string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.hasThemeLocked(key)
+}
+
+// hasThemeLocked is the lock-free core of HasTheme. Callers must hold a.mu.
+func (a *Account) hasThemeLocked(key string) bool {
+	for _, k := range a.Unlocks.Themes {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// UnlockTheme records key as an unlocked theme and persists the account. If the
+// theme was already unlocked it is a no-op: (false, nil) with no write. Otherwise
+// it appends the key (deduped via the membership check), persists via Save, and
+// returns (true, <Save error>) — newly is true even if the subsequent Save fails,
+// since the in-memory set did change. theming.md fires the unlock toast only on
+// newly==true, so replayed milestone checks never re-toast an owned theme.
+func (a *Account) UnlockTheme(key string) (newly bool, err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.hasThemeLocked(key) {
+		return false, nil
+	}
+	a.Unlocks.Themes = append(a.Unlocks.Themes, key)
+	return true, a.Save()
+}
+
+// UnlockedThemes returns the unlocked-theme keys in deterministic (sorted) order.
+// It returns a fresh copy, so callers can't mutate the account's backing slice.
+func (a *Account) UnlockedThemes() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.Unlocks.Themes))
+	copy(out, a.Unlocks.Themes)
+	sort.Strings(out)
+	return out
+}
+
+// ActiveTheme returns the persisted active-theme key, or "" if none is set.
+func (a *Account) ActiveTheme() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.Prefs.ActiveTheme
+}
+
+// SetActiveTheme persists key as the active theme and returns the Save error.
+// It does NOT validate that key is unlocked — accounts is key-agnostic and theming
+// owns validity + the always-unlocked policy. The only error path is the Save error.
+func (a *Account) SetActiveTheme(key string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Prefs.ActiveTheme = key
+	return a.Save()
 }

--- a/game/account_unlock_test.go
+++ b/game/account_unlock_test.go
@@ -1,0 +1,171 @@
+package game
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestUnlockThemeNewlyAndHasTheme covers the core unlock contract: the first
+// UnlockTheme returns newly=true, a repeat returns false, and HasTheme reflects the
+// unlocked set throughout (accounts.md §8).
+func TestUnlockThemeNewlyAndHasTheme(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	if acct.HasTheme("amber_crt") {
+		t.Fatal("HasTheme(amber_crt) true before any unlock")
+	}
+
+	newly, err := acct.UnlockTheme("amber_crt")
+	if err != nil {
+		t.Fatalf("UnlockTheme (first): %v", err)
+	}
+	if !newly {
+		t.Error("first UnlockTheme returned newly=false, want true")
+	}
+	if !acct.HasTheme("amber_crt") {
+		t.Error("HasTheme(amber_crt) false after unlock")
+	}
+
+	newly, err = acct.UnlockTheme("amber_crt")
+	if err != nil {
+		t.Fatalf("UnlockTheme (second): %v", err)
+	}
+	if newly {
+		t.Error("second UnlockTheme returned newly=true, want false")
+	}
+
+	// Re-unlocking must not have duplicated the key.
+	if got := acct.UnlockedThemes(); len(got) != 1 || got[0] != "amber_crt" {
+		t.Errorf("UnlockedThemes after re-unlock = %v, want [amber_crt]", got)
+	}
+}
+
+// TestUnlockThemePersistsAcrossRestart confirms an unlock survives a fresh
+// LoadOrCreate (the on-disk store), with the signature still valid and no tamper
+// flag — i.e. UnlockTheme persisted via a properly-signed Save.
+func TestUnlockThemePersistsAcrossRestart(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (first): %v", err)
+	}
+	if _, err := acct.UnlockTheme("obsidian"); err != nil {
+		t.Fatalf("UnlockTheme: %v", err)
+	}
+
+	reloaded, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (reload): %v", err)
+	}
+	if !reloaded.HasTheme("obsidian") {
+		t.Error("HasTheme(obsidian) false after restart")
+	}
+	if reloaded.Tampered {
+		t.Error("reloaded account flagged Tampered after UnlockTheme persisted")
+	}
+	if !verifyAccount(reloaded) {
+		t.Error("reloaded account fails signature verification after UnlockTheme")
+	}
+}
+
+// TestUnlockThemeSurvivesReset asserts unlocks live at the account layer, not in a
+// save: an account-level unlock is unaffected by a new-game flow. Reset() preserves
+// the *Account (engine-level coverage is TestResetPreservesAccount); here we assert
+// the account store itself keeps the unlock when reloaded fresh, mimicking the
+// account a new game would carry forward.
+func TestUnlockThemeSurvivesReset(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	if _, err := acct.UnlockTheme("cyberpunk"); err != nil {
+		t.Fatalf("UnlockTheme: %v", err)
+	}
+
+	// A new game reloads the persisted account — the unlock must still be present.
+	afterNewGame, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (new game): %v", err)
+	}
+	if !afterNewGame.HasTheme("cyberpunk") {
+		t.Error("HasTheme(cyberpunk) false after new-game reload; unlocks must be account-wide")
+	}
+}
+
+// TestActiveThemePersistsAcrossRestart covers the active-theme pref: it is "" before
+// any set, persists via SetActiveTheme, and reloads across a fresh LoadOrCreate.
+func TestActiveThemePersistsAcrossRestart(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (first): %v", err)
+	}
+	if got := acct.ActiveTheme(); got != "" {
+		t.Errorf("ActiveTheme() = %q before any set, want \"\"", got)
+	}
+
+	if err := acct.SetActiveTheme("obsidian"); err != nil {
+		t.Fatalf("SetActiveTheme: %v", err)
+	}
+	if got := acct.ActiveTheme(); got != "obsidian" {
+		t.Errorf("ActiveTheme() = %q after set, want obsidian", got)
+	}
+
+	reloaded, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (reload): %v", err)
+	}
+	if got := reloaded.ActiveTheme(); got != "obsidian" {
+		t.Errorf("ActiveTheme() = %q after restart, want obsidian", got)
+	}
+	if reloaded.Tampered || !verifyAccount(reloaded) {
+		t.Error("reloaded account tampered or fails verification after SetActiveTheme")
+	}
+}
+
+// TestSetActiveThemeIsKeyAgnostic confirms accounts does not validate the key: a key
+// that was never unlocked is still persisted. Theming owns validity/always-unlocked.
+func TestSetActiveThemeIsKeyAgnostic(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	if err := acct.SetActiveTheme("never_unlocked"); err != nil {
+		t.Fatalf("SetActiveTheme rejected an unvalidated key: %v", err)
+	}
+	if got := acct.ActiveTheme(); got != "never_unlocked" {
+		t.Errorf("ActiveTheme() = %q, want never_unlocked (accounts is key-agnostic)", got)
+	}
+}
+
+// TestUnlockedThemesSorted confirms UnlockedThemes returns a deterministic, sorted
+// list regardless of unlock insertion order.
+func TestUnlockedThemesSorted(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	for _, k := range []string{"obsidian", "amber_crt", "parchment", "cyberpunk"} {
+		if _, err := acct.UnlockTheme(k); err != nil {
+			t.Fatalf("UnlockTheme(%q): %v", k, err)
+		}
+	}
+
+	want := []string{"amber_crt", "cyberpunk", "obsidian", "parchment"}
+	if got := acct.UnlockedThemes(); !reflect.DeepEqual(got, want) {
+		t.Errorf("UnlockedThemes() = %v, want %v (sorted)", got, want)
+	}
+}


### PR DESCRIPTION
## Account foundation — Phase 3: persisted theme unlock API (the keystone)

Per `accounts.md` §8/§9. This is the piece that **unblocks theming.md Phase 2** (account-wide unlock persistence) — theming calls exactly this surface.

Five `*Account` methods, persisting to the §3.3 schema (`unlocks.themes` / `prefs.active_theme`):
- `HasTheme(key) bool`
- `UnlockTheme(key) (newly, err)` — dedupes; persists + `newly=true` only on first unlock
- `UnlockedThemes() []string` — sorted copy
- `ActiveTheme() string` / `SetActiveTheme(key) error` — key-agnostic (theming owns validity + the always-unlocked policy)

**Scope (deliberate):** per the design, the unlock *condition* (which milestone grants which theme) lives in theming.md — this phase ships only the persisted API it calls. No milestone hook, picker UI, or stats/recovery/export (those are theming's job + Phases 4-6).

**Thread-safe:** an account-local mutex guards reads/writes — independent of `ge.mu`, its own file, no engine-deadlock. Adding the mutex tripped a `go vet` copylocks issue in `signAccount`; refactored it to take `*Account` and build a **byte-identical** signed payload, so signatures + the golden/round-trip tests stay green.

### Tests
newly-true-then-false · persists across restart · survives Reset (new game) · active-theme persists · key-agnostic SetActiveTheme · sorted UnlockedThemes. `go build/vet/test` (incl. copylocks) all green.

### Account arc status
Phases 1-3 done (storage · boot wiring/attribution · unlock API). Remaining: 4 recovery code, 5 export/import, 6 lifetime stats. The theme track can now build Phase 2 against this real API.

Trello: https://trello.com/c/AxjbiTF1
