### PR TITLE
fix(savenames): flatten the distribution — kill phrase clustering

### DIFF
--- a/game/savenames.go
+++ b/game/savenames.go
@@ -37,6 +37,28 @@ func cleanSaveName(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
+// maybeThe returns "The " roughly half the time and "" the rest, so any
+// template that opens with it also produces a bare "<Adj> <Noun>" form. This
+// keeps the leading-article share from dominating the distribution.
+// cleanSaveName trims, so a leading "" collapses cleanly.
+func maybeThe() string {
+	if rand.Intn(2) == 0 {
+		return "The "
+	}
+	return ""
+}
+
+// polityPrefixes are varied "<X> of" phrasings for the "of" templates, so no
+// single connective (the old hardcoded "Grand Duchy of") dominates. All entries
+// are filesystem-safe: letters and single spaces only, no punctuation.
+var polityPrefixes = []string{
+	"Grand Duchy of", "Republic of", "Free State of", "League of",
+	"Order of", "Dominion of", "Confederacy of", "Principality of",
+	"Commonwealth of", "Sovereign State of", "United Provinces of",
+	"Most Serene Republic of", "Protectorate of", "Assembly of",
+	"Realm of", "Council of",
+}
+
 // --- EPIC: grand, dominion-flavoured. "The <Adj> <Noun>" / "<Root> <Suffix>".
 
 var epicAdjectives = []string{
@@ -153,10 +175,19 @@ var epicSuffixes = []string{
 }
 
 func generateEpicName() string {
-	if rand.Intn(2) == 0 {
-		return "The " + pick(epicAdjectives) + " " + pick(epicNouns)
+	switch rand.Intn(5) {
+	case 0:
+		return maybeThe() + pick(epicAdjectives) + " " + pick(epicNouns)
+	case 1:
+		return pick(epicPlaceRoots) + " " + pick(epicSuffixes)
+	case 2:
+		return pick(epicAdjectives) + " " + pick(epicPlaceRoots)
+	case 3:
+		return pick(epicNouns) + " of " + pick(epicPlaceRoots)
+	default:
+		// e.g. "Dominion of Ironhold"
+		return pick(polityPrefixes) + " " + pick(epicPlaceRoots)
 	}
-	return pick(epicPlaceRoots) + " " + pick(epicSuffixes)
 }
 
 // --- MYTHIC: coined ancient-sounding names. No apostrophes (filesystem-safe).
@@ -285,9 +316,9 @@ func generateMythicName() string {
 		// Two coined words: <Root> <Root+suffix>
 		return pick(mythicRoots) + " " + pick(mythicRoots) + pick(mythicSuffixes)
 	default:
-		// "The <Adj> <EpochNoun>" / "<Adj> <Root>"
+		// "[The] <Adj> <EpochNoun>" / "<Adj> <Root>"
 		if rand.Intn(2) == 0 {
-			return "The " + pick(mythicAdjectives) + " " + pick(mythicEpochNouns)
+			return maybeThe() + pick(mythicAdjectives) + " " + pick(mythicEpochNouns)
 		}
 		return pick(mythicAdjectives) + " " + pick(mythicRoots)
 	}
@@ -395,13 +426,18 @@ var whimsicalOfThings = []string{
 }
 
 func generateWhimsicalName() string {
-	switch rand.Intn(3) {
+	switch rand.Intn(5) {
 	case 0:
 		return pick(whimsicalWholeNames)
 	case 1:
-		return "The " + pick(whimsicalAdjectives) + " " + pick(whimsicalNouns)
+		return maybeThe() + pick(whimsicalAdjectives) + " " + pick(whimsicalNouns)
+	case 2:
+		// "Grand Duchy of" is now 1 of ~16 polity prefixes, not the only one.
+		return pick(polityPrefixes) + " " + pick(whimsicalOfThings)
+	case 3:
+		return pick(whimsicalWholeNames) + " " + pick(whimsicalNouns)
 	default:
-		return "Grand Duchy of " + pick(whimsicalOfThings)
+		return pick(whimsicalAdjectives) + " " + pick(whimsicalWholeNames)
 	}
 }
 

--- a/game/savenames_test.go
+++ b/game/savenames_test.go
@@ -33,3 +33,58 @@ func TestGenerateSaveNameVariety(t *testing.T) {
 		t.Errorf("GenerateSaveName() produced only %d distinct values across 200 calls, want > 5", len(seen))
 	}
 }
+
+// TestGenerateSaveNameDistribution is the regression guard against connective
+// clustering. The old structure produced "Grand Duchy of" in ~11% of names and
+// a "The " prefix in ~33%; both would fail the thresholds below. The flattened
+// design (varied polity prefixes + optional article + more templates) passes
+// these with wide margin at N=30000, where variance is negligible.
+func TestGenerateSaveNameDistribution(t *testing.T) {
+	const n = 30000
+
+	twoWordPrefix := make(map[string]int)
+	grandDuchy := 0
+	therePrefix := 0
+	distinct := make(map[string]struct{})
+
+	for i := 0; i < n; i++ {
+		name := GenerateSaveName()
+		distinct[name] = struct{}{}
+
+		if strings.HasPrefix(name, "The ") {
+			therePrefix++
+		}
+		if strings.HasPrefix(name, "Grand Duchy of") {
+			grandDuchy++
+		}
+
+		fields := strings.Fields(name)
+		if len(fields) >= 2 {
+			twoWordPrefix[fields[0]+" "+fields[1]]++
+		}
+	}
+
+	// Most common two-word prefix must be < 4% — kills the old 11% cluster.
+	var topPrefix string
+	var topCount int
+	for p, c := range twoWordPrefix {
+		if c > topCount {
+			topPrefix, topCount = p, c
+		}
+	}
+	if frac := float64(topCount) / float64(n); frac >= 0.04 {
+		t.Errorf("top two-word prefix %q = %.2f%% of names, want < 4%%", topPrefix, frac*100)
+	}
+
+	if frac := float64(grandDuchy) / float64(n); frac >= 0.03 {
+		t.Errorf("%q prefix = %.2f%% of names, want < 3%%", "Grand Duchy of", frac*100)
+	}
+
+	if frac := float64(therePrefix) / float64(n); frac >= 0.22 {
+		t.Errorf("%q prefix = %.2f%% of names, want < 22%%", "The ", frac*100)
+	}
+
+	if frac := float64(len(distinct)) / float64(n); frac <= 0.70 {
+		t.Errorf("distinct names = %.2f%% of %d, want > 70%%", frac*100, n)
+	}
+}


### PR DESCRIPTION
You were right to be picky. The RNG is fine (Go 1.24 global `rand`, auto-seeded) — the repetition was **structural**.

**Measured (30k samples):**

| | before | after |
|---|---|---|
| "Grand Duchy of" | **11.2%** | 0.88% |
| "The …" prefix | **33.2%** | 9.3% |
| top two-word prefix | 11.2% | 1.0% |
| unique | — | 86% |

**Fixes:**
- `polityPrefixes` bank (16 "<X> of" phrasings) — "Grand Duchy of" is now 1-of-16, not a hardcoded literal.
- `maybeThe()` — the article is a ~50% coin-flip on every template that used it (bare "<Adj> <Noun>" now appears too).
- Epic templates 2→5, whimsical 3→5 for structural spread.

**Guard:** new `TestGenerateSaveNameDistribution` (N=30k) asserts top two-word prefix < 4%, "Grand Duchy of" < 3%, "The " < 22%, unique > 70% — passes the new design with margin, fails the old 11%/33% structure. FS-safe + variety tests untouched.

Trello: names-quality follow-up.