### PR TITLE
feat(account): recovery code — backup/restore your identity (phase 4)

### DIFF
--- a/game/account.go
+++ b/game/account.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -323,4 +324,194 @@ func (a *Account) SetActiveTheme(key string) error {
 	defer a.mu.Unlock()
 	a.Prefs.ActiveTheme = key
 	return a.Save()
+}
+
+// --- Recovery code (identity backup, accounts.md §3.5 / §8 / §9 Phase 4) ---
+//
+// The recovery code encodes IDENTITY ONLY — the 16-byte account_id plus a 2-byte
+// checksum — into a short, dash-grouped, uppercase, Crockford-base32 string with an
+// `AGEF-` prefix (e.g. AGEF-7Q2K-9X4M-ZJ31-...). It restores who you are across
+// machines/reinstalls; it does NOT restore earned progress (unlocks/stats) — that is
+// DATA, backed up separately via export/import (Phase 5). The code is a convenience
+// identifier, not a credential (accounts.md §3.5): the checksum guards against TYPOS,
+// not forgery, and account state is cosmetic, not security-critical.
+
+// recoveryCodePrefix is the human-readable namespace stamped on every recovery code.
+const recoveryCodePrefix = "AGEF"
+
+// crockfordAlphabet is the Crockford base32 symbol set: 0-9 then A-Z excluding the
+// ambiguous I, L, O, U. Index = 5-bit value; the string is the canonical encoder.
+const crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// crc16CCITT computes the CRC-16/CCITT-FALSE checksum of data: 16-bit, polynomial
+// 0x1021, init 0xFFFF, no reflection, no final XOR. It is a small, standard,
+// dependency-free typo guard for the recovery code (accounts.md §3.5).
+func crc16CCITT(data []byte) uint16 {
+	crc := uint16(0xFFFF)
+	for _, b := range data {
+		crc ^= uint16(b) << 8
+		for i := 0; i < 8; i++ {
+			if crc&0x8000 != 0 {
+				crc = (crc << 1) ^ 0x1021
+			} else {
+				crc <<= 1
+			}
+		}
+	}
+	return crc
+}
+
+// crockfordEncode encodes data as an uppercase Crockford base32 string (no padding).
+// Bits are packed MSB-first; a trailing partial group is left-padded with zero bits,
+// matching crockfordDecode's symmetric unpacking.
+func crockfordEncode(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var out []byte
+	var buf uint32
+	bits := 0
+	for _, b := range data {
+		buf = (buf << 8) | uint32(b)
+		bits += 8
+		for bits >= 5 {
+			bits -= 5
+			out = append(out, crockfordAlphabet[(buf>>uint(bits))&0x1F])
+		}
+	}
+	if bits > 0 {
+		out = append(out, crockfordAlphabet[(buf<<uint(5-bits))&0x1F])
+	}
+	return string(out)
+}
+
+// crockfordDecodeChar maps a single character to its 5-bit value using Crockford's
+// lenient rules: case-insensitive, with I/L→1, O→0, U→V (per the Crockford spec, U is
+// treated as V to absorb a common transcription slip). Returns (value, ok).
+func crockfordDecodeChar(c byte) (byte, bool) {
+	switch {
+	case c >= 'a' && c <= 'z':
+		c -= 'a' - 'A' // normalize to upper
+	}
+	switch c {
+	case 'O':
+		c = '0'
+	case 'I', 'L':
+		c = '1'
+	case 'U':
+		c = 'V'
+	}
+	for i := 0; i < len(crockfordAlphabet); i++ {
+		if crockfordAlphabet[i] == c {
+			return byte(i), true
+		}
+	}
+	return 0, false
+}
+
+// crockfordDecode decodes a Crockford base32 string (already stripped of the prefix,
+// dashes, and spaces) back to bytes. byteLen is the expected decoded length; any
+// trailing partial-group bits beyond byteLen*8 are discarded (they are the encoder's
+// zero padding). Returns an error on an unknown symbol or insufficient input.
+func crockfordDecode(s string, byteLen int) ([]byte, error) {
+	out := make([]byte, 0, byteLen)
+	var buf uint32
+	bits := 0
+	for i := 0; i < len(s); i++ {
+		v, ok := crockfordDecodeChar(s[i])
+		if !ok {
+			return nil, fmt.Errorf("invalid recovery code (bad character %q)", string(s[i]))
+		}
+		buf = (buf << 5) | uint32(v)
+		bits += 5
+		if bits >= 8 {
+			bits -= 8
+			out = append(out, byte((buf>>uint(bits))&0xFF))
+		}
+	}
+	if len(out) < byteLen {
+		return nil, fmt.Errorf("invalid recovery code (too short)")
+	}
+	return out[:byteLen], nil
+}
+
+// groupBy4 inserts a dash after every 4 characters, leaving any trailing partial
+// group as-is (e.g. 29 chars → 7 groups of 4 + 1). Matches the doc's example shape.
+func groupBy4(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if i > 0 && i%4 == 0 {
+			b.WriteByte('-')
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// RecoveryCode returns this account's identity-recovery code (accounts.md §3.5/§8):
+// the 16 raw account-id bytes plus a 2-byte CRC-16 checksum, Crockford-base32 encoded,
+// uppercased, dash-grouped in 4s, with the AGEF- prefix. Identity only — never progress.
+func (a *Account) RecoveryCode() string {
+	a.mu.Lock()
+	id := a.AccountID
+	a.mu.Unlock()
+
+	idBytes, err := hex.DecodeString(id)
+	if err != nil || len(idBytes) != 16 {
+		// An account ID that isn't 16 hex bytes can't form a code; return the prefix
+		// only rather than panic. LoadOrCreate always produces a valid 16-byte ID.
+		return recoveryCodePrefix + "-"
+	}
+	sum := crc16CCITT(idBytes)
+	payload := make([]byte, 0, 18)
+	payload = append(payload, idBytes...)
+	payload = append(payload, byte(sum>>8), byte(sum&0xFF))
+	body := groupBy4(crockfordEncode(payload))
+	return recoveryCodePrefix + "-" + body
+}
+
+// ImportRecoveryCode decodes a recovery code, verifies its checksum, and writes a
+// FRESH signed account.json carrying the recovered account ID with EMPTY data —
+// identity only, never restoring unlocks/stats (accounts.md §3.5/§8). It reuses the
+// normal signed atomic Save path; it never hand-rolls a second integrity scheme.
+//
+// Input is normalized leniently: uppercased, the AGEF- prefix stripped, dashes and
+// spaces removed, and ambiguous Crockford characters mapped (I/L→1, O→0, U→V). A
+// checksum mismatch returns a clear typo-guard error rather than silently minting a
+// wrong account.
+func ImportRecoveryCode(code string) (*Account, error) {
+	// Normalize: drop spaces, uppercase, strip the AGEF- prefix, strip dashes.
+	norm := strings.ToUpper(strings.TrimSpace(code))
+	norm = strings.ReplaceAll(norm, " ", "")
+	norm = strings.ReplaceAll(norm, "-", "")
+	if p := strings.ToUpper(recoveryCodePrefix); strings.HasPrefix(norm, p) {
+		norm = norm[len(p):]
+	}
+	if norm == "" {
+		return nil, fmt.Errorf("invalid recovery code (empty)")
+	}
+
+	payload, err := crockfordDecode(norm, 18)
+	if err != nil {
+		return nil, err
+	}
+	idBytes := payload[:16]
+	gotSum := uint16(payload[16])<<8 | uint16(payload[17])
+	if gotSum != crc16CCITT(idBytes) {
+		return nil, fmt.Errorf("invalid recovery code (checksum failed)")
+	}
+
+	now := time.Now()
+	acct := &Account{
+		Version:   accountSchemaVersion,
+		AccountID: hex.EncodeToString(idBytes),
+		Created:   now,
+		LastSeen:  now,
+		// EMPTY data: identity only. Unlocks/Stats/Achievements/Prefs stay zero —
+		// progress is carried by export/import (Phase 5), not the recovery code.
+	}
+	if err := acct.Save(); err != nil {
+		return nil, err
+	}
+	return acct, nil
 }

--- a/game/account_test.go
+++ b/game/account_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -240,5 +241,177 @@ func TestLoadOrCreateCorruptBacksUpAndRecreates(t *testing.T) {
 	// And the live file must parse + verify again.
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("fresh account.json not written after corrupt recovery: %v", err)
+	}
+}
+
+// --- Phase 4: recovery code (accounts.md §3.5 / §8 / §9) ---
+
+// TestRecoveryCodeRoundTrip covers the core contract: a.RecoveryCode() →
+// ImportRecoveryCode(thatCode) yields an account with the SAME AccountID.
+func TestRecoveryCodeRoundTrip(t *testing.T) {
+	isolateAccountDir(t)
+
+	orig, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	code := orig.RecoveryCode()
+
+	restored, err := ImportRecoveryCode(code)
+	if err != nil {
+		t.Fatalf("ImportRecoveryCode(%q): %v", code, err)
+	}
+	if restored.AccountID != orig.AccountID {
+		t.Errorf("round-trip ID mismatch: %q != %q", restored.AccountID, orig.AccountID)
+	}
+}
+
+// TestRecoveryCodeFormat checks the produced shape: AGEF- prefix, all uppercase,
+// dash-grouped in 4-char groups, and that it decodes back to the same ID.
+func TestRecoveryCodeFormat(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	code := acct.RecoveryCode()
+
+	if !strings.HasPrefix(code, "AGEF-") {
+		t.Errorf("code %q missing AGEF- prefix", code)
+	}
+	if code != strings.ToUpper(code) {
+		t.Errorf("code %q is not uppercase", code)
+	}
+	// Each dash-separated group after the prefix is at most 4 chars (4s with a
+	// trailing partial group).
+	groups := strings.Split(code, "-")
+	if groups[0] != "AGEF" {
+		t.Errorf("first group = %q, want AGEF", groups[0])
+	}
+	for _, g := range groups[1:] {
+		if len(g) == 0 || len(g) > 4 {
+			t.Errorf("group %q has invalid length %d (want 1..4)", g, len(g))
+		}
+	}
+	// Must still decode back to the same ID.
+	restored, err := ImportRecoveryCode(code)
+	if err != nil {
+		t.Fatalf("ImportRecoveryCode(%q): %v", code, err)
+	}
+	if restored.AccountID != acct.AccountID {
+		t.Errorf("decoded ID mismatch: %q != %q", restored.AccountID, acct.AccountID)
+	}
+}
+
+// TestRecoveryCodeTypoGuard flips a single payload character in a valid code and
+// asserts ImportRecoveryCode rejects it with a checksum error (not a silent wrong ID).
+func TestRecoveryCodeTypoGuard(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	code := acct.RecoveryCode()
+
+	// Flip an early body character (a high-order payload bit, well inside the real
+	// 144-bit payload — not the trailing padding bits) to a different valid Crockford
+	// symbol. Mutating real ID/checksum bits must trip the checksum guard.
+	b := []byte(code)
+	// Index 5 is the first body char after the "AGEF-" prefix (indices 0..4).
+	idx := 5
+	orig := b[idx]
+	repl := byte('Z')
+	if orig == repl {
+		repl = '2'
+	}
+	b[idx] = repl
+	typo := string(b)
+	if typo == code {
+		t.Fatal("typo mutation did not change the code")
+	}
+
+	if _, err := ImportRecoveryCode(typo); err == nil {
+		t.Errorf("typo'd code %q imported without error (typo guard failed)", typo)
+	} else if !strings.Contains(err.Error(), "checksum") {
+		t.Errorf("typo'd code error = %q, want a checksum error", err.Error())
+	}
+}
+
+// TestImportRecoveryCodeWritesSignedEmptyAccount confirms the imported account is
+// written as a valid signed account.json with EMPTY data (identity only).
+func TestImportRecoveryCodeWritesSignedEmptyAccount(t *testing.T) {
+	isolateAccountDir(t)
+
+	orig, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	code := orig.RecoveryCode()
+
+	restored, err := ImportRecoveryCode(code)
+	if err != nil {
+		t.Fatalf("ImportRecoveryCode: %v", err)
+	}
+	// Signed in-memory (no tamper), and EMPTY data — identity only.
+	if !verifyAccount(restored) {
+		t.Error("imported account fails signature verification")
+	}
+	if restored.Tampered {
+		t.Error("imported account flagged Tampered")
+	}
+	if len(restored.Unlocks.Themes) != 0 || restored.Stats.TotalPrestiges != 0 ||
+		len(restored.Achievements) != 0 || restored.Prefs.ActiveTheme != "" {
+		t.Errorf("imported account carried DATA, want empty: unlocks=%v stats=%+v ach=%v prefs=%+v",
+			restored.Unlocks.Themes, restored.Stats, restored.Achievements, restored.Prefs)
+	}
+
+	// And the on-disk file must reload, verify, and be untampered.
+	reloaded, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (reload after import): %v", err)
+	}
+	if reloaded.AccountID != orig.AccountID {
+		t.Errorf("reloaded ID = %q, want %q", reloaded.AccountID, orig.AccountID)
+	}
+	if reloaded.Tampered {
+		t.Error("reloaded imported account flagged Tampered (signed Save failed)")
+	}
+	if !verifyAccount(reloaded) {
+		t.Error("reloaded imported account fails signature verification")
+	}
+}
+
+// TestImportRecoveryCodeLenient covers Crockford's lenient decode: lowercase, with
+// spaces, and I-vs-1 substituted variants of a valid code all import to the same ID.
+func TestImportRecoveryCodeLenient(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	code := acct.RecoveryCode()
+	want := acct.AccountID
+
+	variants := map[string]string{
+		"lowercase":      strings.ToLower(code),
+		"with-spaces":    strings.ReplaceAll(code, "-", " "),
+		"no-dashes":      strings.ReplaceAll(code, "-", ""),
+		"i-for-1":        strings.ReplaceAll(code, "1", "I"),
+		"l-for-1":        strings.ReplaceAll(code, "1", "L"),
+		"o-for-0":        strings.ReplaceAll(code, "0", "O"),
+		"surround-space": "  " + code + "  ",
+	}
+	for name, v := range variants {
+		got, err := ImportRecoveryCode(v)
+		if err != nil {
+			t.Errorf("%s: ImportRecoveryCode(%q): %v", name, v, err)
+			continue
+		}
+		if got.AccountID != want {
+			t.Errorf("%s: ID = %q, want %q", name, got.AccountID, want)
+		}
 	}
 }

