### PR TITLE
feat(account): name your account on first run; name-derived identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ releases/
 # Claude Code session files
 .claude/
 spritegen
+data/account.json
+data/account-export.json
+data/*.corrupt

--- a/game/account.go
+++ b/game/account.go
@@ -3,6 +3,7 @@ package game
 import (
 	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -127,6 +128,113 @@ func newAccount() (*Account, error) {
 		Created:   now,
 		LastSeen:  now,
 	}, nil
+}
+
+// normalizeAccountName canonicalizes a name for ID derivation: trimmed, lowercased,
+// and with any internal whitespace run collapsed to a single space. So "  Bob   the
+// Builder " and "bob the builder" normalize identically and therefore derive the same
+// account ID. It is the identity key — re-entering the same name on a fresh machine
+// regenerates the same ID (name-based recovery). DisplayName keeps the ORIGINAL trimmed
+// casing; this normalized form never leaves the derivation.
+func normalizeAccountName(name string) string {
+	return strings.Join(strings.Fields(strings.ToLower(name)), " ")
+}
+
+// accountIDFromName derives the 32-char hex account ID from a name:
+// hex(sha256(normalize(name))[:16]). Deterministic — the same name always yields the
+// same ID — and it keeps the existing 16-byte / 32-hex-char ID format intact, so the
+// recovery code and save attribution keep working unchanged. The leading 16 bytes of
+// the SHA-256 digest are ample collision resistance for a local-only cosmetic identity.
+func accountIDFromName(name string) string {
+	sum := sha256.Sum256([]byte(normalizeAccountName(name)))
+	return hex.EncodeToString(sum[:16])
+}
+
+// Established reports whether this account has been named (DisplayName set). An account
+// loaded from disk with no display name (e.g. a legacy random-id dev account) is NOT
+// established, so boot/UI code can prompt the player to name it on first run.
+func (a *Account) Established() bool {
+	return a.DisplayName != ""
+}
+
+// LoadAccount loads an EXISTING account.json without ever creating one — the read-only
+// counterpart to LoadOrCreate, used by the name-first boot flow (the UI mints the account
+// after prompting for a name). Behavior by file state:
+//
+//   - Absent: return (nil, false, nil) — no file, nothing to load. The caller prompts.
+//   - Present + parses + signature valid (or unsigned/legacy): return (acct, true, nil).
+//   - Present + parses + signature INVALID: return (acct, true, nil) with Tampered=true —
+//     a cosmetic flag, not a lockout. The file is NOT deleted.
+//   - Present but UNPARSEABLE: back the bad file up to account.json.corrupt and return
+//     (nil, false, nil) — there is no salvageable account, so the caller prompts fresh.
+//
+// It never writes on the happy/tampered paths; the only disk mutation is the .corrupt
+// rename for an unparseable file (mirrors LoadOrCreate's corrupt handling, minus the
+// create).
+func LoadAccount() (*Account, bool, error) {
+	path := accountPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to read account: %w", err)
+	}
+
+	var acct Account
+	if err := json.Unmarshal(data, &acct); err != nil {
+		// Corrupt / unparseable → back it up and report "not found" so the caller
+		// prompts for a fresh name (accounts.md §7).
+		backup := path + ".corrupt"
+		if renameErr := os.Rename(path, backup); renameErr != nil {
+			return nil, false, fmt.Errorf("account file is corrupt and could not be backed up: %w", renameErr)
+		}
+		return nil, false, nil
+	}
+
+	if !verifyAccount(&acct) {
+		// Signature present but mismatched → tampered. Flag it, still load it.
+		acct.Tampered = true
+	}
+	return &acct, true, nil
+}
+
+// CreateNamedAccount mints a signed account whose identity is derived from name:
+// AccountID = accountIDFromName(name), DisplayName = the trimmed ORIGINAL name (display
+// keeps casing/whitespace; the ID does not). Re-entering the same name reproduces the
+// same ID — that IS the cross-machine recovery story (accounts.md §3.5).
+//
+// MIGRATION: if an account file already exists (e.g. a legacy random-id dev account from
+// the old LoadOrCreate auto-create), its DATA — unlocks, lifetime stats, achievements,
+// prefs — is carried over into the new named account so earned progress is not lost when
+// the identity is re-keyed to the name. Identity fields (the old random ID, Created) are
+// replaced; the new named identity wins. A corrupt/unparseable existing file is ignored
+// (LoadAccount backs it up) and the named account starts with empty data.
+func CreateNamedAccount(name string) (*Account, error) {
+	trimmed := strings.TrimSpace(name)
+	now := time.Now()
+	acct := &Account{
+		Version:        accountSchemaVersion,
+		AccountID:      accountIDFromName(trimmed),
+		DisplayName:    trimmed,
+		Created:        now,
+		LastSeen:       now,
+		FreshlyCreated: true,
+	}
+
+	// Carry over DATA from any pre-existing account so unlocks/stats survive the
+	// identity re-key. found=false (absent or corrupt) → start clean.
+	if prior, found, err := LoadAccount(); err == nil && found && prior != nil {
+		acct.Unlocks = prior.Unlocks
+		acct.Stats = prior.Stats
+		acct.Achievements = append([]string(nil), prior.Achievements...)
+		acct.Prefs = prior.Prefs
+	}
+
+	if err := acct.Save(); err != nil {
+		return nil, err
+	}
+	return acct, nil
 }
 
 // accountPath resolves the full path to account.json, mirroring savePath's
@@ -847,6 +955,16 @@ func (a *Account) FlushIfDirty() error {
 	}
 	a.dirty = false
 	return nil
+}
+
+// Name returns the account's display name under a.mu, for the lock-safe UI snapshot
+// (GetState). DisplayName is chosen-once identity and never mutated by the Record*
+// writers, but reading it under a.mu keeps the snapshot consistent with the rest of
+// LifetimeStats and free of any data-race tooling complaint.
+func (a *Account) Name() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.DisplayName
 }
 
 // LifetimeStats returns a lock-guarded COPY of the account's lifetime stats and unlocked

--- a/game/account_name_test.go
+++ b/game/account_name_test.go
@@ -1,0 +1,170 @@
+package game
+
+import (
+	"testing"
+)
+
+// TestAccountIDFromNameDeterministic confirms the derived ID is stable for the same
+// name and 32 hex chars (16 bytes) — the format the recovery code + save attribution
+// depend on.
+func TestAccountIDFromNameDeterministic(t *testing.T) {
+	id1 := accountIDFromName("Imperium")
+	id2 := accountIDFromName("Imperium")
+	if id1 != id2 {
+		t.Errorf("same name derived different IDs: %q != %q", id1, id2)
+	}
+	if len(id1) != 32 {
+		t.Errorf("derived ID = %q (len %d), want 32 hex chars", id1, len(id1))
+	}
+}
+
+// TestAccountIDFromNameNormalizes confirms the normalization rules: case-insensitive,
+// surrounding whitespace trimmed, internal whitespace runs collapsed — all map to one ID.
+func TestAccountIDFromNameNormalizes(t *testing.T) {
+	base := accountIDFromName("bob")
+	variants := map[string]string{
+		"trailing-space": "Bob ",
+		"leading-space":  "  bob",
+		"uppercase":      "BOB",
+		"mixed-case":     "Bob",
+	}
+	for name, v := range variants {
+		if got := accountIDFromName(v); got != base {
+			t.Errorf("%s: accountIDFromName(%q) = %q, want %q (same as %q)", name, v, got, base, "bob")
+		}
+	}
+
+	// Internal whitespace collapse: "bob  the   builder" == "bob the builder".
+	if a, b := accountIDFromName("bob  the   builder"), accountIDFromName("bob the builder"); a != b {
+		t.Errorf("internal whitespace not collapsed: %q != %q", a, b)
+	}
+
+	// Different names → different IDs.
+	if accountIDFromName("alice") == accountIDFromName("bob") {
+		t.Error("different names derived the same ID")
+	}
+}
+
+// TestCreateNamedAccount confirms identity derivation: DisplayName keeps the original
+// (trimmed) name, AccountID is name-derived, and the account is Established + signed.
+func TestCreateNamedAccount(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, err := CreateNamedAccount("  Imperium Romanum  ")
+	if err != nil {
+		t.Fatalf("CreateNamedAccount: %v", err)
+	}
+	if acct.DisplayName != "Imperium Romanum" {
+		t.Errorf("DisplayName = %q, want %q (trimmed original)", acct.DisplayName, "Imperium Romanum")
+	}
+	if acct.AccountID != accountIDFromName("Imperium Romanum") {
+		t.Errorf("AccountID = %q, want derived %q", acct.AccountID, accountIDFromName("Imperium Romanum"))
+	}
+	if !acct.Established() {
+		t.Error("named account not Established()")
+	}
+	if acct.Signature == "" {
+		t.Error("named account not signed")
+	}
+	if !verifyAccount(acct) {
+		t.Error("named account fails signature verification")
+	}
+}
+
+// TestCreateNamedAccountCarriesOverData confirms the migration: a pre-existing account
+// with an earned unlock has that DATA carried into the new named account when the
+// identity is re-keyed to a name.
+func TestCreateNamedAccountCarriesOverData(t *testing.T) {
+	isolateAccountDir(t)
+
+	// Seed a legacy random-id account with an unlock + a lifetime stat.
+	legacy, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate (legacy seed): %v", err)
+	}
+	legacy.Unlocks.Themes = []string{"obsidian"}
+	legacy.Stats.TotalPrestiges = 7
+	legacy.Achievements = []string{"first_prestige"}
+	if err := legacy.Save(); err != nil {
+		t.Fatalf("Save legacy: %v", err)
+	}
+
+	named, err := CreateNamedAccount("Carthage")
+	if err != nil {
+		t.Fatalf("CreateNamedAccount: %v", err)
+	}
+	if named.AccountID != accountIDFromName("Carthage") {
+		t.Errorf("AccountID = %q, want name-derived", named.AccountID)
+	}
+	if named.AccountID == legacy.AccountID {
+		t.Error("named account kept the legacy random ID; should be name-derived")
+	}
+	if len(named.Unlocks.Themes) != 1 || named.Unlocks.Themes[0] != "obsidian" {
+		t.Errorf("unlock not carried over: %v", named.Unlocks.Themes)
+	}
+	if named.Stats.TotalPrestiges != 7 {
+		t.Errorf("lifetime stat not carried over: TotalPrestiges = %d, want 7", named.Stats.TotalPrestiges)
+	}
+	if len(named.Achievements) != 1 || named.Achievements[0] != "first_prestige" {
+		t.Errorf("achievement not carried over: %v", named.Achievements)
+	}
+}
+
+// TestLoadAccountFoundFalseWhenNoFile confirms LoadAccount never creates: with no file
+// it returns found=false and a nil account.
+func TestLoadAccountFoundFalseWhenNoFile(t *testing.T) {
+	isolateAccountDir(t)
+
+	acct, found, err := LoadAccount()
+	if err != nil {
+		t.Fatalf("LoadAccount (absent): %v", err)
+	}
+	if found {
+		t.Error("LoadAccount reported found=true with no file on disk")
+	}
+	if acct != nil {
+		t.Errorf("LoadAccount returned a non-nil account with no file: %+v", acct)
+	}
+}
+
+// TestLoadAccountFoundTrueForExisting confirms LoadAccount loads an existing account.
+func TestLoadAccountFoundTrueForExisting(t *testing.T) {
+	isolateAccountDir(t)
+
+	created, err := CreateNamedAccount("Babylon")
+	if err != nil {
+		t.Fatalf("CreateNamedAccount: %v", err)
+	}
+
+	loaded, found, err := LoadAccount()
+	if err != nil {
+		t.Fatalf("LoadAccount (existing): %v", err)
+	}
+	if !found {
+		t.Fatal("LoadAccount reported found=false for an existing account")
+	}
+	if loaded.AccountID != created.AccountID {
+		t.Errorf("loaded ID = %q, want %q", loaded.AccountID, created.AccountID)
+	}
+	if loaded.DisplayName != "Babylon" {
+		t.Errorf("loaded DisplayName = %q, want Babylon", loaded.DisplayName)
+	}
+}
+
+// TestRecoveryViaName confirms the cross-machine recovery story: re-entering the same
+// name regenerates the same AccountID.
+func TestRecoveryViaName(t *testing.T) {
+	isolateAccountDir(t)
+
+	first, err := CreateNamedAccount("Persia")
+	if err != nil {
+		t.Fatalf("CreateNamedAccount (first): %v", err)
+	}
+	second, err := CreateNamedAccount("Persia")
+	if err != nil {
+		t.Fatalf("CreateNamedAccount (second): %v", err)
+	}
+	if first.AccountID != second.AccountID {
+		t.Errorf("re-entering the same name produced a different ID: %q != %q", first.AccountID, second.AccountID)
+	}
+}

--- a/game/engine.go
+++ b/game/engine.go
@@ -2961,6 +2961,7 @@ func (ge *GameEngine) GetState() GameState {
 			}
 			s, ach := ge.account.LifetimeStats()
 			return &AccountStatsView{
+				DisplayName:          ge.account.Name(),
 				TotalPrestiges:       s.TotalPrestiges,
 				HighestAge:           s.HighestAge,
 				CivilizationsStarted: s.CivilizationsStarted,

--- a/game/types.go
+++ b/game/types.go
@@ -80,6 +80,7 @@ type GameState struct {
 // hands the UI its mutable backing slices. Achievements holds unlocked keys; the UI
 // resolves human names via game.AchievementName.
 type AccountStatsView struct {
+	DisplayName          string
 	TotalPrestiges       int
 	HighestAge           string
 	CivilizationsStarted int

--- a/main.go
+++ b/main.go
@@ -19,20 +19,14 @@ func main() {
 	// Create game engine
 	engine := game.NewGameEngine()
 
-	// Load (or first-run create) the per-player account and hand it to the engine, so
-	// the UI/dashboard — which share this engine — can reach it via engine.Account()
-	// in later phases (accounts.md §6). The account is non-critical: if loading fails,
-	// log to stderr and run without one rather than blocking play.
-	acct, err := game.LoadOrCreate()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not load account, continuing without one: %v\n", err)
-	} else if acct != nil {
+	// Load an EXISTING, established account and hand it to the engine so the UI/dashboard
+	// — which share this engine — can reach it via engine.Account() (accounts.md §6). We
+	// no longer auto-create here: on first run (no file, or a legacy unnamed account) the
+	// engine is left accountless and the UI prompts the player to name their account, which
+	// derives the identity (game.CreateNamedAccount). Loading is non-critical: ignore errors
+	// and run accountless rather than block play.
+	if acct, found, _ := game.LoadAccount(); found && acct.Established() {
 		engine.SetAccount(acct)
-		if acct.FreshlyCreated {
-			// Non-blocking first-run notice: surfaces in the in-game log, never gates
-			// play (accounts.md §6). Player-facing, no jargon.
-			engine.AddLog("info", "Welcome! A local account was created on this machine to track your unlocks across all your games.")
-		}
 	}
 
 	// Create UI

--- a/site/docs/account.md
+++ b/site/docs/account.md
@@ -8,16 +8,20 @@ This page explains what an account is, what the recovery code does (and, just as
 
 ## Your account
 
-Your account is created **automatically on first run** and stored at `./data/account.json`. There's no signup, no prompt, and it never blocks you from playing — it's just there the first time you launch the game. One account per machine, or more precisely one per data directory.
+The **first time you launch the game**, AgeForge asks you to **name your account**. The prompt comes up before the main menu, pre-filled with a suggested empire-style name you can keep, edit, or reroll. Whatever you settle on becomes your account's display name — and, just as importantly, your **identity**. The account is then stored at `./data/account.json`. One account per machine, or more precisely one per data directory.
+
+> **Your name *is* your identity.** The account ID is **derived from your name** — specifically `sha256(normalize(name))`, taking the first 16 bytes as a 32-character hex ID. "Normalize" means the name is lowercased, trimmed, and internal spacing collapsed before hashing, so `Imperium`, `imperium`, and the same name with stray surrounding spaces all derive the *same* ID. The display name keeps your original casing. Because the ID is name-derived, **re-entering the exact same name on a new machine regenerates the exact same account ID** — that's the simplest way to restore your identity (see [Restoring on a new machine](#restoring-on-a-new-machine)).
 
 The account holds two distinct things:
 
 | Part | What it is |
 |---|---|
-| **Identity** | A stable account ID, and optionally a display name |
+| **Identity** | Your chosen name and the account ID derived from it |
 | **Data** | Your earned meta-progression — theme unlocks, lifetime stats, achievements |
 
-The split matters, because the two halves are recovered very differently (see below). The recovery code carries your **identity**; the **data** is backed up separately with **progress export** (see [Backing up your progress](#backing-up-your-progress)).
+The split matters, because the two halves are recovered very differently (see below). Your **identity** is carried by either your account name *or* the recovery code (both point at the same ID); the **data** is backed up separately with **progress export** (see [Backing up your progress](#backing-up-your-progress)).
+
+> **Naming is chosen-once.** Because the ID is derived from the name, picking a *different* name later mints a *different* identity — it does not rename the account in place. There's no in-game rename for this reason. Choose a name you're happy to keep.
 
 ---
 
@@ -139,7 +143,15 @@ If the file is missing or has been tampered with, the import is rejected with a 
 
 ## Restoring on a new machine
 
-On the new machine (or after a reinstall), run:
+There are **two ways** to restore your identity, because your identity has two equivalent forms — your name and your recovery code both resolve to the same account ID.
+
+### The simplest way: re-enter your name
+
+On a fresh machine, the first-run prompt asks you to name your account. **Type the exact same name you used before** and you'll regenerate the exact same account ID — no code required. (Remember normalization: casing and surrounding spaces don't matter, but a *meaningfully* different name is a different identity.) This restores **identity only**, not your earned progress — for that you still need a progress export.
+
+### The precise way: recover from a code
+
+Alternatively, on the new machine (or after a reinstall), run:
 
 ```
 account recover AGEF-7Q2K-9X4M-ZJ31-…

--- a/ui/app.go
+++ b/ui/app.go
@@ -36,6 +36,23 @@ func (a *App) setup() {
 	a.pages.AddPage("dashboard", a.dashboard.Root(), true, false)
 
 	a.tviewApp.SetRoot(a.pages, true)
+
+	// First run: if no established (named) account is wired, prompt for the account
+	// name as the very first thing the player sees — over the splash menu. The name
+	// derives the identity (game.CreateNamedAccount); the modal's Esc-accepts policy
+	// guarantees we always come away with an account. Once confirmed, install it and
+	// reveal the splash beneath.
+	if acct := a.engine.Account(); acct == nil || !acct.Established() {
+		showAccountNameModal(a.tviewApp, a.pages, splash, func(name string) {
+			newAcct, err := game.CreateNamedAccount(name)
+			if err != nil {
+				// Account is non-critical; on the rare Save failure, fall through to
+				// the splash accountless rather than block play.
+				return
+			}
+			a.engine.SetAccount(newAcct)
+		})
+	}
 }
 
 // Run starts the tview application (blocks until exit)

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -558,9 +558,19 @@ func (d *Dashboard) refreshStatus(state game.GameState) {
 		moraleDelta = fmt.Sprintf(" [%s]%s[-]", mBand.Color, mBand.DeltaLabel)
 	}
 	moraleStr := fmt.Sprintf("  Morale: [%s]%.0f%%[-]%s", mBand.Color, state.Morale*100, moraleDelta)
+	// Leading account-name segment, when an account is wired. Truncate a long name so
+	// the status line stays readable on narrow terminals.
+	acctStr := ""
+	if state.AccountStats != nil && state.AccountStats.DisplayName != "" {
+		name := state.AccountStats.DisplayName
+		if len(name) > 20 {
+			name = name[:19] + "…"
+		}
+		acctStr = fmt.Sprintf("[gold]%s[-] · ", name)
+	}
 	d.statusTV.SetText(fmt.Sprintf(
-		"[gold]%s[-]%s%s%s  Tick: %d%s%s%s  |  Pop: %d/%d%s  |  [gray]type panel name to open  ESC=close/menu[-]",
-		state.AgeName, prestigeStr, titleStr, epochStr, state.Tick, nextAgeStr, speedStr, devStr,
+		"%s[gold]%s[-]%s%s%s  Tick: %d%s%s%s  |  Pop: %d/%d%s  |  [gray]type panel name to open  ESC=close/menu[-]",
+		acctStr, state.AgeName, prestigeStr, titleStr, epochStr, state.Tick, nextAgeStr, speedStr, devStr,
 		state.Workers.TotalPop, state.Workers.MaxPop, moraleStr,
 	))
 }

--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -13,6 +13,18 @@ import (
 // newGameNamePage is the unique page name for the New Game name-entry modal.
 const newGameNamePage = "newgame_name"
 
+// accountNamePage is the unique page name for the first-run account-name modal.
+const accountNamePage = "account_name"
+
+// showAccountNameModal pops the first-run "name your account" prompt over the splash.
+// It reuses showSaveNameModalOpts with the account variant's Esc policy (Esc accepts the
+// current/generated value — naming can't be cancelled into an accountless state), so the
+// first run ALWAYS yields a named account. onConfirm receives the cleaned name; the caller
+// derives the identity via game.CreateNamedAccount and installs it on the engine.
+func showAccountNameModal(app *tview.Application, pages *tview.Pages, restoreFocus tview.Primitive, onConfirm func(name string)) {
+	showSaveNameModalOpts(app, pages, " Name Your AgeForge Account ", accountNamePage, restoreFocus, onConfirm, true)
+}
+
 // showNewGameNameModal pops the New Game name prompt. It is a thin wrapper over
 // showSaveNameModal so the splash menu keeps its existing behavior unchanged.
 //
@@ -31,6 +43,16 @@ func showNewGameNameModal(app *tview.Application, pages *tview.Pages, restoreFoc
 // title customizes the heading; pageName must be distinct per caller so two
 // concurrent modals (e.g. New Game vs. Branch) can't collide on the page stack.
 func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageName string, focusReturn tview.Primitive, onConfirm func(name string)) {
+	showSaveNameModalOpts(app, pages, title, pageName, focusReturn, onConfirm, false)
+}
+
+// showSaveNameModalOpts is showSaveNameModal with an explicit Esc policy. When
+// escAccepts is false (the default for New Game / Branch), Esc cancels — removing
+// the page and restoring focus without calling onConfirm. When escAccepts is true
+// (first-run account naming), Esc instead ACCEPTS the current/generated value: the
+// account naming step must always produce an account, so it cannot be cancelled into
+// an accountless state. The hint line adjusts to match.
+func showSaveNameModalOpts(app *tview.Application, pages *tview.Pages, title, pageName string, focusReturn tview.Primitive, onConfirm func(name string), escAccepts bool) {
 	errTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter)
@@ -44,10 +66,14 @@ func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageNa
 		SetFieldBackgroundColor(tcell.NewRGBColor(48, 54, 61)).
 		SetFieldTextColor(tcell.ColorWhite)
 
+	escHint := "Esc: cancel"
+	if escAccepts {
+		escHint = "Esc: accept"
+	}
 	hintTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
-		SetText("[#8b949e]Enter: confirm  ·  Tab: reroll name  ·  Esc: cancel[-]")
+		SetText("[#8b949e]Enter: confirm  ·  Tab: reroll name  ·  " + escHint + "[-]")
 
 	// closeAndRestore removes the modal page and restores focus to focusReturn.
 	// Used on cancel (Esc).
@@ -114,7 +140,13 @@ func showSaveNameModal(app *tview.Application, pages *tview.Pages, title, pageNa
 	modal.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
 		switch ev.Key() {
 		case tcell.KeyEsc:
-			closeAndRestore()
+			if escAccepts {
+				// First-run account naming can't be cancelled into a no-account state:
+				// Esc accepts the current/generated value via the normal submit path.
+				submit()
+			} else {
+				closeAndRestore()
+			}
 			return nil
 		case tcell.KeyTab, tcell.KeyBacktab:
 			reroll()

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -49,6 +49,9 @@ func statsProvider(state game.GameState, _ int) string {
 		sb.WriteString(" [gray]No account loaded[-]\n")
 	} else {
 		as := state.AccountStats
+		if as.DisplayName != "" {
+			fmt.Fprintf(&sb, " [#8b949e]Account:[-] [white]%s[-]\n", as.DisplayName)
+		}
 		fmt.Fprintf(&sb, " [gold]Total Prestiges:[-]   %d\n", as.TotalPrestiges)
 
 		highestAge := "—"


### PR DESCRIPTION
## Name your AgeForge account on first run + name-derived identity

On first launch (no established account) the player gets a **"Name Your AgeForge Account"** prompt; the account ID is **derived from that name**, so the name *is* the identity — retype it on a new machine and you're back (the recovery code still works as a secondary backup).

- **`accountIDFromName(name)` = `hex(sha256(normalize(name))[:16])`** — same 32-hex format, so the recovery code + save attribution are unchanged. normalize = lowercase + trim + collapse whitespace; `DisplayName` keeps the original casing.
- **`LoadAccount()`** (load-only, no random auto-create) + **`CreateNamedAccount()`** which **carries over** any existing account's unlocks/stats into the named identity (so your current dev account's data isn't lost — it just gains a name).
- **First-run prompt** fires in app setup over the splash, reusing the name-entry modal; **Esc accepts** the generated default so you can't end up account-less. Generated empire-name pre-fill, Tab to reroll.
- **Name shown** in the Stats "Lifetime (Account)" block and the **main status bar**.
- **Rename = a new identity** (name is chosen-once) — documented caveat.
- **.gitignore**: now ignores `data/account.json` / `account-export.json` / `*.corrupt` — these were untracked and at risk of being committed (your real playtest account was sitting there).

### Tests
deterministic + normalized ID (`"Bob "` == `"bob"`), `CreateNamedAccount` sets name + derived ID + carries over data, `LoadAccount` found/not-found, **recovery-via-name** (same name → same ID). `go build/vet/test` green.

### Worth a playtest
Delete/rename your `data/account.json` (or run fresh) → you should get the name prompt; pick a name; then see it in the status bar + Stats. (Your existing nameless account will prompt for a name and keep its data.)

### Known wrinkle (noted, out of scope)
With name-derived IDs, typing a *slightly different* name on a restore silently makes a fresh empty account — wiki calls this out; a "no account for that name — create new?" confirm could come later.

Trello: https://trello.com/c/JSWOuAJt
