### PR TITLE
feat(account): lifetime stats + achievements (phase 6 — arc complete)

### DIFF
--- a/game/account.go
+++ b/game/account.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/espresso20/ageforge/config"
 )
 
 // accountSchemaVersion is the on-disk schema version of account.json. Bumped only
@@ -82,6 +84,14 @@ type Account struct {
 	// changing LoadOrCreate's signature. json:"-" keeps it off disk; it is false for
 	// any account loaded from an existing file.
 	FreshlyCreated bool `json:"-"`
+
+	// dirty is the in-memory, non-persisted write-debounce flag for the lifetime-stats
+	// hooks (accounts.md §8 "debounce writes"). RecordPrestige/RecordAgeReached mutate
+	// the in-memory stats and set dirty=true WITHOUT touching the disk — they run under
+	// the engine write lock (advanceAge/DoPrestige) where file I/O is forbidden. The
+	// engine's periodic autosave block (outside ge.mu) calls FlushIfDirty, which Saves
+	// once if dirty and clears the flag. json:"-" keeps it off disk and out of the sig.
+	dirty bool `json:"-"`
 
 	// mu guards the unlock/prefs reads and writes (and the Save inside the mutating
 	// methods): the account is read from the UI goroutine (HasTheme/ActiveTheme/
@@ -673,4 +683,180 @@ func maxInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// --- Lifetime stats + achievements (accounts.md §3.3 / §8 / §9 Phase 6) ---
+//
+// Lifetime stats are CROSS-SAVE aggregates living on the ACCOUNT — distinct from the
+// per-save ge.Stats system, which resets on every new game/prestige. Achievements are
+// one-time, account-wide unlock keys appended on first satisfaction and never removed.
+//
+// LOCKING DISCIPLINE (the load-bearing constraint, accounts.md §8 + project rule):
+// the engine calls RecordPrestige/RecordAgeReached from UNDER the engine write lock
+// (ge.mu — advanceAge and DoPrestige both hold it). Those methods therefore MUST be
+// in-memory only: they take the account's OWN mutex (a.mu, fully independent of ge.mu),
+// do NO file I/O, and NEVER call back into ge.* (AddLog/GetState/…), or the non-reentrant
+// ge.mu would deadlock. The actual Save happens later via FlushIfDirty, called from the
+// engine's periodic-autosave block which runs OUTSIDE ge.mu (accounts.md §8 write cadence).
+
+// accountAchievement is one entry in the in-file achievement table: a stable unlock key
+// plus a human-readable name and a predicate over the lifetime stats. The predicate is
+// pure (no locks, no I/O) and is evaluated by recordEvaluateLocked while a.mu is held.
+type accountAchievement struct {
+	Key  string
+	Name string
+	// met reports whether the given stats satisfy this achievement. ageOrder is the
+	// order of the age that triggered the current evaluation (-1 when the trigger was
+	// a prestige, not an age-up), so age achievements can key off the just-reached age.
+	met func(s AccountStats, ageOrder int) bool
+}
+
+// achievementAge* are the age Order thresholds the age achievements fire at, named so
+// the table reads as intent rather than magic numbers (config/ages.go: Order is 0-indexed;
+// iron_age = 3, modern_age = 12). Kept here, not imported from config, to keep the table
+// dependency-free and the predicate pure.
+const (
+	achievementOrderIron   = 3  // iron_age
+	achievementOrderModern = 12 // modern_age
+)
+
+// accountAchievements is the small, sensible achievement set for Phase 6. Two prestige
+// tiers and two age milestones — enough to prove the wiring without a sprawling table.
+// New entries are purely additive (the key is the only persisted artifact).
+var accountAchievements = []accountAchievement{
+	{Key: "first_prestige", Name: "First Prestige", met: func(s AccountStats, _ int) bool {
+		return s.TotalPrestiges >= 1
+	}},
+	{Key: "prestige_x10", Name: "Serial Reincarnator", met: func(s AccountStats, _ int) bool {
+		return s.TotalPrestiges >= 10
+	}},
+	// Age achievements: the trigger's ageOrder must be at/above the threshold. We gate on
+	// the live trigger order (not HighestAge) so a single RecordAgeReached call evaluates
+	// only the age just reached; HighestAge has already been updated to that age by then,
+	// so a later re-eval would still hold, but the trigger gate keeps each unlock crisp.
+	{Key: "reached_iron", Name: "Age of Iron", met: func(_ AccountStats, ageOrder int) bool {
+		return ageOrder >= achievementOrderIron
+	}},
+	{Key: "reached_modern", Name: "Into the Modern Age", met: func(_ AccountStats, ageOrder int) bool {
+		return ageOrder >= achievementOrderModern
+	}},
+}
+
+// AchievementName returns the human-readable name for an achievement key, or the key
+// itself if it is unknown (so the UI degrades gracefully on a future/renamed key).
+func AchievementName(key string) string {
+	for _, a := range accountAchievements {
+		if a.Key == key {
+			return a.Name
+		}
+	}
+	return key
+}
+
+// recordEvaluateLocked evaluates the achievement table against the current stats and
+// appends any newly-satisfied keys to a.Achievements (deduped). Callers MUST hold a.mu.
+// ageOrder is the order of the age that triggered this evaluation, or -1 for a prestige
+// trigger. It performs NO Save — the caller sets a.dirty and the flush persists later.
+func (a *Account) recordEvaluateLocked(ageOrder int) {
+	for _, def := range accountAchievements {
+		if a.hasAchievementLocked(def.Key) {
+			continue
+		}
+		if def.met(a.Stats, ageOrder) {
+			a.Achievements = append(a.Achievements, def.Key)
+		}
+	}
+}
+
+// hasAchievementLocked reports whether key is already unlocked. Callers must hold a.mu.
+func (a *Account) hasAchievementLocked(key string) bool {
+	for _, k := range a.Achievements {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// RecordPrestige increments the lifetime prestige count, evaluates prestige achievements,
+// and marks the account dirty for the next flush (accounts.md §8). It is IN-MEMORY ONLY:
+// it takes a.mu, performs no file I/O, and never calls back into the engine — so it is
+// safe to call from DoPrestige while the engine write lock is held. The write is deferred
+// to FlushIfDirty (engine autosave block, outside ge.mu).
+func (a *Account) RecordPrestige() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Stats.TotalPrestiges++
+	a.recordEvaluateLocked(-1) // -1: prestige trigger, not an age-up
+	a.dirty = true
+}
+
+// RecordAgeReached records that the account's player has reached the given age, lifting
+// HighestAge only when ageOrder exceeds the order of the currently-stored highest age (so
+// a lower age never regresses the lifetime best), then evaluates age achievements and marks
+// the account dirty (accounts.md §8). IN-MEMORY ONLY (same discipline as RecordPrestige).
+//
+// DEVIATION from accounts.md §8: the doc sketches RecordAgeReached(ageKey) with no order.
+// The account stores only the highest age KEY (AccountStats.HighestAge, accounts.md §3.3),
+// and a bare key can't be ranked without consulting the age table — which would couple the
+// account to config and re-derive order on every call. We take ageOrder explicitly from the
+// engine (which already knows it) so the comparison is a cheap int compare and the account
+// stays config-free. The stored highest order is derived from HighestAge on demand via
+// highestOrderLocked, so it needs no extra persisted field.
+func (a *Account) RecordAgeReached(ageKey string, ageOrder int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if ageOrder > a.highestOrderLocked() {
+		a.Stats.HighestAge = ageKey
+	}
+	a.recordEvaluateLocked(ageOrder)
+	a.dirty = true
+}
+
+// highestOrderLocked returns the Order of the currently-stored HighestAge, or -1 if none
+// is set (or the stored key is unknown — treated as "below everything" so any real age
+// wins). Callers must hold a.mu. It consults the pure config age table (no locks).
+func (a *Account) highestOrderLocked() int {
+	if a.Stats.HighestAge == "" {
+		return -1
+	}
+	if def, ok := config.AgeByKey()[a.Stats.HighestAge]; ok {
+		return def.Order
+	}
+	return -1
+}
+
+// FlushIfDirty persists the account once if the in-memory stats/achievements have changed
+// since the last write, then clears the dirty flag (accounts.md §8 write cadence). It is the
+// ONLY place lifetime-stat changes touch the disk, and it MUST be called from OUTSIDE the
+// engine write lock (the autosave block / clean-exit path) — never from a Record* call site.
+//
+// Self-deadlock avoidance: Save() does NOT acquire a.mu itself (the theme mutators call
+// a.Save() while already holding a.mu, by design). So FlushIfDirty can hold a.mu across the
+// Save() call without re-entering the same non-reentrant mutex. If dirty is false it is a
+// pure no-op (no Save, no error). On a Save error the dirty flag is left SET so the next
+// flush retries rather than silently dropping the unsaved progress.
+func (a *Account) FlushIfDirty() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.dirty {
+		return nil
+	}
+	if err := a.Save(); err != nil {
+		return err // keep dirty set: retry on the next flush
+	}
+	a.dirty = false
+	return nil
+}
+
+// LifetimeStats returns a lock-guarded COPY of the account's lifetime stats and unlocked
+// achievement keys, for the UI snapshot (GetState). It never exposes the account's backing
+// slice — the returned achievements slice is freshly allocated — so a snapshot consumer can
+// neither mutate account state nor race the Record* writers.
+func (a *Account) LifetimeStats() (AccountStats, []string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	ach := make([]string, len(a.Achievements))
+	copy(ach, a.Achievements)
+	return a.Stats, ach
 }

--- a/game/account_stats_test.go
+++ b/game/account_stats_test.go
@@ -1,0 +1,176 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/espresso20/ageforge/config"
+)
+
+// hasAchievement reports whether key is present in the account's achievement set.
+// A small test helper so each assertion reads as intent rather than a loop.
+func hasAchievement(a *Account, key string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.hasAchievementLocked(key)
+}
+
+// TestRecordPrestigeIncrementsAndUnlocks covers the prestige hook: the lifetime count
+// climbs with each call, "first_prestige" unlocks at 1, and the higher "prestige_x10"
+// tier unlocks only once the threshold is crossed — never before.
+func TestRecordPrestigeIncrementsAndUnlocks(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	acct.RecordPrestige()
+	if acct.Stats.TotalPrestiges != 1 {
+		t.Fatalf("TotalPrestiges = %d, want 1", acct.Stats.TotalPrestiges)
+	}
+	if !hasAchievement(acct, "first_prestige") {
+		t.Fatalf("expected first_prestige unlocked at 1 prestige")
+	}
+	if hasAchievement(acct, "prestige_x10") {
+		t.Fatalf("prestige_x10 unlocked too early (1 prestige)")
+	}
+	if !acct.dirty {
+		t.Fatalf("expected dirty=true after RecordPrestige")
+	}
+
+	// Climb to 10; prestige_x10 fires exactly at the threshold, not before.
+	for acct.Stats.TotalPrestiges < 9 {
+		acct.RecordPrestige()
+		if hasAchievement(acct, "prestige_x10") {
+			t.Fatalf("prestige_x10 unlocked early at %d prestiges", acct.Stats.TotalPrestiges)
+		}
+	}
+	acct.RecordPrestige() // -> 10
+	if acct.Stats.TotalPrestiges != 10 {
+		t.Fatalf("TotalPrestiges = %d, want 10", acct.Stats.TotalPrestiges)
+	}
+	if !hasAchievement(acct, "prestige_x10") {
+		t.Fatalf("expected prestige_x10 unlocked at 10 prestiges")
+	}
+}
+
+// TestRecordAgeReachedRanksByOrder covers the age hook: HighestAge advances only when
+// a strictly higher order is reached, a lower order does NOT regress it, and the age
+// achievements fire at their threshold orders.
+func TestRecordAgeReachedRanksByOrder(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	ages := config.AgeByKey()
+	iron := ages["iron_age"]     // Order 3
+	bronze := ages["bronze_age"] // Order 2
+	modern := ages["modern_age"] // Order 12
+
+	acct.RecordAgeReached(iron.Key, iron.Order)
+	if acct.Stats.HighestAge != "iron_age" {
+		t.Fatalf("HighestAge = %q, want iron_age", acct.Stats.HighestAge)
+	}
+	if !hasAchievement(acct, "reached_iron") {
+		t.Fatalf("expected reached_iron unlocked at iron_age")
+	}
+	if hasAchievement(acct, "reached_modern") {
+		t.Fatalf("reached_modern unlocked too early (iron_age)")
+	}
+
+	// A LOWER age must not regress the lifetime best.
+	acct.RecordAgeReached(bronze.Key, bronze.Order)
+	if acct.Stats.HighestAge != "iron_age" {
+		t.Fatalf("HighestAge regressed to %q after lower age; want iron_age", acct.Stats.HighestAge)
+	}
+
+	// A higher age advances it and unlocks the modern achievement.
+	acct.RecordAgeReached(modern.Key, modern.Order)
+	if acct.Stats.HighestAge != "modern_age" {
+		t.Fatalf("HighestAge = %q, want modern_age", acct.Stats.HighestAge)
+	}
+	if !hasAchievement(acct, "reached_modern") {
+		t.Fatalf("expected reached_modern unlocked at modern_age")
+	}
+}
+
+// TestFlushIfDirtyPersistsAndClears covers the write-debounce lifecycle: a Record* call
+// marks the account dirty; FlushIfDirty Saves and clears the flag; a fresh LoadOrCreate
+// reflects the persisted stats (survives a "restart"); a flush when clean is a no-op.
+func TestFlushIfDirtyPersistsAndClears(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	acct.RecordPrestige()
+	acct.RecordAgeReached("iron_age", config.AgeByKey()["iron_age"].Order)
+	if !acct.dirty {
+		t.Fatalf("expected dirty after Record* calls")
+	}
+
+	// This call must NOT hang — FlushIfDirty holds a.mu across Save(), which does not
+	// re-acquire a.mu (self-deadlock guard). If the lock discipline were wrong this
+	// test would deadlock rather than fail.
+	if err := acct.FlushIfDirty(); err != nil {
+		t.Fatalf("FlushIfDirty: %v", err)
+	}
+	if acct.dirty {
+		t.Fatalf("expected dirty cleared after FlushIfDirty")
+	}
+
+	// A second flush when clean is a pure no-op (no error, stays clean).
+	if err := acct.FlushIfDirty(); err != nil {
+		t.Fatalf("FlushIfDirty (clean no-op): %v", err)
+	}
+
+	// Persisted across a "restart": a fresh LoadOrCreate reads the same data root.
+	reloaded, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (reload): %v", err)
+	}
+	if reloaded.Stats.TotalPrestiges != 1 {
+		t.Fatalf("reloaded TotalPrestiges = %d, want 1", reloaded.Stats.TotalPrestiges)
+	}
+	if reloaded.Stats.HighestAge != "iron_age" {
+		t.Fatalf("reloaded HighestAge = %q, want iron_age", reloaded.Stats.HighestAge)
+	}
+	if !hasAchievement(reloaded, "first_prestige") || !hasAchievement(reloaded, "reached_iron") {
+		t.Fatalf("reloaded account missing expected achievements: %v", reloaded.Achievements)
+	}
+	if reloaded.Tampered {
+		t.Fatalf("reloaded account flagged tampered — sign/round-trip broke")
+	}
+}
+
+// TestLifetimeStatsReturnsCopy covers the snapshot accessor: it returns the current
+// stats plus a COPY of the achievements slice that the caller cannot use to mutate the
+// account's backing state.
+func TestLifetimeStatsReturnsCopy(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	acct.RecordPrestige()
+
+	stats, ach := acct.LifetimeStats()
+	if stats.TotalPrestiges != 1 {
+		t.Fatalf("LifetimeStats TotalPrestiges = %d, want 1", stats.TotalPrestiges)
+	}
+	if len(ach) == 0 {
+		t.Fatalf("expected at least first_prestige in returned achievements")
+	}
+	// Mutating the returned slice must not affect the account.
+	ach[0] = "tampered_key"
+	if hasAchievement(acct, "tampered_key") {
+		t.Fatalf("LifetimeStats leaked its backing slice — caller mutation reached the account")
+	}
+}