--- a/site/docs/_sidebar.md
+++ b/site/docs/_sidebar.md
@@ -9,6 +9,7 @@
   - [How to Play](how-to-play.md)
   - [All Commands](commands.md)
   - [Saving & Loading](saving-and-loading.md)
+  - [Account & Recovery](account.md)
   - [Resources](resources.md)
   - [Workers](villagers.md)
 

--- a/site/docs/account.md
+++ b/site/docs/account.md
@@ -1,0 +1,103 @@
+# Account & Recovery
+
+AgeForge is a **local terminal game**. There is no server, no login screen, no cloud — everything lives on your own machine under `./data/`, relative to the directory you launch the game from. Your account is part of that: a small file on disk that gives your civilization a stable identity and holds your earned meta-progression.
+
+This page explains what an account is, what the recovery code does (and, just as important, what it doesn't), and how to carry your identity to a new machine.
+
+---
+
+## Your account
+
+Your account is created **automatically on first run** and stored at `./data/account.json`. There's no signup, no prompt, and it never blocks you from playing — it's just there the first time you launch the game. One account per machine, or more precisely one per data directory.
+
+The account holds two distinct things:
+
+| Part | What it is |
+|---|---|
+| **Identity** | A stable account ID, and optionally a display name |
+| **Data** | Your earned meta-progression — theme unlocks, lifetime stats, achievements |
+
+The split matters, because the two halves are recovered very differently (see below). The **data** side is still being built out — lifetime stats and unlocks are tracked, but exporting and importing your progress between machines is **coming in a later update**.
+
+---
+
+## The recovery code
+
+Run the `account` command at the `>` prompt to see your account's short ID and its **recovery code**:
+
+```
+account
+```
+
+The recovery code looks like this:
+
+```
+AGEF-7Q2K-9X4M-ZJ31-…
+```
+
+It's an uppercase string, grouped into 4-character chunks separated by dashes, around 41 characters long including the `AGEF-` prefix. It's encoded in [Crockford base32](https://www.crockford.com/base32.html), which deliberately omits the ambiguous letters `I`, `L`, `O`, and `U` — so it transcribes cleanly when you write it on paper or read it aloud.
+
+The code encodes **only your account ID plus a checksum**. Nothing else.
+
+- **The checksum is a typo guard.** If you mistype the code, the import is rejected with a clear "checksum failed" message instead of silently creating the wrong account.
+- **It is not a password.** The checksum guards against typos, not against other people. The code is a convenience identifier, not a credential or a secret — there is nothing to steal. Account state is cosmetic.
+
+---
+
+## What it restores (and what it doesn't)
+
+This is the part to read carefully.
+
+| | Restored by the recovery code? |
+|---|---|
+| Your **identity** (account ID) | **Yes** |
+| Your earned **progress** (theme unlocks, lifetime stats, achievements) | **No** |
+
+The recovery code restores your **identity** across machines and reinstalls. It does **not** restore your earned progress, because that progress is separate **data** — and the code is small precisely because it carries identity, not data.
+
+To carry your progress between machines you'll back it up via **progress export**, which is **coming in a later update**. Until then, progress lives only in `./data/` on the machine that earned it.
+
+---
+
+## Restoring on a new machine
+
+On the new machine (or after a reinstall), run:
+
+```
+account recover AGEF-7Q2K-9X4M-ZJ31-…
+```
+
+This replaces the local account's identity with the one encoded in the code.
+
+**Recovery is lenient about transcription.** You don't have to get the formatting perfect:
+
+- Lowercase is fine.
+- Extra spaces are ignored.
+- The ambiguous swaps `I`/`L` ↔ `1` and `O` ↔ `0` are corrected automatically.
+
+So if you wrote it down by hand and your `0` looks like an `O`, it'll still import.
+
+### Overwrite guard
+
+Recovering **replaces** the local identity. If the local account already has **unlocked progress**, `account recover` won't blow it away silently — it warns you and asks you to confirm:
+
+```
+account recover AGEF-… confirm
+```
+
+The guard exists because the code does **not** carry your unlocks. Recovering points this machine at a different identity; the local progress doesn't travel with it. The `confirm` keyword is your acknowledgement that you understand that before proceeding.
+
+---
+
+## The honest truth
+
+With no server, **identity recovery is a short code you write down** — that's the whole trick. But **progress recovery requires you to have exported it first.** We can't make data appear from nothing: if a machine's `./data/` is gone and the progress was never backed up, there's no server holding a copy to pull it back from. The recovery code resurrects who you are, not what you've done.
+
+That's also why the code is safe to share or lose track of — it's an identifier for a cosmetic, local account, not a key to anything worth guarding.
+
+---
+
+## See also
+
+- [All Commands](commands.md) — the full `account` / `account recover` command reference
+- [Saving & Loading](saving-and-loading.md) — how your *game saves* (a separate thing from your account) are stored under `./data/saves/`

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -209,10 +209,14 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 | `load <name>` | Load that save directly |
 | `saves` | List all save files |
 | `Esc` | Quick-save to your active save |
+| `account` | Show your account's short ID and **recovery code** (restores identity, not progress) |
+| `account recover <code>` | Restore your identity from a recovery code on a new machine/reinstall |
 | `dump` | Export logs to a file for debugging |
 | `help` | Open the Help panel — full command reference and list of available panels |
 
 Save files live in `./data/saves/*.json`, relative to the directory you launch the game from. The `save <name>` and `load <name>` commands above work with the same files as the **Load Game** browser below.
+
+`account` (no arguments) prints your account's short ID and its **recovery code** — a short `AGEF-…` string that restores your **identity** (your account ID) across machines and reinstalls. The code restores **identity only, not earned progress** (theme unlocks and lifetime stats are separate; progress export is coming in a later update). Write the code down to keep your identity; it is a convenience identifier, not a password. To restore on another machine, run `account recover <code>`. If the local account already has unlocked progress, recovery asks you to confirm with `account recover <code> confirm` first, since recovering replaces the local identity and the code does not carry your unlocks. See [Account & Recovery](account.md) for the full model.
 
 A bare `save` (no name) opens a prompt: **Overwrite** writes your current run to its **active** save right now, while **Branch new** forks a fresh save (suggested name, editable) whose parent is your current save and then moves autosave onto the new branch — leaving the old save frozen at the branch point. `save <name>` branches straight to that name. The active save is the one you most recently named or loaded (a new game has you name it up front); the periodic autosave and `Esc` continuously overwrite it, so your current game is always kept current on disk. See [Saving & Loading](saving-and-loading.md) for the full model.
 

--- a/ui/autocomplete.go
+++ b/ui/autocomplete.go
@@ -33,6 +33,7 @@ var commands = []string{
 	"prestige",
 	"upgrade",
 	"advance", "rates", "speed", "save", "saves", "load",
+	"account",
 	"wonder",
 	"dump", "exportlogs",
 	"milestones", "ms",
@@ -208,6 +209,12 @@ func suggestArg(cmd string, completed []string, partial string, prefix string, e
 
 	case "load":
 		return filterPrefix(saveNames(), partial, prefix)
+
+	case "account", "acct":
+		// Only subcommand is "recover"; recover's <code> arg isn't enumerable.
+		if len(completed) == 0 {
+			return filterPrefix([]string{"recover"}, partial, prefix)
+		}
 
 	case "catastrophe", "cat":
 		return filterPrefix([]string{"invoke"}, partial, prefix)

--- a/ui/input.go
+++ b/ui/input.go
@@ -113,6 +113,8 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 		return cmdSave(args, engine)
 	case "load":
 		return cmdLoad(args, engine)
+	case "account", "acct":
+		return cmdAccount(args, engine)
 	default:
 		return CommandResult{
 			Message: fmt.Sprintf("Unknown command: %s. Type 'help' for commands.", cmd),
@@ -545,6 +547,93 @@ func cmdStatus(engine *game.GameEngine) CommandResult {
 	}
 
 	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+}
+
+// shortAccountID returns a human-friendly short form of a 32-char hex account ID:
+// the first 8 hex chars (enough to recognize an account at a glance). Falls back to
+// the whole string when it's shorter than 8 chars.
+func shortAccountID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// cmdAccount handles the `account` command family (accounts.md §9 Phase 4):
+//
+//   account                 → show the short ID + recovery code + honest "identity,
+//                             not progress" copy.
+//   account recover <code>  → re-create the local identity from a recovery code.
+//                             Guarded: if the current account already holds unlocks,
+//                             require `account recover <code> confirm` to overwrite.
+//
+// It talks to engine.Account()/SetAccount() directly — no GameState snapshot needed.
+func cmdAccount(args []string, engine *game.GameEngine) CommandResult {
+	acct := engine.Account()
+
+	if len(args) == 0 {
+		if acct == nil {
+			return CommandResult{
+				Message: "Accounts are unavailable (no account is loaded).",
+				Type:    "warning",
+			}
+		}
+		var lines []string
+		lines = append(lines, fmt.Sprintf("[gold]Account:[-] %s", shortAccountID(acct.AccountID)))
+		lines = append(lines, fmt.Sprintf("[gold]Recovery code:[-] %s", acct.RecoveryCode()))
+		lines = append(lines, "")
+		lines = append(lines, "This code restores your IDENTITY (your account ID) across machines and")
+		lines = append(lines, "reinstalls — NOT your earned progress. Unlocks and stats are separate and")
+		lines = append(lines, "are not carried by this code (progress export is coming in a later update).")
+		lines = append(lines, "Write the code down to keep your identity. It is not a password: it proves")
+		lines = append(lines, "nothing secret, only which account you are.")
+		lines = append(lines, "")
+		lines = append(lines, "Restore on another machine with:  account recover <code>")
+		return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+	}
+
+	sub := strings.ToLower(args[0])
+	switch sub {
+	case "recover":
+		if len(args) < 2 {
+			return CommandResult{
+				Message: "Usage: account recover <code>",
+				Type:    "error",
+			}
+		}
+		code := args[1]
+		confirmed := len(args) >= 3 && strings.EqualFold(args[2], "confirm")
+
+		// Overwrite guard: if the CURRENT account already has earned progress (unlocked
+		// themes), recovering would replace the local identity and the code does NOT
+		// carry that progress. Require an explicit confirm token before proceeding.
+		if acct != nil && len(acct.UnlockedThemes()) > 0 && !confirmed {
+			var lines []string
+			lines = append(lines, "[red]Warning:[-] this account has unlocked progress on this machine.")
+			lines = append(lines, "Recovering will REPLACE the current local identity. The recovery code")
+			lines = append(lines, "carries identity only — your unlocks/stats are NOT carried by it and")
+			lines = append(lines, "would no longer be attached to this identity (export your progress first;")
+			lines = append(lines, "progress export is coming in a later update).")
+			lines = append(lines, "")
+			lines = append(lines, fmt.Sprintf("To proceed anyway:  account recover %s confirm", code))
+			return CommandResult{Message: strings.Join(lines, "\n"), Type: "warning"}
+		}
+
+		restored, err := game.ImportRecoveryCode(code)
+		if err != nil {
+			return CommandResult{Message: err.Error(), Type: "error"}
+		}
+		engine.SetAccount(restored)
+		return CommandResult{
+			Message: fmt.Sprintf("Identity restored: %s", shortAccountID(restored.AccountID)),
+			Type:    "success",
+		}
+	default:
+		return CommandResult{
+			Message: "Usage: account  |  account recover <code>",
+			Type:    "error",
+		}
+	}
 }
 
 func cmdSave(args []string, engine *game.GameEngine) CommandResult {


### PR DESCRIPTION
## Account foundation — Phase 4: recovery code (the backup)

Per `accounts.md` §3.5/§8/§9. Closes the **founding requirement** — a player can now back up their account identity and restore it on another machine/reinstall.

- **`RecoveryCode()`** — `AGEF-`-prefixed, dash-grouped Crockford base32 of the account ID + a **CRC-16/CCITT checksum** (e.g. `AGEF-2XA4-GZP1-…`). Restores **IDENTITY only**, never earned progress (that's Phase 5 export).
- **`ImportRecoveryCode(code)`** — lenient decode (case / spaces / I-vs-1 tolerant); the checksum makes a **typo fail loudly** instead of silently minting a wrong ID; writes a fresh signed `account.json` with the recovered ID via the existing `Save` path (no second integrity scheme).
- **`account` / `acct` command** — shows your short ID + recovery code + the honest copy (*identity, not progress; not a password*). `account recover <code>` restores; an **overwrite guard** refuses to clobber an account that has unlocks unless you add `confirm`.

### Tests
round-trip (code → same ID) · format (`AGEF-`, uppercase, grouped) · typo→checksum error · import writes a valid signed empty-data account · lenient decode variants. `go build/vet/test` green.

### Note
The code runs ~41 chars (16 ID bytes + 2 checksum → ~29 base32 chars + prefix/dashes). Manageable but a touch long to hand-copy — if you'd rather a shorter code we can trim the ID to 12 bytes in a follow-up. Works as-is.

### Account arc
Phases 1-4 done (storage · boot/attribution · unlock API · recovery). Remaining: 5 export/import (progress data), 6 lifetime stats. The account is now fully backup-able — ready to pivot to the **Theme payoff** whenever you want.

Trello: https://trello.com/c/AxjbiTF1