--- a/game/engine.go
+++ b/game/engine.go
@@ -443,6 +443,19 @@ func (ge *GameEngine) Start() {
 					ge.addLog("debug", "Autosave complete")
 					ge.mu.Unlock()
 				}
+
+				// Account lifetime-stats flush (Phase 6): persist any pending
+				// RecordPrestige/RecordAgeReached deltas. MUST be here, outside the
+				// tick write lock — Save does file I/O. Use the locking accessor, not
+				// ge.account directly, since we're outside ge.mu. No-op when not dirty.
+				if acct := ge.Account(); acct != nil {
+					if err := acct.FlushIfDirty(); err != nil {
+						ge.mu.Lock()
+						ge.addLog("warning", fmt.Sprintf("Account flush failed: %v", err))
+						ge.mu.Unlock()
+					}
+				}
+
 				lastAutosave = time.Now()
 			}
 
@@ -653,6 +666,12 @@ func (ge *GameEngine) Stop() {
 		ge.running = false
 		ge.mu.Unlock()
 		close(ge.stopCh)
+		// Flush any pending account lifetime stats on a clean exit so a prestige/age-up
+		// since the last autosave isn't lost (Phase 6). Outside ge.mu — Save does I/O —
+		// and via the locking accessor. No-op when not dirty.
+		if acct := ge.Account(); acct != nil {
+			_ = acct.FlushIfDirty()
+		}
 	})
 }
 
@@ -1294,6 +1313,15 @@ func (ge *GameEngine) advanceAge(newAge string) {
 
 	ge.applyAgeUnlocks(newAge)
 	ge.Stats.RecordAge(newAge)
+
+	// Account lifetime stat (Phase 6): record the highest age reached IN-MEMORY only.
+	// advanceAge holds ge.mu, so RecordAgeReached must not do I/O or re-enter the
+	// engine; the persisting flush runs later in the autosave block (outside ge.mu).
+	// Order comes from the pure config age table (no locks) — the account stays
+	// config-free and ranks ages by this int rather than re-deriving order itself.
+	if ge.account != nil {
+		ge.account.RecordAgeReached(newAge, config.AgeByKey()[newAge].Order)
+	}
 
 	// note: Age-transition carryover model (EPIC: age-pacing economy rebalance).
 	// The old flat-10% reduction still left a huge stockpile (10% of a hoard is
@@ -2691,6 +2719,13 @@ func (ge *GameEngine) DoPrestige() error {
 	}
 	ge.addLog("info", "Type [cyan]help[-] to get started again.")
 
+	// Account lifetime stat (Phase 6): record the prestige IN-MEMORY only — we hold
+	// ge.mu here, so RecordPrestige must not do I/O or re-enter the engine. The write
+	// is deferred to FlushIfDirty in the autosave block (outside ge.mu).
+	if ge.account != nil {
+		ge.account.RecordPrestige()
+	}
+
 	return nil
 }
 
@@ -2916,6 +2951,23 @@ func (ge *GameEngine) GetState() GameState {
 		// re-acquires a lock). All() returns a fresh copy — no shared mutable
 		// state escapes.
 		Modifiers: ge.buildResolver().All(),
+		// Account lifetime stats (Phase 6). We hold ge.mu.RLock here; LifetimeStats
+		// takes the account's OWN mutex (a.mu) — consistent lock order ge.mu → a.mu,
+		// and the Record* writers never hold a.mu while touching ge.mu, so no deadlock.
+		// nil when no account is wired (e.g. headless tests without SetAccount).
+		AccountStats: func() *AccountStatsView {
+			if ge.account == nil {
+				return nil
+			}
+			s, ach := ge.account.LifetimeStats()
+			return &AccountStatsView{
+				TotalPrestiges:       s.TotalPrestiges,
+				HighestAge:           s.HighestAge,
+				CivilizationsStarted: s.CivilizationsStarted,
+				SavesCompleted:       s.SavesCompleted,
+				Achievements:         ach,
+			}
+		}(),
 	}
 }
 

--- a/game/types.go
+++ b/game/types.go
@@ -67,6 +67,24 @@ type GameState struct {
 	// the engine uses for its rates, so the panel can never drift from the
 	// math. Populated in GetState(); not stored in save JSON.
 	Modifiers []Modifier `json:"-"`
+	// AccountStats carries the account-wide LIFETIME (cross-save) stats and
+	// achievements for the Stats overlay (accounts.md §3.3, Phase 6). nil when
+	// no account is wired (e.g. tests that build an engine without SetAccount).
+	// Distinct from Stats above, which is the per-save ge.Stats snapshot.
+	// Populated in GetState() from ge.account.LifetimeStats(); not in save JSON.
+	AccountStats *AccountStatsView `json:"-"`
+}
+
+// AccountStatsView is the read-only UI projection of the account's lifetime stats
+// and achievements (accounts.md §3.3 / Phase 6). It is a copy — the account never
+// hands the UI its mutable backing slices. Achievements holds unlocked keys; the UI
+// resolves human names via game.AchievementName.
+type AccountStatsView struct {
+	TotalPrestiges       int
+	HighestAge           string
+	CivilizationsStarted int
+	SavesCompleted       int
+	Achievements         []string
 }
 
 // AgeAdvanceSummary holds data about what changed during an age advance transition.

--- a/site/docs/account.md
+++ b/site/docs/account.md
@@ -59,6 +59,30 @@ To carry your progress between machines, back it up via **progress export** — 
 
 ---
 
+## Lifetime stats & achievements
+
+Some progress is **account-wide and cross-save** — it accumulates across *every* game you play and *every* prestige, not just your current run. This lives on your account, separate from the per-save Statistics that reset when you start over or prestige.
+
+| Lifetime stat | What it tracks |
+|---|---|
+| **Total Prestiges** | Every prestige you've ever completed, across all games |
+| **Highest Age Ever** | The furthest age any of your civilizations has reached — it only ever goes *up* |
+
+**Achievements** are one-time, account-wide badges. Once unlocked, they stay unlocked — they ride with your account and travel in a progress export. The current set:
+
+| Achievement | Unlocks when |
+|---|---|
+| **First Prestige** | You complete your first prestige |
+| **Serial Reincarnator** | You reach 10 lifetime prestiges |
+| **Age of Iron** | Any civilization reaches the Iron Age |
+| **Into the Modern Age** | Any civilization reaches the Modern Age |
+
+**Where to see them:** open the **Stats** overlay. Below the per-run Statistics there's a **Lifetime (Account)** section showing your total prestiges, highest age ever reached, and the achievements you've unlocked. (Reaching a milestone is recorded silently — there's no pop-up; check the Stats overlay to see what's unlocked.)
+
+These stats update the moment you prestige or advance into a new age, and are saved to your account alongside the next autosave (and on a clean exit), so a fresh prestige is never lost.
+
+---
+
 ## Backing up your progress
 
 Your account has **two backups, and they do different jobs**:

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -40,6 +40,41 @@ func statsProvider(state game.GameState, _ int) string {
 		fmt.Fprintf(&sb, "   %-12s %s\n", k, FormatNumber(s.TotalGathered[k]))
 	}
 
+	// ─── Lifetime (Account) ───
+	// Cross-save aggregates persisted on the account (accounts.md §3.3, Phase 6),
+	// distinct from the per-save Statistics above. Renders "—" gracefully when no
+	// account is wired (AccountStats nil) so the overlay never blanks out.
+	sb.WriteString("\n [yellow]── Lifetime (Account) ──[-]\n")
+	if state.AccountStats == nil {
+		sb.WriteString(" [gray]No account loaded[-]\n")
+	} else {
+		as := state.AccountStats
+		fmt.Fprintf(&sb, " [gold]Total Prestiges:[-]   %d\n", as.TotalPrestiges)
+
+		highestAge := "—"
+		if as.HighestAge != "" {
+			highestAge = as.HighestAge
+			if def, ok := config.AgeByKey()[as.HighestAge]; ok {
+				highestAge = def.Name
+			}
+		}
+		fmt.Fprintf(&sb, " [gold]Highest Age Ever:[-]  %s\n", highestAge)
+
+		sb.WriteString(" [gold]Achievements:[-]\n")
+		if len(as.Achievements) == 0 {
+			sb.WriteString("   [gray]None unlocked yet[-]\n")
+		} else {
+			names := make([]string, 0, len(as.Achievements))
+			for _, key := range as.Achievements {
+				names = append(names, game.AchievementName(key))
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				fmt.Fprintf(&sb, "   [green]★[-] %s\n", name)
+			}
+		}
+	}
+
 	// Epoch & Legacy section
 	sb.WriteString("\n [yellow]── Epoch & Legacy ──[-]\n")
 


### PR DESCRIPTION
## Account foundation — Phase 6: lifetime stats + achievements (arc complete)

Per `accounts.md` §3.3/§8/§9. The final phase — cross-save aggregates + account-wide achievements, shown in the Stats overlay.

- **Lifetime stats** (total prestiges, highest age, etc.) + **Achievements** `[]string`, via `RecordPrestige()` / `RecordAgeReached(key, order)` that mutate **in memory only** (account mutex, no I/O) — safe to call from under the engine write lock. A dirty flag + `FlushIfDirty()` does the `Save` **only outside `ge.mu`**.
- **Three lock-safe hooks:** age in `advanceAge` (order via lock-free `config.AgeByKey`), prestige at the end of `DoPrestige`, flush in the periodic-autosave block + `Stop()` (SIGINT routes through `Stop`, so clean exit flushes — no `main.go` change).
- **Achievements:** `first_prestige`, `prestige_x10`, `reached_iron`, `reached_modern`.
- **Stats overlay** gains a "Lifetime (Account)" block (total prestiges, highest age ever, achievement names); graceful when no account is wired. No toasts (would risk `AddLog` under the write lock).
- `FlushIfDirty` avoids self-deadlock: `Save()` doesn't take the account mutex (its mutators already hold it), so flush holds it across `Save`.

### Tests
prestige increments + unlocks · age ranks by order (no regression) · flush persists across restart + clean-flush no-op + no-deadlock · LifetimeStats returns a copy. `go build/vet/test` green (incl. golden).

### 🎉 Account arc complete (Phases 1–6)
storage · boot + save attribution · unlock API · recovery code · export/import · lifetime stats. **Every Theme-project prerequisite is now in place** — identity, persistent account-wide unlocks, backup/restore.

Trello: https://trello.com/c/AxjbiTF1
