### PR TITLE
feat(theme): full theme system — palettes, accessibility, account-wide unlocks

### DIFF
--- a/game/save.go
+++ b/game/save.go
@@ -224,6 +224,19 @@ type UnlockedState struct {
 // runs outside tests.
 var dataDirOverride string
 
+// SetDataDirForTest points the data root (saves/account) at dir and returns a
+// restore func, so tests in OTHER packages (e.g. ui) can isolate the data root the
+// way in-package tests do via dataDirOverride directly. Pass "" to clear. This is a
+// test-only seam — production never calls it; it is exported solely to cross the
+// package boundary. The active theme persists into account.json under this root, so
+// a ui test that exercises SetActiveTheme must call this to avoid clobbering a real
+// ./data/account.json. Usage: defer game.SetDataDirForTest(t.TempDir())().
+func SetDataDirForTest(dir string) (restore func()) {
+	prior := dataDirOverride
+	dataDirOverride = dir
+	return func() { dataDirOverride = prior }
+}
+
 // dataDirectory returns the canonical data root: data/ next to the binary, resolved
 // via os.Executable + EvalSymlinks. Falls back to a CWD-relative "data" if the
 // binary path cannot be determined. Saves, accounts, and (eventually) logs share

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.24.0
 
 require (
 	github.com/gdamore/tcell/v2 v2.13.10
+	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/rivo/tview v0.42.0
 )
 
 require (
 	github.com/gdamore/encoding v1.0.1 // indirect
-	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/term v0.38.0 // indirect

--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -13,6 +13,7 @@ AgeForge runs entirely in your terminal using a full-screen TUI built with Go + 
 | [Installation](getting-started.md) | Download and run in 3 steps |
 | [How to Play](how-to-play.md) | Core gameplay loop explained |
 | [All Commands](commands.md) | Full command reference |
+| [Themes & Accessibility](themes.md) | Palettes, colorblind-safe + high-contrast themes |
 | [The 22 Ages](ages.md) | Every age, its requirements, and unlocks |
 | [Buildings](buildings.md) | All 284 buildings including wonders |
 | [Technologies](technologies.md) | All 52 techs with effects |

--- a/site/docs/_sidebar.md
+++ b/site/docs/_sidebar.md
@@ -10,6 +10,7 @@
   - [All Commands](commands.md)
   - [Saving & Loading](saving-and-loading.md)
   - [Account & Recovery](account.md)
+  - [Themes & Accessibility](themes.md)
   - [Resources](resources.md)
   - [Workers](villagers.md)
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -214,6 +214,9 @@ Voluntary catastrophes let you force an epoch event outside the normal roll. Use
 | `account export [path]` | Write a signed **progress** backup (unlocks, stats, achievements) to a file (default `data/account-export.json`) |
 | `account import <path> [replace]` | Restore a progress backup file — **merges** by default; add `replace` to overwrite wholesale |
 | `account wipe` | Points you to the main-menu **Wipe Account** action — the actual (permanent) wipe lives behind a type-your-name confirm, not this command |
+| `theme` | Open the **Themes** picker — browse palettes with live preview (also on the main menu) |
+| `theme list` | List every theme by name and key, marking the active one and noting which are accessible |
+| `theme <key>` | Switch directly to a theme by key (e.g. `theme high_contrast`) |
 | `dump` | Export logs to a file for debugging |
 | `help` | Open the Help panel — full command reference and list of available panels |
 
@@ -230,6 +233,25 @@ A bare `save` (no name) opens a prompt: **Overwrite** writes your current run to
 A bare `load` (no name) opens the **Load Game** browser so you can pick which save/branch to load from your save tree — it never assumes a slot. You can open it mid-game; `Esc` returns you to your current run without loading anything. `load <name>` skips the browser and loads that save directly.
 
 See [Saving & Loading](saving-and-loading.md) for the full save system.
+
+---
+
+## Themes
+
+AgeForge's interface colors are driven by a small set of swappable themes. Open the picker with the **Themes** entry on the main menu, or type `theme` from the in-game prompt.
+
+- `theme` opens the picker: a list of themes on the left, a detail pane on the right showing each theme's blurb and a row of **palette swatches** (Background, Text, Accent, Positive, Negative, Highlight, Dim, Selection). Highlighting a theme with `↑`/`↓` **previews it live** — the whole UI retints instantly so you can judge it in place. `Enter` keeps the highlighted theme; `Esc` cancels and reverts to whatever you had before.
+- `theme list` prints every theme with its name and key, marks the active one, and notes which are accessible.
+- `theme <key>` switches straight to a theme by key (e.g. `theme deuteranopia`). An unknown key lists the valid ones.
+
+### Accessibility
+
+Color is never the only signal. Alongside the default **Forge** look, three accessibility themes ship **unlocked from the start**:
+
+- **Deuteranopia-safe** and **Protanopia-safe** — for red-green color vision deficiency. Because AgeForge normally uses **green for gains and red for losses**, these themes drop that pairing entirely: gains are **blue**, losses are **orange** (the standard colorblind-safe opposition), and `▲`/`▼` glyphs mark the sign by **shape as well as color** so the direction reads even if the hues don't.
+- **High Contrast** — maximum legibility on near-black, for low-vision players and high-glare terminals. It also keeps the blue/orange + `▲`/`▼` encoding, so it's colorblind-safe too.
+
+Your theme choice applies immediately. (Theme preferences persist per session for now; account-wide persistence lands in a later update.)
 
 ---
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -240,9 +240,9 @@ See [Saving & Loading](saving-and-loading.md) for the full save system.
 
 AgeForge's interface colors are driven by a small set of swappable themes. Open the picker with the **Themes** entry on the main menu, or type `theme` from the in-game prompt.
 
-- `theme` opens the picker: a list of themes on the left, a detail pane on the right showing each theme's blurb and a row of **palette swatches** (Background, Text, Accent, Positive, Negative, Highlight, Dim, Selection). Highlighting a theme with `↑`/`↓` **previews it live** — the whole UI retints instantly so you can judge it in place. `Enter` keeps the highlighted theme; `Esc` cancels and reverts to whatever you had before.
-- `theme list` prints every theme with its name and key, marks the active one, and notes which are accessible.
-- `theme <key>` switches straight to a theme by key (e.g. `theme deuteranopia`). An unknown key lists the valid ones.
+- `theme` opens the picker: a list of themes on the left, a detail pane on the right showing each theme's blurb and a row of **palette swatches** (Background, Text, Accent, Positive, Negative, Highlight, Dim, Selection). Highlighting a theme with `↑`/`↓` **previews it live** — the whole UI retints instantly so you can judge it in place. `Enter` keeps the highlighted theme; `Esc` cancels and reverts to whatever you had before. A **locked** flavor theme shows a `🔒 Locked — <how to unlock>` line above its swatches (you can still preview it, but `Enter` won't switch to one you haven't earned).
+- `theme list` prints every theme with its name and key, marks the active one, notes which are accessible, and shows the `🔒` unlock condition for any **locked** flavor theme (e.g. `monochrome  🔒 Reach the Information Age`).
+- `theme <key>` switches straight to a theme by key (e.g. `theme deuteranopia`). An unknown key lists the valid ones; a locked key tells you it isn't unlocked yet.
 
 ### Accessibility
 
@@ -250,6 +250,20 @@ Color is never the only signal. Alongside the default **Forge** look, three acce
 
 - **Deuteranopia-safe** and **Protanopia-safe** — for red-green color vision deficiency. Because AgeForge normally uses **green for gains and red for losses**, these themes drop that pairing entirely: gains are **blue**, losses are **orange** (the standard colorblind-safe opposition), and `▲`/`▼` glyphs mark the sign by **shape as well as color** so the direction reads even if the hues don't.
 - **High Contrast** — maximum legibility on near-black, for low-vision players and high-glare terminals. It also keeps the blue/orange + `▲`/`▼` encoding, so it's colorblind-safe too.
+
+### Flavor themes & unlocks
+
+Beyond Forge and the accessibility set, AgeForge ships **flavor themes** — purely cosmetic looks (Parchment, Bronze, Cyberpunk, Monochrome, Cosmic) — that you **unlock by reaching milestones**. Each is tied to an age milestone:
+
+| Theme | Unlocks when you… |
+|---|---|
+| **Bronze** | Reach the Bronze Age |
+| **Parchment** | Reach the Renaissance Age |
+| **Monochrome** | Reach the Information Age |
+| **Cyberpunk** | Reach the Cyberpunk Age |
+| **Cosmic** | Reach the Galactic Age |
+
+When you hit the milestone, the theme unlocks and a log line tells you (`🎨 New theme unlocked: …`). Unlocks are **account-wide and permanent**: earn a theme on one empire and it's yours on every save and every future new game — exactly like your accessibility themes. Until then the theme is **locked**: the picker and `theme list` still show it (with its unlock condition) and let you preview it, but you can't make it your active theme until you've earned it.
 
 Your theme choice applies immediately and **persists per account** — it is saved with your account (in `account.json`), not with any individual game save, so it carries across every save and every new game, and loading an old save never changes your theme. Switching via the picker (`Enter`) or with `theme <key>` both stick; cancelling the picker with `Esc` reverts and saves nothing.
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -251,7 +251,7 @@ Color is never the only signal. Alongside the default **Forge** look, three acce
 - **Deuteranopia-safe** and **Protanopia-safe** — for red-green color vision deficiency. Because AgeForge normally uses **green for gains and red for losses**, these themes drop that pairing entirely: gains are **blue**, losses are **orange** (the standard colorblind-safe opposition), and `▲`/`▼` glyphs mark the sign by **shape as well as color** so the direction reads even if the hues don't.
 - **High Contrast** — maximum legibility on near-black, for low-vision players and high-glare terminals. It also keeps the blue/orange + `▲`/`▼` encoding, so it's colorblind-safe too.
 
-Your theme choice applies immediately. (Theme preferences persist per session for now; account-wide persistence lands in a later update.)
+Your theme choice applies immediately and **persists per account** — it is saved with your account (in `account.json`), not with any individual game save, so it carries across every save and every new game, and loading an old save never changes your theme. Switching via the picker (`Enter`) or with `theme <key>` both stick; cancelling the picker with `Esc` reverts and saves nothing.
 
 ---
 

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -238,34 +238,23 @@ See [Saving & Loading](saving-and-loading.md) for the full save system.
 
 ## Themes
 
-AgeForge's interface colors are driven by a small set of swappable themes. Open the picker with the **Themes** entry on the main menu, or type `theme` from the in-game prompt.
+AgeForge's interface colors are driven by a set of swappable themes. Open the picker with the **Themes** entry on the main menu, or type `theme` from the in-game prompt.
 
-- `theme` opens the picker: a list of themes on the left, a detail pane on the right showing each theme's blurb and a row of **palette swatches** (Background, Text, Accent, Positive, Negative, Highlight, Dim, Selection). Highlighting a theme with `↑`/`↓` **previews it live** — the whole UI retints instantly so you can judge it in place. `Enter` keeps the highlighted theme; `Esc` cancels and reverts to whatever you had before. A **locked** flavor theme shows a `🔒 Locked — <how to unlock>` line above its swatches (you can still preview it, but `Enter` won't switch to one you haven't earned).
-- `theme list` prints every theme with its name and key, marks the active one, notes which are accessible, and shows the `🔒` unlock condition for any **locked** flavor theme (e.g. `monochrome  🔒 Reach the Information Age`).
-- `theme <key>` switches straight to a theme by key (e.g. `theme deuteranopia`). An unknown key lists the valid ones; a locked key tells you it isn't unlocked yet.
-
-### Accessibility
-
-Color is never the only signal. Alongside the default **Forge** look, three accessibility themes ship **unlocked from the start**:
-
-- **Deuteranopia-safe** and **Protanopia-safe** — for red-green color vision deficiency. Because AgeForge normally uses **green for gains and red for losses**, these themes drop that pairing entirely: gains are **blue**, losses are **orange** (the standard colorblind-safe opposition), and `▲`/`▼` glyphs mark the sign by **shape as well as color** so the direction reads even if the hues don't.
-- **High Contrast** — maximum legibility on near-black, for low-vision players and high-glare terminals. It also keeps the blue/orange + `▲`/`▼` encoding, so it's colorblind-safe too.
-
-### Flavor themes & unlocks
-
-Beyond Forge and the accessibility set, AgeForge ships **flavor themes** — purely cosmetic looks (Parchment, Bronze, Cyberpunk, Monochrome, Cosmic) — that you **unlock by reaching milestones**. Each is tied to an age milestone:
-
-| Theme | Unlocks when you… |
+| Command | Description |
 |---|---|
-| **Bronze** | Reach the Bronze Age |
-| **Parchment** | Reach the Renaissance Age |
-| **Monochrome** | Reach the Information Age |
-| **Cyberpunk** | Reach the Cyberpunk Age |
-| **Cosmic** | Reach the Galactic Age |
+| `theme` | Open the **Themes** picker — browse palettes with live preview (`↑`/`↓` previews, `Enter` keeps, `Esc` reverts) |
+| `theme list` | List every theme by name and key, marking the active one and the lock status of any theme you haven't unlocked |
+| `theme <key>` | Switch directly to a theme by key (e.g. `theme high_contrast`) |
 
-When you hit the milestone, the theme unlocks and a log line tells you (`🎨 New theme unlocked: …`). Unlocks are **account-wide and permanent**: earn a theme on one empire and it's yours on every save and every future new game — exactly like your accessibility themes. Until then the theme is **locked**: the picker and `theme list` still show it (with its unlock condition) and let you preview it, but you can't make it your active theme until you've earned it.
+```
+theme
+theme list
+theme high_contrast
+```
 
-Your theme choice applies immediately and **persists per account** — it is saved with your account (in `account.json`), not with any individual game save, so it carries across every save and every new game, and loading an old save never changes your theme. Switching via the picker (`Enter`) or with `theme <key>` both stick; cancelling the picker with `Esc` reverts and saves nothing.
+Your theme choice **persists per account** (saved in `account.json`, not in any game save), so it carries across every save and new game. There are 9 themes — the default **Forge** look, three always-unlocked **accessibility** themes (colorblind-safe + high-contrast), and five **flavor** themes you unlock by reaching later ages.
+
+See [Themes & Accessibility](themes.md) for the full list and unlock conditions.
 
 ---
 

--- a/site/docs/events.md
+++ b/site/docs/events.md
@@ -59,7 +59,7 @@ At 1x speed (default 2 seconds per tick):
 
 Use the `logs` command (or press `L`) to open the Logs overlay and see your full event history. Events appear as log entries with their effect description and duration. When a timed event ends, the "ended" entry shows accumulated losses in yellow — useful for assessing actual damage.
 
-The **Stats overlay** lists every currently active timed event under "Active Events" with its ticks remaining. Beneath each event, its ongoing per-tick or percentage effect is now shown explicitly and color-coded — **green** for a bonus, **red** for a penalty — so you can see at a glance exactly what each active event is doing to your economy (e.g. a Famine shows `food -3.0/t` in red; a production-boost event shows `all production +10%` in green). Instant one-shot effects (resource grants, theft) are not listed here since they already fired at trigger.
+The **Stats overlay** lists every currently active timed event under "Active Events" with its ticks remaining. Beneath each event, its ongoing per-tick or percentage effect is now shown explicitly and color-coded — **green** for a bonus, **red** for a penalty — so you can see at a glance exactly what each active event is doing to your economy (e.g. a Famine shows `food -3.0/t` in red; a production-boost event shows `all production +10%` in green). (On the colorblind-safe and high-contrast [themes](commands.md#themes), bonuses show **blue** and penalties **orange**, with `▲`/`▼` glyphs marking the sign.) Instant one-shot effects (resource grants, theft) are not listed here since they already fired at trigger.
 
 ---
 

--- a/site/docs/morale.md
+++ b/site/docs/morale.md
@@ -94,7 +94,7 @@ Stack enough of them and their per-tick lift outpaces the drift-to-neutral, park
 - **Stats panel** (`stats`) — when morale is off-neutral it appears under **Active Multipliers** in the **All Production** breakdown as a `Morale ×N.NN` factor, shown alongside your research, wonder, prestige, and active-event bonuses on that line. Entries are colour-coded: a **green** headline (and fragment) is a net bonus, a **red** one a penalty, and a **white** headline marks a line that only shows because opposing sources cancel out. Each contributing source is listed and coloured individually, so a penalty (e.g. a famine event) is never hidden by a bonus on the same line. The panel lists **rate multipliers only** — capacity and storage bonuses (population cap, resource caps) are shown elsewhere, since they aren't rate multipliers.
 - **Load Game browser** — each save's detail pane shows its morale, so you can size up a civilization before loading it.
 
-The bar is **green when morale is above 50%** (boosting production), **neutral exactly at 50%**, and **red when it is below 50%** (penalising production).
+The bar is **green when morale is above 50%** (boosting production), **neutral exactly at 50%**, and **red when it is below 50%** (penalising production). On the colorblind-safe and high-contrast [themes](commands.md#themes) the boost/penalty colors become blue/orange instead of green/red.
 
 ---
 

--- a/site/docs/themes.md
+++ b/site/docs/themes.md
@@ -1,0 +1,95 @@
+# 🎨 Themes & Accessibility
+
+AgeForge's interface colors are driven by a set of swappable **themes** — 9 in all. You can switch between them **live** at any time, and your choice sticks: it's saved with your **account**, not with any individual game save, so it travels across every save and every new game. Loading an old save never changes your theme.
+
+Themes come in three flavors: the default **Forge** look, a set of **accessibility** themes (colorblind-safe and high-contrast, always unlocked), and **flavor** themes you unlock by reaching later ages.
+
+---
+
+## 🎨 The themes
+
+| Theme | Key | Type | How to get it |
+|---|---|---|---|
+| **Forge** | `forge` | Default | The classic dark + gold look — active by default |
+| **Deuteranopia-safe** | `deuteranopia` | Accessibility | Unlocked from the start |
+| **Protanopia-safe** | `protanopia` | Accessibility | Unlocked from the start |
+| **High Contrast** | `high_contrast` | Accessibility | Unlocked from the start |
+| **Bronze** | `bronze` | Flavor | Reach the Bronze Age |
+| **Parchment** | `parchment` | Flavor | Reach the Renaissance Age |
+| **Monochrome** | `monochrome` | Flavor | Reach the Information Age |
+| **Cyberpunk** | `cyberpunk` | Flavor | Reach the Cyberpunk Age |
+| **Cosmic** | `cosmic` | Flavor | Reach the Galactic Age |
+
+---
+
+## 🔀 How to switch
+
+You can change theme from the **`theme` command** at the `>` prompt, or from the **Themes** entry on the main menu. Both open the same picker.
+
+| Command | What it does |
+|---|---|
+| `theme` | Open the live theme picker |
+| `theme list` | List every theme by name and key, marking the active one and showing the lock status of any theme you haven't unlocked |
+| `theme <key>` | Switch directly to a theme by key (e.g. `theme high_contrast`) |
+
+```
+theme
+theme list
+theme high_contrast
+```
+
+### The picker
+
+The picker is a full-screen, **live-preview** screen:
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Preview a theme — the whole UI retints instantly so you can judge it in place |
+| `Enter` | Keep the highlighted theme |
+| `Esc` | Cancel and revert to whatever you had before |
+
+It shows **palette swatches** (colored blocks for each color role) and, for the accessibility themes, the `▲` / `▼` glyphs. A **locked** flavor theme can still be previewed, but `Enter` won't keep one you haven't earned yet.
+
+---
+
+## ♿ Accessibility
+
+Color is never the only signal. Three accessibility themes ship **unlocked from the start** and are **never gated** — they're always available:
+
+- **Deuteranopia-safe** and **Protanopia-safe** — for red-green color vision deficiency.
+- **High Contrast** — maximum legibility on a near-black background, for low-vision players and high-glare terminals.
+
+Because AgeForge normally uses **green for gains and red for losses**, the accessible themes drop that pairing entirely. Instead:
+
+- Gains are **blue**, losses are **orange** — the standard colorblind-safe opposition, so red-green colorblind players can tell `+` from `−`.
+- `▲` (gain) and `▼` (loss) glyphs mark the sign by **shape as well as color**, a redundant non-color cue so the direction reads even if the hues don't.
+
+When an accessible theme is active, the usual "green = gain / red = loss" UI legends adapt to **blue / orange + glyphs** to match.
+
+Every shipped theme is **contrast-checked** (WCAG AA for text on its background). The accessibility themes additionally pass a **colorblind-distinguishability** check.
+
+---
+
+## 🔓 Unlocking flavor themes
+
+Beyond Forge and the accessibility set, AgeForge ships **flavor themes** — purely cosmetic looks you unlock by reaching an age:
+
+| Theme | Unlocks when you… |
+|---|---|
+| **Bronze** | Reach the Bronze Age |
+| **Parchment** | Reach the Renaissance Age |
+| **Monochrome** | Reach the Information Age |
+| **Cyberpunk** | Reach the Cyberpunk Age |
+| **Cosmic** | Reach the Galactic Age |
+
+Unlocks are **account-wide and permanent**: earn a theme on one empire and it's yours on **every save and every future new game** — exactly like your accessibility themes.
+
+Until you've earned it, a flavor theme shows in the picker (and in `theme list`) with a `🔒` and its unlock condition. You can still preview a locked theme, but you can't make it your active theme until you reach the age that unlocks it.
+
+---
+
+## See also
+
+- [All Commands](commands.md) — the full `theme` command reference
+- [Account & Recovery](account.md) — how theme unlocks (and other account-wide progress) persist and travel between machines
+- [The 22 Ages](ages.md) — the ages that unlock the flavor themes

--- a/site/docs/workers-and-domains.md
+++ b/site/docs/workers-and-domains.md
@@ -74,7 +74,7 @@ Workers are recruited from available housing capacity. No domain argument — wo
 
 **`max` behaviour:** attempts to fill all remaining housing slots (up to population cap). It does not check your food income — you can recruit more workers than your food supports, putting you into a deficit.
 
-**Viewing workers:** type `workers` for the full three-panel overlay (summary, slot utilization, domain breakdown), or press `e` for the Economy tab. The `workers` overlay shows net food/tick color-coded green/red, a break-even or starvation warning, and per-building fill bars. A worker mini-box is always visible in the sidebar showing pop/idle/housing/drain/net at a glance.
+**Viewing workers:** type `workers` for the full three-panel overlay (summary, slot utilization, domain breakdown), or press `e` for the Economy tab. The `workers` overlay shows net food/tick color-coded green/red (blue/orange on the accessible [themes](commands.md#themes)), a break-even or starvation warning, and per-building fill bars. A worker mini-box is always visible in the sidebar showing pop/idle/housing/drain/net at a glance.
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -255,6 +255,16 @@
                             compound across prestige runs, rewarding the bold.
                         </p>
                     </div>
+                    <div class="feat-card" data-anim>
+                        <div class="feat-icon">🎨</div>
+                        <h3>Accessibility-First Theming</h3>
+                        <p>
+                            9 swappable themes you can switch live, including
+                            colorblind-safe and high-contrast palettes. Gains and
+                            losses read by shape as well as color, and your choice
+                            persists per account across every save.
+                        </p>
+                    </div>
                 </div>
             </div>
         </section>

--- a/theme/contrast.go
+++ b/theme/contrast.go
@@ -1,0 +1,161 @@
+package theme
+
+import (
+	"math"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	colorful "github.com/lucasb-eyer/go-colorful"
+)
+
+// This file implements the contrast-safety guard math (theming.md §8). Two
+// independent properties:
+//
+//  1. WCAG luminance contrast (RelativeLuminance / ContrastRatio) — "is the text
+//     readable against the background." Used for the AA floors.
+//  2. Colorblind distinguishability (Distinguishable) — "do two role colors stay
+//     perceptibly different under deutan/protan simulation." Luminance contrast is
+//     blind to this; it's what catches an Accent ≈ Positive collision for a
+//     colorblind player.
+//
+// The contrast TEST (contrast_test.go) drives all of this against the shipped
+// themes; these are the reusable primitives.
+
+// srgbToLinear inverts the sRGB transfer function for one channel in [0,1].
+func srgbToLinear(c float64) float64 {
+	if c <= 0.04045 {
+		return c / 12.92
+	}
+	return math.Pow((c+0.055)/1.055, 2.4)
+}
+
+// RelativeLuminance returns the WCAG relative luminance of c in [0,1]:
+// 0.2126 R + 0.7152 G + 0.0722 B over sRGB-linearized channels (theming.md §8).
+func RelativeLuminance(c tcell.Color) float64 {
+	r, g, b := rgbUnit(c)
+	rl := srgbToLinear(r)
+	gl := srgbToLinear(g)
+	bl := srgbToLinear(b)
+	return 0.2126*rl + 0.7152*gl + 0.0722*bl
+}
+
+// ContrastRatio returns the WCAG contrast ratio between a and b, in [1.0, 21.0]:
+// (Llighter + 0.05) / (Ldarker + 0.05). Order-independent.
+func ContrastRatio(a, b tcell.Color) float64 {
+	la := RelativeLuminance(a)
+	lb := RelativeLuminance(b)
+	if la < lb {
+		la, lb = lb, la
+	}
+	return (la + 0.05) / (lb + 0.05)
+}
+
+// DistinguishableThreshold is the minimum CIEDE2000 distance between two colors,
+// after colorblind simulation, for them to count as perceptibly different.
+//
+// NOTE ON SCALE: go-colorful's DistanceCIEDE2000 operates on its Lab values, which
+// are normalized to [0,1]-ish channels rather than the textbook L*∈[0,100] scale.
+// Its distances therefore land ~1/100th of conventional ΔE numbers — e.g. a vivid
+// red vs green here is ~0.72, not ~72. Do not reach for a "ΔE ~ 1 = JND" intuition;
+// these are this library's units. The threshold below is calibrated empirically
+// against the shipped palettes (see contrast_test.go):
+//
+//	accessible blue/orange ± under deut/protan sim: ~0.63–0.78  (must PASS)
+//	red/green under deut/protan sim:                ~0.26–0.43  (must FAIL — collapses)
+//	red/green with no sim:                          ~0.72       (passes — they differ)
+//
+// 0.55 cleanly separates the safe pairs (margin above) from a CVD-collapsed
+// red/green (well below), while still treating un-simulated red/green as distinct.
+const DistinguishableThreshold = 0.55
+
+// Distinguishable reports whether colors a and b remain perceptibly different after
+// simulating the given color-vision deficiency. sim is "deuteranopia" or
+// "protanopia" (case-insensitive prefix "deut"/"prot"); any other value simulates
+// nothing (compares the colors as-is). Distance is CIEDE2000 ΔE in Lab space.
+//
+// This is the §8 colorblind check: it catches role-color collisions that luminance
+// contrast cannot see.
+func Distinguishable(a, b tcell.Color, sim string) bool {
+	ca := simulate(a, sim)
+	cb := simulate(b, sim)
+	return ca.DistanceCIEDE2000(cb) >= DistinguishableThreshold
+}
+
+// toColorful converts a tcell.Color to a go-colorful Color via its RGB components.
+func toColorful(c tcell.Color) colorful.Color {
+	r, g, b := rgbUnit(c)
+	return colorful.Color{R: r, G: g, B: b}
+}
+
+// rgbUnit returns c's RGB as floats in [0,1].
+func rgbUnit(c tcell.Color) (r, g, b float64) {
+	ri, gi, bi := c.RGB()
+	return float64(ri) / 255.0, float64(gi) / 255.0, float64(bi) / 255.0
+}
+
+// simulate applies a dichromat color-vision-deficiency transform to c and returns
+// the perceived color. Uses the Viénot/Brettel-style approach: linearize sRGB,
+// project onto the dichromat plane in LMS via a fixed matrix, then de-linearize.
+// "deut*" => deuteranopia, "prot*" => protanopia; anything else is identity.
+func simulate(c tcell.Color, sim string) colorful.Color {
+	r, g, b := rgbUnit(c)
+	// Linearize for the matrix math (the CVD matrices operate on linear light).
+	r, g, b = srgbToLinear(r), srgbToLinear(g), srgbToLinear(b)
+
+	var rr, gg, bb float64
+	switch normSim(sim) {
+	case "deuteranopia":
+		// Viénot 1999 deuteranopia matrix (sRGB-linear domain).
+		rr = 0.625*r + 0.375*g + 0.0*b
+		gg = 0.70*r + 0.30*g + 0.0*b
+		bb = 0.0*r + 0.30*g + 0.70*b
+	case "protanopia":
+		// Viénot 1999 protanopia matrix.
+		rr = 0.567*r + 0.433*g + 0.0*b
+		gg = 0.558*r + 0.442*g + 0.0*b
+		bb = 0.0*r + 0.242*g + 0.758*b
+	default:
+		rr, gg, bb = r, g, b
+	}
+
+	// Clamp then de-linearize back to sRGB for a perceptual (Lab) comparison.
+	rr = clamp01(rr)
+	gg = clamp01(gg)
+	bb = clamp01(bb)
+	return colorful.Color{
+		R: linearToSRGB(rr),
+		G: linearToSRGB(gg),
+		B: linearToSRGB(bb),
+	}
+}
+
+// linearToSRGB applies the forward sRGB transfer function to one linear channel.
+func linearToSRGB(c float64) float64 {
+	if c <= 0.0031308 {
+		return 12.92 * c
+	}
+	return 1.055*math.Pow(c, 1.0/2.4) - 0.055
+}
+
+// normSim normalizes a CVD name to its canonical form by prefix.
+func normSim(sim string) string {
+	s := strings.ToLower(strings.TrimSpace(sim))
+	switch {
+	case strings.HasPrefix(s, "deut"):
+		return "deuteranopia"
+	case strings.HasPrefix(s, "prot"):
+		return "protanopia"
+	default:
+		return ""
+	}
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/theme/contrast_test.go
+++ b/theme/contrast_test.go
@@ -1,0 +1,124 @@
+package theme
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Floors per theming.md §8.
+const (
+	floorBodyText  = 4.5 // Text/Label/Positive/Negative/Highlight vs Background (AA)
+	floorLargeText = 3.0 // Dim and Accent vs Background (AA large-text / glyphs)
+	floorSelection = 4.5 // Text drawn on the Selection background
+)
+
+// TestContrast_AllThemes enforces the WCAG AA luminance floors for every shipped
+// theme (§8). Themes are tuned against this test, not by eye — a theme that fails
+// here cannot ship.
+func TestContrast_AllThemes(t *testing.T) {
+	for _, th := range All() {
+		th := th
+		t.Run(th.Key, func(t *testing.T) {
+			bg := th.Color(RoleBackground)
+
+			body := []Role{RoleText, RoleLabel, RolePositive, RoleNegative, RoleHighlight}
+			for _, role := range body {
+				if r := ContrastRatio(th.Color(role), bg); r < floorBodyText {
+					t.Errorf("%s: %s vs Background = %.2f, want >= %.1f (AA body text)",
+						th.Key, role, r, floorBodyText)
+				}
+			}
+
+			large := []Role{RoleDim, RoleAccent}
+			for _, role := range large {
+				if r := ContrastRatio(th.Color(role), bg); r < floorLargeText {
+					t.Errorf("%s: %s vs Background = %.2f, want >= %.1f (AA large)",
+						th.Key, role, r, floorLargeText)
+				}
+			}
+
+			// Text must stay readable when drawn on a selected row.
+			if r := ContrastRatio(th.Color(RoleText), th.Color(RoleSelection)); r < floorSelection {
+				t.Errorf("%s: Text vs Selection = %.2f, want >= %.1f",
+					th.Key, r, floorSelection)
+			}
+		})
+	}
+}
+
+// TestContrast_AccessibleColorblind asserts that for every accessible theme, the
+// ± colors (Positive vs Negative) stay perceptibly distinct under BOTH
+// deuteranopia and protanopia simulation (§8). This is the check luminance contrast
+// is blind to — it catches a blue/orange pair collapsing under CVD (or a stray
+// red/green sneaking into an "accessible" theme).
+func TestContrast_AccessibleColorblind(t *testing.T) {
+	for _, th := range All() {
+		if !th.Accessible {
+			continue
+		}
+		th := th
+		t.Run(th.Key, func(t *testing.T) {
+			pos := th.Color(RolePositive)
+			neg := th.Color(RoleNegative)
+
+			for _, sim := range []string{"deuteranopia", "protanopia"} {
+				if !Distinguishable(pos, neg, sim) {
+					t.Errorf("%s: Positive vs Negative NOT distinguishable under %s "+
+						"(ΔE < %.0f) — ± encoding collapses for colorblind players",
+						th.Key, sim, DistinguishableThreshold)
+				}
+			}
+
+			// Accent must not collide with Positive under CVD either (avoids
+			// "is that a gain or a border?" ambiguity).
+			acc := th.Color(RoleAccent)
+			for _, sim := range []string{"deuteranopia", "protanopia"} {
+				if !Distinguishable(acc, pos, sim) {
+					t.Errorf("%s: Accent vs Positive NOT distinguishable under %s",
+						th.Key, sim)
+				}
+			}
+
+			// Belt-and-suspenders: accessible themes must carry signed glyphs so
+			// the sign is encoded by shape, not just hue (§4).
+			if th.GainGlyph == "" || th.LossGlyph == "" {
+				t.Errorf("%s: accessible theme must set GainGlyph and LossGlyph", th.Key)
+			}
+		})
+	}
+}
+
+// TestContrast_RedGreenCollapses is a guard on the guard: a naive red/green pair
+// must FAIL the colorblind check, proving the threshold actually discriminates and
+// isn't trivially satisfied by any two colors.
+func TestContrast_RedGreenCollapses(t *testing.T) {
+	red := tcell.NewRGBColor(0xf8, 0x51, 0x49)
+	green := tcell.NewRGBColor(0x3f, 0xb9, 0x50)
+	for _, sim := range []string{"deuteranopia", "protanopia"} {
+		if Distinguishable(red, green, sim) {
+			t.Errorf("red/green reported distinguishable under %s — threshold %.0f is too low",
+				sim, DistinguishableThreshold)
+		}
+	}
+	// Sanity: with no simulation, red and green ARE different.
+	if !Distinguishable(red, green, "none") {
+		t.Errorf("red/green should be distinguishable with no CVD simulation")
+	}
+}
+
+// TestRelativeLuminance_Endpoints sanity-checks the WCAG math at the extremes:
+// black -> 0, white -> 1, and white/black contrast == 21.
+func TestRelativeLuminance_Endpoints(t *testing.T) {
+	black := tcell.NewRGBColor(0, 0, 0)
+	white := tcell.NewRGBColor(255, 255, 255)
+	if l := RelativeLuminance(black); l > 1e-9 {
+		t.Errorf("luminance(black) = %v, want ~0", l)
+	}
+	if l := RelativeLuminance(white); l < 1-1e-9 {
+		t.Errorf("luminance(white) = %v, want ~1", l)
+	}
+	if r := ContrastRatio(white, black); r < 20.9 || r > 21.1 {
+		t.Errorf("contrast(white,black) = %.3f, want ~21", r)
+	}
+}

--- a/theme/palette.go
+++ b/theme/palette.go
@@ -1,0 +1,90 @@
+package theme
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// DefaultKey is the theme applied when nothing else is selected. Forge is the
+// shipped default (theming.md §4).
+const DefaultKey = "forge"
+
+// active is the package-global current theme. It is process-wide state by design:
+// the name-remap in remap.go mutates global tcell.ColorNames, so there is exactly
+// one active theme per process. Guarded by mu.
+var (
+	mu     sync.RWMutex
+	active Theme
+)
+
+// init seeds the active theme to Forge and applies its remap so the very first
+// Draw (splash) already wears a coherent palette. The themes_*.go init()s run
+// before this (same package, registration order is forge → accessible), so the
+// registry is populated by now; we fall back to a zero Theme defensively.
+func init() {
+	t, ok := ByKey(DefaultKey)
+	if !ok {
+		// Should never happen — Forge registers in themes_forge.go init(). If a
+		// future refactor breaks that, don't panic the whole program over a theme;
+		// just run with the zero value until SetActive is called.
+		return
+	}
+	active = t
+	applyRemap(t)
+}
+
+// Active returns the currently active theme (a copy).
+func Active() Theme {
+	mu.RLock()
+	defer mu.RUnlock()
+	return active
+}
+
+// SetActive switches the active theme by key: it updates the package-global
+// active theme, rewrites the tcell.ColorNames remap (remap.go), and re-applies the
+// restylable-widget registry (restyle.go) so live chrome re-pulls its colors.
+//
+// It does NOT trigger a redraw — the caller owns app.Draw / QueueUpdateDraw, since
+// only the UI layer holds the tview.Application. Returns an error for unknown keys
+// and leaves the active theme unchanged in that case.
+func SetActive(key string) error {
+	t, ok := ByKey(key)
+	if !ok {
+		return fmt.Errorf("theme: unknown theme %q", key)
+	}
+	mu.Lock()
+	active = t
+	mu.Unlock()
+
+	// Order matters: remap the named tags first (so any restyle closure that pulls
+	// a color sees the new palette), then re-run the widget restyle pass. Both are
+	// idempotent. The caller redraws afterward.
+	applyRemap(t)
+	Restyle()
+	return nil
+}
+
+// Color returns the active theme's color for role. Path B (direct widget chrome)
+// routes through here instead of tcell color literals (theming.md §3.3).
+func Color(role Role) tcell.Color {
+	mu.RLock()
+	defer mu.RUnlock()
+	return active.Color(role)
+}
+
+// Tag returns the active theme's color for role as a tview inline color tag, e.g.
+// "[#ffd700]". This is the §3.2 fallback / future semantic-token form (§9): a
+// helper that emits the active hex at format time, independent of the ColorNames
+// remap. Unused by Phase 1a UI but provided so the fallback path exists.
+func Tag(role Role) string {
+	return tagFor(Color(role))
+}
+
+// tagFor renders a tcell.Color as a tview "[#rrggbb]" tag. Colors carry true RGB
+// (themes are built with NewRGBColor), so RGB() yields the literal components.
+func tagFor(c tcell.Color) string {
+	r, g, b := c.RGB()
+	return fmt.Sprintf("[#%02x%02x%02x]", r, g, b)
+}

--- a/theme/remap.go
+++ b/theme/remap.go
@@ -1,0 +1,56 @@
+package theme
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// remappedNames is the FIXED set of tcell color-name keys the theme system owns,
+// paired with the role each is retinted to. This is the load-bearing table from
+// theming.md §3.2.
+//
+// Discipline (theming.md §3.2): tcell.ColorNames is global, mutable, process-wide
+// state — tcell.GetColor("gold") reads the SAME map as tview's [gold] tag parser.
+// So overwriting these keys retints every named-color resolution in the process,
+// not just inline text tags. We own exactly these keys, and applyRemap rewrites
+// ALL of them on every switch so no name is ever left pointing at a stale value.
+// Do NOT reach for tcell.ColorNames["gold"] expecting tcell's gold once a theme
+// is active — it's the active Accent.
+var remappedNames = []struct {
+	name string
+	role Role
+}{
+	{"gold", RoleAccent},
+	{"gray", RoleDim},
+	{"cyan", RoleLabel},
+	{"green", RolePositive},
+	{"red", RoleNegative},
+	{"yellow", RoleHighlight},
+	{"white", RoleText},
+}
+
+// applyRemap retints the fixed set of named tcell colors to the given theme's role
+// colors and pushes chrome defaults into tview.Styles. After this runs, the next
+// Draw cycle retints every existing named inline tag ([gold], [green], …) for free,
+// because tview re-resolves named tags through tcell.ColorNames on every Draw.
+//
+// applyRemap does NOT call app.Draw — the caller (UI layer) owns the redraw. It is
+// safe to call repeatedly; every call overwrites the full set.
+func applyRemap(t Theme) {
+	for _, m := range remappedNames {
+		tcell.ColorNames[m.name] = t.Color(m.role)
+	}
+
+	// Chrome defaults for *future* widgets (existing ones are handled by Restyle).
+	// tview.Styles is read inside NewBox() at construction time (theming.md §2).
+	tview.Styles.PrimitiveBackgroundColor = t.Color(RoleBackground)
+	tview.Styles.BorderColor = t.Color(RoleAccent)
+	tview.Styles.TitleColor = t.Color(RoleAccent)
+	tview.Styles.PrimaryTextColor = t.Color(RoleText)
+	tview.Styles.SecondaryTextColor = t.Color(RoleDim)
+
+	// ContrastBackgroundColor backs selection/active rows. Use the theme's
+	// Selection role — it's chosen to read against Text and is what list selection
+	// and focused fields lean on.
+	tview.Styles.ContrastBackgroundColor = t.Color(RoleSelection)
+}

--- a/theme/remap_test.go
+++ b/theme/remap_test.go
@@ -1,0 +1,122 @@
+package theme
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// sentinel is an arbitrary RGB that no shipped theme uses, so a match proves the
+// remap drove resolution rather than a coincidence.
+var sentinel = tcell.NewRGBColor(0x12, 0x34, 0x56)
+
+// restoreColorNames snapshots and restores the tcell.ColorNames keys this package
+// owns, so the remap tests don't leave global state poisoned for other tests.
+func restoreColorNames(t *testing.T) {
+	t.Helper()
+	saved := map[string]tcell.Color{}
+	for _, m := range remappedNames {
+		saved[m.name] = tcell.ColorNames[m.name]
+	}
+	t.Cleanup(func() {
+		for name, c := range saved {
+			tcell.ColorNames[name] = c
+		}
+	})
+}
+
+// TestRemap_MapDrivesResolution is the floor assertion (§3.6): after remapping
+// ColorNames["gold"], tcell.GetColor("gold") — the SAME lookup tview's tag parser
+// uses — returns the sentinel. If this fails, the name-remap strategy is dead at
+// the root.
+func TestRemap_MapDrivesResolution(t *testing.T) {
+	restoreColorNames(t)
+
+	tcell.ColorNames["gold"] = sentinel
+	got := tcell.GetColor("gold")
+	if got.Hex() != sentinel.Hex() {
+		t.Fatalf("GetColor(\"gold\") = %06x, want sentinel %06x; ColorNames does not drive resolution",
+			got.Hex(), sentinel.Hex())
+	}
+}
+
+// TestRemap_RenderedCellRetints is the real §3.6 guard: render a "[gold]X" TextView
+// to a SimulationScreen with gold remapped to the sentinel, then read back the
+// rendered cell and assert its foreground IS the sentinel. tview re-resolves named
+// tags through tcell.ColorNames on every Draw, so this passes today. If a future
+// tview caches resolved colors at parse time, this FAILS loudly — signaling the §9
+// semantic-token fallback.
+func TestRemap_RenderedCellRetints(t *testing.T) {
+	restoreColorNames(t)
+	tcell.ColorNames["gold"] = sentinel
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("SimulationScreen.Init: %v", err)
+	}
+	defer screen.Fini()
+	screen.SetSize(10, 1)
+
+	tv := tview.NewTextView().SetDynamicColors(true)
+	tv.SetText("[gold]X")
+	// No border, origin at 0,0 so 'X' lands at cell (0,0).
+	tv.SetRect(0, 0, 10, 1)
+	tv.Draw(screen)
+	screen.Show()
+
+	cells, w, _ := screen.GetContents()
+	if w < 1 || len(cells) == 0 {
+		t.Fatalf("empty simulation screen contents (w=%d, cells=%d)", w, len(cells))
+	}
+
+	// Find the cell carrying 'X'. With no border it's cell 0, but scan to be robust
+	// against tview padding tweaks across versions.
+	var found bool
+	var fg tcell.Color
+	for _, c := range cells {
+		if len(c.Runes) == 1 && c.Runes[0] == 'X' {
+			fg, _, _ = c.Style.Decompose()
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("did not find rendered 'X' cell in simulation output")
+	}
+	if fg.Hex() != sentinel.Hex() {
+		t.Fatalf("rendered [gold]X foreground = %06x, want sentinel %06x; "+
+			"tview no longer re-resolves named tags through tcell.ColorNames — "+
+			"switch to the §9 semantic-token fallback",
+			fg.Hex(), sentinel.Hex())
+	}
+}
+
+// TestApplyRemap_OverwritesFullSet asserts applyRemap rewrites the entire owned set
+// (no name left stale) and pushes chrome defaults into tview.Styles.
+func TestApplyRemap_OverwritesFullSet(t *testing.T) {
+	restoreColorNames(t)
+
+	// Poison every owned key first; applyRemap must overwrite all of them.
+	for _, m := range remappedNames {
+		tcell.ColorNames[m.name] = sentinel
+	}
+
+	applyRemap(Forge)
+
+	for _, m := range remappedNames {
+		want := Forge.Color(m.role)
+		got := tcell.ColorNames[m.name]
+		if got.Hex() != want.Hex() {
+			t.Errorf("ColorNames[%q] = %06x, want Forge %s %06x",
+				m.name, got.Hex(), m.role, want.Hex())
+		}
+	}
+
+	if tview.Styles.BorderColor.Hex() != Forge.Color(RoleAccent).Hex() {
+		t.Errorf("tview.Styles.BorderColor not set to Accent")
+	}
+	if tview.Styles.PrimitiveBackgroundColor.Hex() != Forge.Color(RoleBackground).Hex() {
+		t.Errorf("tview.Styles.PrimitiveBackgroundColor not set to Background")
+	}
+}

--- a/theme/restyle.go
+++ b/theme/restyle.go
@@ -1,0 +1,68 @@
+package theme
+
+import "sync"
+
+// The restylable-widget registry routes Path B (direct widget chrome calls —
+// SetBorderColor, SetBackgroundColor, list selection, …) through a live theme
+// switch. Those setters apply once at construction, so a live switch needs each
+// long-lived chrome widget to re-pull its colors. See theming.md §3.3.
+//
+// Registration discipline (§3.3): a registry someone must *remember* to populate
+// will rot — some future widget ships unthemed because nobody touched the slice.
+// Track makes registration the default path: it applies the closure *now* AND
+// enrolls it, in one call, so a chrome widget cannot be created without being
+// tracked. The UI registers widgets here in Phase 1b; this package only provides
+// the mechanism.
+
+var (
+	restyleMu sync.Mutex
+	restylers []func()
+)
+
+// Track runs apply() immediately (so the widget is styled at construction) and
+// stores it for re-application on every later theme switch. This is the single
+// combined "apply-now-and-enroll" operation that prevents untracked chrome.
+//
+// The apply closure should pull from theme.Color(role) each time it runs — never
+// capture a tcell.Color once — so it reflects whatever theme is active when
+// Restyle() re-invokes it. Typical shape:
+//
+//	theme.Track(func() {
+//	    box.SetBorderColor(theme.Color(theme.RoleAccent)).
+//	        SetTitleColor(theme.Color(theme.RoleAccent))
+//	})
+//
+// Track is safe for concurrent use. A nil apply is ignored.
+func Track(apply func()) {
+	if apply == nil {
+		return
+	}
+	apply()
+
+	restyleMu.Lock()
+	restylers = append(restylers, apply)
+	restyleMu.Unlock()
+}
+
+// Restyle re-runs every tracked apply closure. SetActive calls it after applyRemap
+// and before the caller's redraw, so existing chrome re-pulls the new palette.
+// The closures run outside the lock so a closure may itself call Track without
+// deadlocking (it just enrolls into the next pass).
+func Restyle() {
+	restyleMu.Lock()
+	snapshot := make([]func(), len(restylers))
+	copy(snapshot, restylers)
+	restyleMu.Unlock()
+
+	for _, apply := range snapshot {
+		apply()
+	}
+}
+
+// resetRestylersForTest clears the registry. Test-only: lets a test assert Track
+// enrolls without leaking closures across tests in this package.
+func resetRestylersForTest() {
+	restyleMu.Lock()
+	restylers = nil
+	restyleMu.Unlock()
+}

--- a/theme/restyle_test.go
+++ b/theme/restyle_test.go
@@ -1,0 +1,86 @@
+package theme
+
+import "testing"
+
+// TestTrack_AppliesNowAndEnrolls verifies the §3.3 registration discipline: Track
+// runs the closure immediately AND re-runs it on Restyle, in one registration.
+func TestTrack_AppliesNowAndEnrolls(t *testing.T) {
+	resetRestylersForTest()
+	t.Cleanup(resetRestylersForTest)
+
+	calls := 0
+	Track(func() { calls++ })
+	if calls != 1 {
+		t.Fatalf("Track did not apply immediately: calls = %d, want 1", calls)
+	}
+
+	Restyle()
+	if calls != 2 {
+		t.Fatalf("Restyle did not re-run tracked closure: calls = %d, want 2", calls)
+	}
+
+	Restyle()
+	if calls != 3 {
+		t.Fatalf("second Restyle: calls = %d, want 3", calls)
+	}
+}
+
+func TestTrack_NilIsIgnored(t *testing.T) {
+	resetRestylersForTest()
+	t.Cleanup(resetRestylersForTest)
+	Track(nil) // must not panic
+	Restyle()  // must not panic on the nil
+}
+
+// TestRegistry_FourBuiltinThemes asserts the four Phase-1a themes registered and
+// that Forge is the default/first.
+func TestRegistry_FourBuiltinThemes(t *testing.T) {
+	all := All()
+	if len(all) < 4 {
+		t.Fatalf("expected >= 4 registered themes, got %d", len(all))
+	}
+	if all[0].Key != DefaultKey {
+		t.Errorf("first registered theme = %q, want default %q", all[0].Key, DefaultKey)
+	}
+	for _, key := range []string{"forge", "deuteranopia", "protanopia", "high_contrast"} {
+		if _, ok := ByKey(key); !ok {
+			t.Errorf("theme %q not registered", key)
+		}
+	}
+	if _, ok := ByKey("does_not_exist"); ok {
+		t.Errorf("ByKey returned ok for an unknown key")
+	}
+}
+
+// TestSetActive verifies switching, the unknown-key error, and that Active reflects
+// the switch.
+func TestSetActive(t *testing.T) {
+	t.Cleanup(func() { _ = SetActive(DefaultKey) })
+
+	if err := SetActive("high_contrast"); err != nil {
+		t.Fatalf("SetActive(high_contrast): %v", err)
+	}
+	if Active().Key != "high_contrast" {
+		t.Errorf("Active().Key = %q, want high_contrast", Active().Key)
+	}
+	if Color(RoleBackground).Hex() != HighContrast.Color(RoleBackground).Hex() {
+		t.Errorf("Color(RoleBackground) did not follow the active theme")
+	}
+
+	if err := SetActive("nope"); err == nil {
+		t.Errorf("SetActive(unknown) returned nil error")
+	}
+	if Active().Key != "high_contrast" {
+		t.Errorf("failed SetActive mutated the active theme to %q", Active().Key)
+	}
+}
+
+// TestTag emits a hex tag for the active theme's role color.
+func TestTag(t *testing.T) {
+	t.Cleanup(func() { _ = SetActive(DefaultKey) })
+	_ = SetActive(DefaultKey)
+	// Forge accent is gold #ffd700.
+	if got, want := Tag(RoleAccent), "[#ffd700]"; got != want {
+		t.Errorf("Tag(RoleAccent) = %q, want %q", got, want)
+	}
+}

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -72,6 +72,40 @@ type Theme struct {
 	// on color alone. Non-accessible themes may leave these empty.
 	GainGlyph string // e.g. "▲" / "+"
 	LossGlyph string // e.g. "▼" / "-"
+
+	// Milestone-gated unlock condition (theming.md §5). A gated (flavor) theme
+	// declares EXACTLY ONE of these — the milestone key or chain key whose
+	// completion unlocks it account-wide. The mapping lives here, in the registry,
+	// not scattered through engine/milestone code: theme stays a leaf package, so
+	// these are plain strings (no game import), and the UI reverse-maps a completed
+	// key back to a theme via UnlockedBy.
+	//
+	// Always-available themes (Accessible, or the default Forge) leave BOTH empty —
+	// they're never gated, so there is nothing to unlock. The registry-consistency
+	// test (unlock_test.go) enforces the XOR for gated themes and the empty-pair for
+	// the always-available set.
+	UnlockMilestone string // milestone key (config/milestones.go) — XOR with UnlockChain
+	UnlockChain     string // milestone-chain key — XOR with UnlockMilestone
+
+	// UnlockHint is the human-readable unlock condition shown for a LOCKED theme in
+	// the picker detail pane and `theme list` (e.g. "Reach the Cyberpunk Age").
+	// Required for gated themes; empty for always-available ones.
+	UnlockHint string
+}
+
+// Gated reports whether the theme is milestone-gated (declares an unlock
+// condition). Always-available themes (Accessible / Forge) are not gated.
+func (t Theme) Gated() bool {
+	return t.UnlockMilestone != "" || t.UnlockChain != ""
+}
+
+// UnlockKey returns the single milestone-or-chain key that unlocks a gated theme
+// (whichever of UnlockMilestone/UnlockChain is set), and "" for an un-gated theme.
+func (t Theme) UnlockKey() string {
+	if t.UnlockMilestone != "" {
+		return t.UnlockMilestone
+	}
+	return t.UnlockChain
 }
 
 // Color returns the theme's color for a role. Out-of-range roles return

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -1,0 +1,126 @@
+// Package theme is AgeForge's single source of truth for UI color.
+//
+// It is a leaf package: it depends only on gdamore/tcell/v2 (plus rivo/tview in
+// remap.go, solely to push chrome defaults into tview.Styles). It must NOT import
+// game/ or ui/ — themes are pure presentation and an import cycle here would be a
+// design smell. See design-and-architecture/theming.md §3.
+//
+// The model is ~9 semantic *roles* (not literal color names): Positive is "the
+// gains color," whatever hue the active theme picks. Inline tview tags like
+// [green] are retinted onto these roles via the name-remap in remap.go.
+package theme
+
+import "github.com/gdamore/tcell/v2"
+
+// Role enumerates the semantic color slots a theme must fill. Order is fixed and
+// load-bearing: themes declare their palette as a [numRoles]tcell.Color indexed by
+// these constants (see theming.md §3.1).
+type Role int
+
+const (
+	RoleBackground Role = iota // canvas / primitive background
+	RoleText                   // primary readable text
+	RoleDim                    // secondary / hints / disabled
+	RoleLabel                  // field labels, values
+	RoleAccent                 // titles, borders, brand highlights
+	RoleHighlight              // numbers, attention, "look here"
+	RolePositive               // gains, success, +deltas
+	RoleNegative               // losses, errors, -deltas
+	RoleSelection              // selected list-row background
+	numRoles
+)
+
+// String renders a Role for diagnostics and test failure messages.
+func (r Role) String() string {
+	switch r {
+	case RoleBackground:
+		return "Background"
+	case RoleText:
+		return "Text"
+	case RoleDim:
+		return "Dim"
+	case RoleLabel:
+		return "Label"
+	case RoleAccent:
+		return "Accent"
+	case RoleHighlight:
+		return "Highlight"
+	case RolePositive:
+		return "Positive"
+	case RoleNegative:
+		return "Negative"
+	case RoleSelection:
+		return "Selection"
+	default:
+		return "Role(?)"
+	}
+}
+
+// Theme is a complete, code-defined palette plus picker metadata. Colors carry
+// true RGB via tcell.NewRGBColor so themes are not at the mercy of a terminal's
+// 16-color palette on truecolor terminals (theming.md §3.1).
+type Theme struct {
+	Key        string // "forge", "deuteranopia", ... — stable identifier
+	Name       string // "Forge" — shown in the picker
+	Blurb      string // one-line flavor for the picker detail pane
+	Accessible bool   // true => never milestone-gated, always unlocked
+
+	Colors [numRoles]tcell.Color
+
+	// Signed sentinels for the ± distinction in accessible themes (theming.md §4):
+	// the sign is encoded by shape as well as hue so colorblind players never rely
+	// on color alone. Non-accessible themes may leave these empty.
+	GainGlyph string // e.g. "▲" / "+"
+	LossGlyph string // e.g. "▼" / "-"
+}
+
+// Color returns the theme's color for a role. Out-of-range roles return
+// tcell.ColorDefault rather than panicking.
+func (t Theme) Color(role Role) tcell.Color {
+	if role < 0 || role >= numRoles {
+		return tcell.ColorDefault
+	}
+	return t.Colors[role]
+}
+
+// registry holds every built-in theme, keyed by Key. Populated by the
+// themes_*.go init() functions via register().
+var registry = map[string]Theme{}
+
+// registryOrder preserves insertion order so All() is deterministic (Forge first).
+var registryOrder []string
+
+// register adds a built-in theme. Called from themes_*.go init(). Duplicate keys
+// panic at init — a programming error, caught before main() runs.
+func register(t Theme) {
+	if _, dup := registry[t.Key]; dup {
+		panic("theme: duplicate theme key " + t.Key)
+	}
+	registry[t.Key] = t
+	registryOrder = append(registryOrder, t.Key)
+}
+
+// ByKey looks up a registered theme. ok is false for unknown keys.
+func ByKey(key string) (Theme, bool) {
+	t, ok := registry[key]
+	return t, ok
+}
+
+// All returns every registered theme with the default (Forge) first, then the rest
+// in registration order. We force the default to the front explicitly rather than
+// lean on init() filename ordering — that ordering is real but fragile, and the
+// picker wants the default at the top deterministically. The returned slice is a
+// fresh copy; callers may sort/filter it freely.
+func All() []Theme {
+	out := make([]Theme, 0, len(registryOrder))
+	if t, ok := registry[DefaultKey]; ok {
+		out = append(out, t)
+	}
+	for _, k := range registryOrder {
+		if k == DefaultKey {
+			continue
+		}
+		out = append(out, registry[k])
+	}
+	return out
+}

--- a/theme/themes_accessible.go
+++ b/theme/themes_accessible.go
@@ -1,0 +1,98 @@
+package theme
+
+import "github.com/gdamore/tcell/v2"
+
+// The accessible themes (theming.md §4) are Accessible: true — never milestone-
+// gated, always unlocked. Their defining constraint: AgeForge uses green=gain /
+// red=loss everywhere, which collapses under red-green deficiency. So these themes
+// encode ± with BLUE (positive) vs ORANGE (negative) — the canonical deutan/protan-
+// safe opposition — AND set GainGlyph/LossGlyph so the sign is carried by shape as
+// well as hue (redundant encoding; never rely on color alone).
+//
+// All three clear the WCAG AA luminance floors AND the colorblind-distinguishability
+// guard (Positive vs Negative stay separated under both deuteranopia and protanopia
+// simulation), enforced by contrast_test.go.
+
+// signedGlyphs are shared by the colorblind-safe themes: ▲ for gains, ▼ for losses.
+const (
+	gainGlyph = "▲"
+	lossGlyph = "▼"
+)
+
+// Deuteranopia is tuned for red-green deficiency of the M-cone type. Positive is a
+// bright blue, Negative a warm orange; Accent/Highlight/Label favor the blue/
+// yellow/white spread that stays mutually distinct under deuteranopia simulation
+// (avoiding an accent≈positive collision).
+var Deuteranopia = Theme{
+	Key:        "deuteranopia",
+	Name:       "Deuteranopia-safe",
+	Blurb:      "Red-green safe: blue gains, orange losses, ▲/▼ signs.",
+	Accessible: true,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x10, 0x14, 0x1a),
+		RoleText:       tcell.NewRGBColor(0xf5, 0xf7, 0xfa),
+		RoleDim:        tcell.NewRGBColor(0x9a, 0xa4, 0xb2),
+		RoleLabel:      tcell.NewRGBColor(0xe9, 0xd8, 0x5a), // warm yellow label, far from the blues
+		RoleAccent:     tcell.NewRGBColor(0xc9, 0xa2, 0x27), // muted gold accent
+		RoleHighlight:  tcell.NewRGBColor(0xf0, 0xc8, 0x4b),
+		RolePositive:   tcell.NewRGBColor(0x3b, 0x9e, 0xff), // blue = gain
+		RoleNegative:   tcell.NewRGBColor(0xff, 0x8c, 0x42), // orange = loss
+		RoleSelection:  tcell.NewRGBColor(0x24, 0x3b, 0x55),
+	},
+	GainGlyph: gainGlyph,
+	LossGlyph: lossGlyph,
+}
+
+// Protanopia is tuned for red-green deficiency of the L-cone type. The safe hues
+// differ slightly from deuteranopia (the orange is pushed a touch warmer/lighter
+// and positive a touch deeper) since L-cone loss darkens reds differently; shipping
+// it separately serves protanopes better than a single "colorblind" catch-all.
+var Protanopia = Theme{
+	Key:        "protanopia",
+	Name:       "Protanopia-safe",
+	Blurb:      "Red-green safe (L-cone): blue gains, amber losses, ▲/▼ signs.",
+	Accessible: true,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x10, 0x14, 0x1a),
+		RoleText:       tcell.NewRGBColor(0xf5, 0xf7, 0xfa),
+		RoleDim:        tcell.NewRGBColor(0x9a, 0xa4, 0xb2),
+		RoleLabel:      tcell.NewRGBColor(0xe9, 0xd8, 0x5a),
+		RoleAccent:     tcell.NewRGBColor(0xcf, 0xb0, 0x3a),
+		RoleHighlight:  tcell.NewRGBColor(0xf2, 0xd0, 0x55),
+		RolePositive:   tcell.NewRGBColor(0x4f, 0xa8, 0xff), // blue = gain
+		RoleNegative:   tcell.NewRGBColor(0xff, 0xa6, 0x3d), // amber = loss (lighter than deutan's)
+		RoleSelection:  tcell.NewRGBColor(0x24, 0x3b, 0x55),
+	},
+	GainGlyph: gainGlyph,
+	LossGlyph: lossGlyph,
+}
+
+// HighContrast is maximum legibility: near-black background, near-white text, and
+// saturated, unambiguous role colors comfortably above the AA floor. For low-vision
+// players and high-glare terminals. It also keeps ± blue/orange + glyphs so it is
+// colorblind-safe as well as high-contrast.
+var HighContrast = Theme{
+	Key:        "high_contrast",
+	Name:       "High Contrast",
+	Blurb:      "Maximum legibility: near-black on near-white, bold roles.",
+	Accessible: true,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x00, 0x00, 0x00),
+		RoleText:       tcell.NewRGBColor(0xff, 0xff, 0xff),
+		RoleDim:        tcell.NewRGBColor(0xc8, 0xc8, 0xc8),
+		RoleLabel:      tcell.NewRGBColor(0x6e, 0xd6, 0xff), // bright sky-blue label
+		RoleAccent:     tcell.NewRGBColor(0xff, 0xe0, 0x33), // vivid yellow accent
+		RoleHighlight:  tcell.NewRGBColor(0xff, 0xff, 0x66),
+		RolePositive:   tcell.NewRGBColor(0x5a, 0xb6, 0xff), // blue = gain
+		RoleNegative:   tcell.NewRGBColor(0xff, 0x9d, 0x3d), // orange = loss
+		RoleSelection:  tcell.NewRGBColor(0x33, 0x33, 0x33),
+	},
+	GainGlyph: gainGlyph,
+	LossGlyph: lossGlyph,
+}
+
+func init() {
+	register(Deuteranopia)
+	register(Protanopia)
+	register(HighContrast)
+}

--- a/theme/themes_flavor.go
+++ b/theme/themes_flavor.go
@@ -40,6 +40,11 @@ var Parchment = Theme{
 	},
 	GainGlyph: flavorGainGlyph,
 	LossGlyph: flavorLossGlyph,
+	// Unlock: the Renaissance-age milestone ("Enlightened" — advance to the
+	// Renaissance Age). Parchment is the manuscript/illuminated-page look, so the
+	// age of letters and printing is its thematic home (config/milestones.go).
+	UnlockMilestone: "enlightened",
+	UnlockHint:      "Reach the Renaissance Age",
 }
 
 // Bronze is a warm metallic look: copper/bronze accent, amber highlight, olive
@@ -62,6 +67,10 @@ var Bronze = Theme{
 	},
 	GainGlyph: flavorGainGlyph,
 	LossGlyph: flavorLossGlyph,
+	// Unlock: the Bronze-age milestone ("Bronze Age Pioneer"). The earliest gated
+	// theme — burnished metal for the age that first worked it (config/milestones.go).
+	UnlockMilestone: "bronze_pioneer",
+	UnlockHint:      "Reach the Bronze Age",
 }
 
 // Cyberpunk is neon on near-black: hot magenta accent, neon-cyan highlight, neon
@@ -85,6 +94,11 @@ var Cyberpunk = Theme{
 	},
 	GainGlyph: flavorGainGlyph,
 	LossGlyph: flavorLossGlyph,
+	// Unlock: the Cyberpunk-age milestone ("cyberpunk_milestone" — advance to the
+	// Cyberpunk Age). The on-the-nose mapping the spec calls out; the theme riffs on
+	// the cyberpunk_age palette (config/milestones.go).
+	UnlockMilestone: "cyberpunk_milestone",
+	UnlockHint:      "Reach the Cyberpunk Age",
 }
 
 // Monochrome is a stylistic greyscale terminal: a single hue's shades. Accent and
@@ -110,6 +124,11 @@ var Monochrome = Theme{
 	},
 	GainGlyph: flavorGainGlyph,
 	LossGlyph: flavorLossGlyph,
+	// Unlock: the Information-age milestone ("Information Pioneer"). The spec's worked
+	// example ("monochrome 🔒 Reach the Information Age") — the retro terminal look
+	// for the age that made the terminal ubiquitous (config/milestones.go).
+	UnlockMilestone: "information_pioneer",
+	UnlockHint:      "Reach the Information Age",
 }
 
 // Cosmic is deep-space: a dark indigo/violet background, starlight text, and
@@ -133,6 +152,11 @@ var Cosmic = Theme{
 	},
 	GainGlyph: flavorGainGlyph,
 	LossGlyph: flavorLossGlyph,
+	// Unlock: the Galactic-age milestone ("Galactic Emperor"). Deep-space indigo for
+	// the age of galactic empire; riffs on the galactic_age palette
+	// (config/milestones.go).
+	UnlockMilestone: "galactic_emperor",
+	UnlockHint:      "Reach the Galactic Age",
 }
 
 func init() {

--- a/theme/themes_flavor.go
+++ b/theme/themes_flavor.go
@@ -1,0 +1,144 @@
+package theme
+
+import "github.com/gdamore/tcell/v2"
+
+// Flavor themes (theming.md §4) are cosmetic, curated palettes that unlock via
+// milestones. They are all Accessible: false — the gating itself lands in Phase 3b;
+// this file only DEFINES and REGISTERS them. Because they're not accessible, the
+// colorblind-distinguishability guard does not apply to them, but every WCAG AA
+// luminance floor in contrast_test.go DOES, and each theme below is tuned to clear
+// those with margin (Text/Label/Positive/Negative/Highlight vs Background >= 4.5,
+// Dim/Accent vs Background >= 3.0, Text-on-Selection >= 4.5).
+//
+// Flavor themes don't need colorblind separation, but the ▲/▼ glyphs are harmless
+// and keep delta formatting consistent across every theme, so they're set anyway.
+const (
+	flavorGainGlyph = "▲"
+	flavorLossGlyph = "▼"
+)
+
+// Parchment is the one LIGHT-background theme: dark ink-brown text on warm cream,
+// with sepia/leather accents. It's the real contrast-guard exercise (theming.md §4,
+// §8) — on a light bg the role colors must be DARK enough to stay legible, so the
+// usual bright accent/positive/negative become deep, saturated versions: forest
+// green gains, wax-red losses, umber labels, sepia accent/highlight.
+var Parchment = Theme{
+	Key:        "parchment",
+	Name:       "Parchment",
+	Blurb:      "Ink on warm parchment — the one light-background look.",
+	Accessible: false,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0xf2, 0xe8, 0xd0), // warm cream
+		RoleText:       tcell.NewRGBColor(0x3a, 0x2c, 0x1a), // dark ink brown
+		RoleDim:        tcell.NewRGBColor(0x6e, 0x5c, 0x40), // faded sepia
+		RoleLabel:      tcell.NewRGBColor(0x6b, 0x4a, 0x12), // deep umber
+		RoleAccent:     tcell.NewRGBColor(0x7e, 0x50, 0x10), // sepia / leather
+		RoleHighlight:  tcell.NewRGBColor(0x7e, 0x50, 0x10), // wax-amber (dark on light)
+		RolePositive:   tcell.NewRGBColor(0x2c, 0x6e, 0x2c), // forest green
+		RoleNegative:   tcell.NewRGBColor(0xa3, 0x2a, 0x1f), // wax red
+		RoleSelection:  tcell.NewRGBColor(0xd8, 0xc4, 0x9a), // darker cream backing
+	},
+	GainGlyph: flavorGainGlyph,
+	LossGlyph: flavorLossGlyph,
+}
+
+// Bronze is a warm metallic look: copper/bronze accent, amber highlight, olive
+// gains and burnt-orange losses on a dark warm brown-black background.
+var Bronze = Theme{
+	Key:        "bronze",
+	Name:       "Bronze",
+	Blurb:      "Burnished copper and amber over dark, warm metal.",
+	Accessible: false,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x1c, 0x14, 0x0c), // dark warm brown-black
+		RoleText:       tcell.NewRGBColor(0xf0, 0xe2, 0xc8), // warm parchment text
+		RoleDim:        tcell.NewRGBColor(0x9a, 0x82, 0x60), // patina'd bronze
+		RoleLabel:      tcell.NewRGBColor(0xd9, 0xa8, 0x6a), // copper
+		RoleAccent:     tcell.NewRGBColor(0xcd, 0x7f, 0x32), // bronze
+		RoleHighlight:  tcell.NewRGBColor(0xf2, 0xc1, 0x60), // amber
+		RolePositive:   tcell.NewRGBColor(0x8f, 0xb5, 0x4a), // olive gain
+		RoleNegative:   tcell.NewRGBColor(0xe0, 0x6a, 0x3c), // burnt-orange loss
+		RoleSelection:  tcell.NewRGBColor(0x3a, 0x2a, 0x18),
+	},
+	GainGlyph: flavorGainGlyph,
+	LossGlyph: flavorLossGlyph,
+}
+
+// Cyberpunk is neon on near-black: hot magenta accent, neon-cyan highlight, neon
+// green/pink for ±, over a near-black violet background (riffs on the cyberpunk_age
+// palette, theming.md §4).
+var Cyberpunk = Theme{
+	Key:        "cyberpunk",
+	Name:       "Cyberpunk",
+	Blurb:      "Hot magenta and neon cyan over near-black violet.",
+	Accessible: false,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x0a, 0x06, 0x12), // near-black violet
+		RoleText:       tcell.NewRGBColor(0xe6, 0xe6, 0xf5), // cool white
+		RoleDim:        tcell.NewRGBColor(0x7a, 0x6e, 0x9e), // muted violet-grey
+		RoleLabel:      tcell.NewRGBColor(0x3d, 0xe1, 0xe8), // cyan
+		RoleAccent:     tcell.NewRGBColor(0xff, 0x2e, 0xc0), // hot magenta
+		RoleHighlight:  tcell.NewRGBColor(0x4d, 0xf0, 0xff), // neon cyan
+		RolePositive:   tcell.NewRGBColor(0x39, 0xff, 0x9e), // neon green gain
+		RoleNegative:   tcell.NewRGBColor(0xff, 0x49, 0x6b), // neon pink-red loss
+		RoleSelection:  tcell.NewRGBColor(0x2a, 0x12, 0x3a),
+	},
+	GainGlyph: flavorGainGlyph,
+	LossGlyph: flavorLossGlyph,
+}
+
+// Monochrome is a stylistic greyscale terminal: a single hue's shades. Accent and
+// Highlight are bright greys/white; the ± distinction rides on LIGHTNESS (a lighter
+// grey gains, a mid grey loses) rather than hue. It is NOT an accessibility theme —
+// just a clean mono look — so it carries Accessible: false and skips the colorblind
+// guard, but still clears every luminance floor.
+var Monochrome = Theme{
+	Key:        "monochrome",
+	Name:       "Monochrome",
+	Blurb:      "Greyscale terminal — meaning carried by lightness, not hue.",
+	Accessible: false,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x12, 0x12, 0x12), // near-black grey
+		RoleText:       tcell.NewRGBColor(0xf5, 0xf5, 0xf5), // near-white
+		RoleDim:        tcell.NewRGBColor(0x8a, 0x8a, 0x8a), // mid grey
+		RoleLabel:      tcell.NewRGBColor(0xc8, 0xc8, 0xc8), // light grey
+		RoleAccent:     tcell.NewRGBColor(0xe8, 0xe8, 0xe8), // bright grey
+		RoleHighlight:  tcell.NewRGBColor(0xff, 0xff, 0xff), // white
+		RolePositive:   tcell.NewRGBColor(0xd8, 0xd8, 0xd8), // lighter grey = gain
+		RoleNegative:   tcell.NewRGBColor(0x9a, 0x9a, 0x9a), // mid grey = loss
+		RoleSelection:  tcell.NewRGBColor(0x33, 0x33, 0x33),
+	},
+	GainGlyph: flavorGainGlyph,
+	LossGlyph: flavorLossGlyph,
+}
+
+// Cosmic is deep-space: a dark indigo/violet background, starlight text, and
+// nebula-pink / cyan accents with aurora-green gains (riffs on galactic_age,
+// theming.md §4).
+var Cosmic = Theme{
+	Key:        "cosmic",
+	Name:       "Cosmic",
+	Blurb:      "Deep indigo with starlight and nebula accents.",
+	Accessible: false,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x0c, 0x0a, 0x1f), // deep indigo
+		RoleText:       tcell.NewRGBColor(0xe8, 0xe6, 0xf8), // starlight
+		RoleDim:        tcell.NewRGBColor(0x7e, 0x78, 0xa6), // dust violet
+		RoleLabel:      tcell.NewRGBColor(0x6e, 0xd6, 0xe8), // cyan
+		RoleAccent:     tcell.NewRGBColor(0xc8, 0x6e, 0xff), // nebula violet
+		RoleHighlight:  tcell.NewRGBColor(0xff, 0x8a, 0xd8), // nebula pink
+		RolePositive:   tcell.NewRGBColor(0x5a, 0xe0, 0xa8), // aurora green
+		RoleNegative:   tcell.NewRGBColor(0xff, 0x6e, 0x8a), // nebula red
+		RoleSelection:  tcell.NewRGBColor(0x24, 0x20, 0x4a),
+	},
+	GainGlyph: flavorGainGlyph,
+	LossGlyph: flavorLossGlyph,
+}
+
+func init() {
+	register(Parchment)
+	register(Bronze)
+	register(Cyberpunk)
+	register(Monochrome)
+	register(Cosmic)
+}

--- a/theme/themes_forge.go
+++ b/theme/themes_forge.go
@@ -1,0 +1,45 @@
+package theme
+
+import "github.com/gdamore/tcell/v2"
+
+// Forge is the default theme: AgeForge's current dark + gold look, formalized as
+// roles (theming.md §4). Accessible is false — it relies on green/red for ± — but
+// it is the shipped default and still clears the WCAG AA luminance floors against
+// its dark background (enforced by contrast_test.go).
+//
+// Role → color rationale:
+//   - Accent  gold (#FFD700)  — titles, borders, brand
+//   - Dim     #8b949e         — the existing dim-hint gray
+//   - Label   cyan (#39C5CF)  — field labels/values (slightly deepened from pure
+//                               cyan so it clears AA on the dark bg with margin)
+//   - Positive green (#3FB950) — gains
+//   - Negative red   (#F85149) — losses
+//   - Highlight yellow (#F2CC60)— numbers / attention
+//   - Text    #ffffff         — primary text
+//   - Background #0d1117       — near-black canvas (GitHub-dark-ish)
+//   - Selection #21304a        — dark slate selected-row backing. (Gold backing
+//     was the obvious "brand" pick, but white-on-gold is ~1.4:1 — unreadable; the
+//     selection backs light text, so it must stay dark. The gold brand lives in
+//     borders/titles via Accent.)
+var Forge = Theme{
+	Key:        "forge",
+	Name:       "Forge",
+	Blurb:      "The classic dark-and-gold AgeForge look.",
+	Accessible: false,
+	Colors: [numRoles]tcell.Color{
+		RoleBackground: tcell.NewRGBColor(0x0d, 0x11, 0x17),
+		RoleText:       tcell.NewRGBColor(0xff, 0xff, 0xff),
+		RoleDim:        tcell.NewRGBColor(0x8b, 0x94, 0x9e),
+		RoleLabel:      tcell.NewRGBColor(0x39, 0xc5, 0xcf),
+		RoleAccent:     tcell.NewRGBColor(0xff, 0xd7, 0x00),
+		RoleHighlight:  tcell.NewRGBColor(0xf2, 0xcc, 0x60),
+		RolePositive:   tcell.NewRGBColor(0x3f, 0xb9, 0x50),
+		RoleNegative:   tcell.NewRGBColor(0xf8, 0x51, 0x49),
+		RoleSelection:  tcell.NewRGBColor(0x21, 0x30, 0x4a),
+	},
+	// Non-accessible: sign carried by color alone, glyphs left empty.
+	GainGlyph: "",
+	LossGlyph: "",
+}
+
+func init() { register(Forge) }

--- a/theme/unlock.go
+++ b/theme/unlock.go
@@ -1,0 +1,66 @@
+package theme
+
+// Milestone-gated unlock resolution (theming.md §5).
+//
+// Gated flavor themes declare their unlock condition as a milestone-or-chain key in
+// the registry (Theme.UnlockMilestone / Theme.UnlockChain). The UI's only job is the
+// reverse direction: "a milestone/chain just completed — does it grant a theme?"
+// UnlockedBy answers that without the UI knowing any theme→key mapping itself, so the
+// mapping stays owned here and theme keys never leak into engine/milestone code.
+//
+// theme remains a leaf package: this is pure string indexing over the registry, no
+// game import.
+
+// unlockIndex maps a completed milestone/chain key → the theme key it unlocks. Built
+// once at init() from the registry's gated themes. A theme contributes its single
+// UnlockKey() (milestone XOR chain); always-available themes contribute nothing.
+//
+// If two themes ever claimed the same unlock key it would be a registry bug (one key
+// can't deterministically grant two themes); init() panics on that collision, the
+// same fail-fast posture register() takes for duplicate theme keys.
+var unlockIndex = map[string]string{}
+
+// buildUnlockIndex (re)builds unlockIndex from the current registry. Called from a
+// dedicated init() AFTER the themes_*.go init()s have registered every theme
+// (Go runs init() in file-name order within a package; this file sorts after the
+// themes_*.go files, and the index is also rebuilt lazily-safe below). It is
+// idempotent: it clears and refills, so a test that registers a stub theme can call
+// it again.
+func buildUnlockIndex() {
+	idx := make(map[string]string, len(registryOrder))
+	for _, key := range registryOrder {
+		t := registry[key]
+		uk := t.UnlockKey()
+		if uk == "" {
+			continue // always-available (Accessible / Forge) — nothing to unlock
+		}
+		if existing, dup := idx[uk]; dup {
+			panic("theme: unlock key " + uk + " maps to both " + existing + " and " + t.Key)
+		}
+		idx[uk] = t.Key
+	}
+	unlockIndex = idx
+}
+
+func init() { buildUnlockIndex() }
+
+// UnlockedBy reverse-maps a completed milestone OR chain key to the theme key it
+// unlocks. ok is false when the key unlocks no theme (the common case — most
+// milestones grant no theme). This is the UI's unlock hook: on a newly-completed
+// milestone/chain it asks UnlockedBy, and on ok it unlocks the mapped theme via the
+// account layer (theming.md §5).
+func UnlockedBy(completedKey string) (themeKey string, ok bool) {
+	themeKey, ok = unlockIndex[completedKey]
+	return
+}
+
+// UnlockHintFor returns the human-readable unlock condition for a theme key (e.g.
+// "Reach the Cyberpunk Age"), or "" for an unknown key or an un-gated theme. Used by
+// the picker detail pane and `theme list` to show LOCKED themes' conditions.
+func UnlockHintFor(themeKey string) string {
+	t, ok := ByKey(themeKey)
+	if !ok {
+		return ""
+	}
+	return t.UnlockHint
+}

--- a/theme/unlock_test.go
+++ b/theme/unlock_test.go
@@ -1,0 +1,101 @@
+package theme
+
+import "testing"
+
+// TestUnlockedByRoundTrip checks the reverse lookup: every gated theme's declared
+// unlock key maps back to that exact theme, and an unmapped key returns ok=false.
+func TestUnlockedByRoundTrip(t *testing.T) {
+	gatedSeen := 0
+	for _, th := range All() {
+		if !th.Gated() {
+			continue
+		}
+		gatedSeen++
+		key := th.UnlockKey()
+		gotTheme, ok := UnlockedBy(key)
+		if !ok {
+			t.Errorf("UnlockedBy(%q): ok=false, want the theme %q", key, th.Key)
+			continue
+		}
+		if gotTheme != th.Key {
+			t.Errorf("UnlockedBy(%q) = %q, want %q", key, gotTheme, th.Key)
+		}
+	}
+	if gatedSeen == 0 {
+		t.Fatal("no gated themes found — expected the 5 flavor themes to be gated")
+	}
+
+	// An unmapped key (a real milestone that grants no theme) returns ok=false.
+	if got, ok := UnlockedBy("first_shelter"); ok {
+		t.Errorf("UnlockedBy(\"first_shelter\") = (%q, true), want ok=false", got)
+	}
+	// A completely bogus key likewise.
+	if got, ok := UnlockedBy("totally_not_a_key"); ok {
+		t.Errorf("UnlockedBy(\"totally_not_a_key\") = (%q, true), want ok=false", got)
+	}
+	// Empty key never unlocks (un-gated themes contribute "" and must not be indexed).
+	if got, ok := UnlockedBy(""); ok {
+		t.Errorf("UnlockedBy(\"\") = (%q, true), want ok=false", got)
+	}
+}
+
+// TestGatedThemeRegistryConsistency is the registry-consistency guard (theming.md
+// §5): every gated theme (non-Accessible, non-default) declares EXACTLY ONE of
+// UnlockMilestone / UnlockChain and a non-empty UnlockHint; every always-available
+// theme (Accessible or the default Forge) declares NEITHER and no hint.
+func TestGatedThemeRegistryConsistency(t *testing.T) {
+	for _, th := range All() {
+		alwaysAvailable := th.Accessible || th.Key == DefaultKey
+		hasMilestone := th.UnlockMilestone != ""
+		hasChain := th.UnlockChain != ""
+
+		if alwaysAvailable {
+			if hasMilestone || hasChain {
+				t.Errorf("theme %q is always-available (accessible=%v, default=%v) but declares an unlock condition (milestone=%q chain=%q); it must declare neither",
+					th.Key, th.Accessible, th.Key == DefaultKey, th.UnlockMilestone, th.UnlockChain)
+			}
+			if th.UnlockHint != "" {
+				t.Errorf("theme %q is always-available but has UnlockHint=%q; it must be empty", th.Key, th.UnlockHint)
+			}
+			if th.Gated() {
+				t.Errorf("theme %q is always-available but Gated() reports true", th.Key)
+			}
+			continue
+		}
+
+		// Gated theme: exactly one of milestone/chain (XOR), and a hint.
+		if hasMilestone == hasChain {
+			t.Errorf("gated theme %q must set EXACTLY ONE of UnlockMilestone/UnlockChain; got milestone=%q chain=%q",
+				th.Key, th.UnlockMilestone, th.UnlockChain)
+		}
+		if th.UnlockHint == "" {
+			t.Errorf("gated theme %q has an empty UnlockHint; a locked theme must explain how to unlock it", th.Key)
+		}
+		if !th.Gated() {
+			t.Errorf("gated theme %q reports Gated()=false", th.Key)
+		}
+		// UnlockKey must return the set key.
+		if want := th.UnlockMilestone + th.UnlockChain; th.UnlockKey() != want {
+			t.Errorf("theme %q UnlockKey()=%q, want %q", th.Key, th.UnlockKey(), want)
+		}
+	}
+}
+
+// TestUnlockHintFor checks the hint accessor for known/unknown keys.
+func TestUnlockHintFor(t *testing.T) {
+	// A gated theme's hint matches its struct field.
+	if got := UnlockHintFor("cyberpunk"); got != Cyberpunk.UnlockHint {
+		t.Errorf("UnlockHintFor(\"cyberpunk\") = %q, want %q", got, Cyberpunk.UnlockHint)
+	}
+	if got := UnlockHintFor("cyberpunk"); got == "" {
+		t.Error("UnlockHintFor(\"cyberpunk\") is empty; want a hint")
+	}
+	// The default theme has no hint.
+	if got := UnlockHintFor(DefaultKey); got != "" {
+		t.Errorf("UnlockHintFor(%q) = %q, want empty (un-gated)", DefaultKey, got)
+	}
+	// Unknown key → "".
+	if got := UnlockHintFor("no_such_theme"); got != "" {
+		t.Errorf("UnlockHintFor(\"no_such_theme\") = %q, want empty", got)
+	}
+}

--- a/ui/app.go
+++ b/ui/app.go
@@ -38,6 +38,14 @@ func NewApp(engine *game.GameEngine, version string) *App {
 }
 
 func (a *App) setup() {
+	// Apply the account's persisted active theme (theming.md §6) before any widget
+	// is built, so the splash and every theme.Track closure in the page constructors
+	// below render in the chosen theme on the very first Draw. applyAccountTheme is
+	// fully defensive: no engine/account, an empty stored key, or an unknown/locked
+	// one all fall back to the default (Forge). NewApp already pinned Forge as a
+	// floor; this layers the account's choice on top once the engine is in place.
+	applyAccountTheme(a.engine)
+
 	a.dashboard = NewDashboard(a.tviewApp, a.engine, a.pages)
 
 	splash := CreateSplashPage(a.tviewApp, a.pages, a.engine, a.version)
@@ -61,6 +69,10 @@ func (a *App) setup() {
 				return
 			}
 			a.engine.SetAccount(newAcct)
+			// A brand-new account starts on its own theme (ActiveTheme "" → Forge)
+			// rather than inheriting whatever was previewed before it was installed
+			// (theming.md §6). Re-resolve from the freshly-wired account.
+			applyAccountTheme(a.engine)
 		})
 	}
 }

--- a/ui/app.go
+++ b/ui/app.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // App manages the tview application and page routing
@@ -17,6 +18,15 @@ type App struct {
 
 // NewApp creates the UI application
 func NewApp(engine *game.GameEngine, version string) *App {
+	// Assert the active theme before any widget is built so the name-remap and
+	// tview.Styles chrome defaults are in place for the first Draw, and every
+	// theme.Track closure in setup() applies against a known palette. The theme
+	// package init() already seeds Forge defensively; this makes the boot explicit
+	// and survives a future import reshuffle. Phase 2 swaps DefaultKey for the
+	// account's stored active theme (theming.md §6). Ignoring the error is fine —
+	// DefaultKey is a registered built-in.
+	_ = theme.SetActive(theme.DefaultKey)
+
 	a := &App{
 		tviewApp: tview.NewApplication(),
 		pages:    tview.NewPages(),

--- a/ui/autocomplete.go
+++ b/ui/autocomplete.go
@@ -34,6 +34,7 @@ var commands = []string{
 	"upgrade",
 	"advance", "rates", "speed", "save", "saves", "load",
 	"account",
+	"theme",
 	"wonder",
 	"dump", "exportlogs",
 	"milestones", "ms",
@@ -209,6 +210,13 @@ func suggestArg(cmd string, completed []string, partial string, prefix string, e
 
 	case "load":
 		return filterPrefix(saveNames(), partial, prefix)
+
+	case "theme":
+		// "theme list" plus a key per registered theme. Only the first arg is
+		// completable; `theme <key>` takes no further args.
+		if len(completed) == 0 {
+			return filterPrefix(append([]string{"list"}, themeKeys()...), partial, prefix)
+		}
 
 	case "account", "acct":
 		// Subcommands: recover (code arg not enumerable), export/import (path args

--- a/ui/catastrophe_modal.go
+++ b/ui/catastrophe_modal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/espresso20/ageforge/config"
+	"github.com/espresso20/ageforge/theme"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -51,8 +52,8 @@ func (d *Dashboard) showCatastropheModal(epochKey string) {
 			}
 			d.closeCatastropheModal()
 		})
-	btnEndure.SetBackgroundColor(tcell.ColorDarkRed)
-	btnEndure.SetLabelColor(tcell.ColorWhite)
+	btnEndure.SetBackgroundColor(theme.Color(theme.RoleNegative))
+	btnEndure.SetLabelColor(theme.Color(theme.RoleText))
 
 	btnSuccumb := tview.NewButton("[SUCCUMB]").
 		SetSelectedFunc(func() {
@@ -61,8 +62,8 @@ func (d *Dashboard) showCatastropheModal(epochKey string) {
 			}
 			d.closeCatastropheModal()
 		})
-	btnSuccumb.SetBackgroundColor(tcell.ColorDarkRed)
-	btnSuccumb.SetLabelColor(tcell.ColorYellow)
+	btnSuccumb.SetBackgroundColor(theme.Color(theme.RoleNegative))
+	btnSuccumb.SetLabelColor(theme.Color(theme.RoleHighlight))
 
 	btnDefer := tview.NewButton("[Defer — Decide Later]").
 		SetSelectedFunc(func() {
@@ -88,8 +89,8 @@ func (d *Dashboard) showCatastropheModal(epochKey string) {
 		AddItem(btnRow, 1, 0, true)
 	inner.SetBorder(true).
 		SetTitle(fmt.Sprintf(" ☄ %s Catastrophe ", ep.Name)).
-		SetTitleColor(tcell.ColorRed).
-		SetBorderColor(tcell.ColorDarkRed)
+		SetTitleColor(theme.Color(theme.RoleNegative)).
+		SetBorderColor(theme.Color(theme.RoleNegative))
 
 	// --- centered overlay ---
 	modal := tview.NewFlex().

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -267,6 +267,12 @@ func (d *Dashboard) build() {
 				d.app.SetFocus(page)
 				return
 			}
+			if strings.ToLower(cmd) == "theme" { // bare theme — open the live picker (theme list / theme <key> fall through)
+				page := CreateThemePickerPage(d.app, d.pages, "dashboard")
+				d.pages.AddPage(themePickerPage, page, true, true)
+				d.app.SetFocus(page)
+				return
+			}
 			result := HandleCommand(text, d.engine)
 			if result.OverlayName != "" {
 				state := d.engine.GetState()

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -74,17 +74,32 @@ type Dashboard struct {
 	overlayMgr *OverlayManager
 	lastState  *game.GameState
 
+	// Milestone-gated theme unlocks (theming.md §5; see theme_unlock.go). Both fields
+	// are owned by the UI goroutine — touched only from refresh(), which runs inside
+	// QueueUpdateDraw and never under the engine lock, so account.UnlockTheme's Save
+	// is safe here.
+	//
+	// themeProcessedKeys de-dupes: each completed milestone/chain key is handled once
+	// per process, so we don't re-ask UnlockedBy / UnlockTheme every tick.
+	//
+	// themeSyncDone is false until the first refresh has processed the load's already-
+	// completed milestones; that first pass unlocks their themes SILENTLY (retroactive
+	// grants), and only unlocks during live play afterward fire the toast.
+	themeProcessedKeys map[string]bool
+	themeSyncDone      bool
+
 	stopCh chan struct{}
 }
 
 // NewDashboard creates the gameplay dashboard
 func NewDashboard(app *tview.Application, engine *game.GameEngine, pages *tview.Pages) *Dashboard {
 	d := &Dashboard{
-		app:     app,
-		engine:  engine,
-		pages:   pages,
-		stopCh:  make(chan struct{}),
-		histIdx: -1,
+		app:                app,
+		engine:             engine,
+		pages:              pages,
+		stopCh:             make(chan struct{}),
+		histIdx:            -1,
+		themeProcessedKeys: make(map[string]bool),
 	}
 	d.build()
 	d.overlayMgr = NewOverlayManager(d.pages, d.app, func() {
@@ -477,6 +492,11 @@ func (d *Dashboard) refresh() {
 	state := d.engine.GetState()
 	d.lastState = &state
 
+	// Milestone-gated theme unlocks (theming.md §5). Runs here, in the UI goroutine,
+	// because account.UnlockTheme persists (file I/O) and must not run under the
+	// engine lock / in a Bus handler. GetState() above already released the lock.
+	d.processThemeUnlocks(state)
+
 	// Phase 9: catastrophe modal — show once per new pending catastrophe; Defer hides it
 	if state.PendingCatastrophe == "" {
 		d.catModalShown = "" // reset so next catastrophe will show fresh
@@ -510,6 +530,44 @@ func (d *Dashboard) refresh() {
 	d.overlayMgr.Refresh(state)
 	d.updateSidebar(d.overlayMgr.ActiveName())
 	d.refreshWorkerMini(state)
+}
+
+// processThemeUnlocks grants milestone-gated themes for newly-completed milestones/
+// chains (theming.md §5), toasting only genuinely-new unlocks during live play.
+//
+// Locking: this is called from refresh() (inside QueueUpdateDraw, on the tview
+// goroutine), which does NOT hold the engine lock — it operates on the GetState()
+// snapshot. So the account Save inside UnlockTheme is safe here; doing this in a Bus
+// handler or under ge.mu would deadlock (CLAUDE.md Bus rule).
+//
+// First-sync handling: the first call processes the load's already-completed
+// milestones with themeSyncDone==false, so evaluateThemeUnlock unlocks their themes
+// SILENTLY (no toast spam for retroactive grants). Subsequent calls run with
+// themeSyncDone==true, so a milestone completed during play toasts once. Each
+// completed key is recorded in themeProcessedKeys so it's evaluated only once per
+// process (idempotent regardless, since UnlockTheme is a no-op once owned).
+func (d *Dashboard) processThemeUnlocks(state game.GameState) {
+	var acct *game.Account
+	if d.engine != nil {
+		acct = d.engine.Account()
+	}
+	firstSync := !d.themeSyncDone
+
+	for _, key := range completedUnlockKeys(state.Milestones) {
+		if d.themeProcessedKeys[key] {
+			continue // already handled this process
+		}
+		d.themeProcessedKeys[key] = true
+		res := evaluateThemeUnlock(acct, key, firstSync)
+		if res.Toast {
+			// AddLog takes the engine lock internally, but we don't hold it here, so
+			// this is safe (it's a plain method call, not a Bus subscriber).
+			d.engine.AddLog("success", themeUnlockToast(res.ThemeName))
+		}
+	}
+
+	// Mark first-sync complete after the first pass so live-play unlocks toast.
+	d.themeSyncDone = true
 }
 
 func (d *Dashboard) refreshWorkerMini(state game.GameState) {

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/espresso20/ageforge/config"
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // shameMessages are randomly chosen at session start when the cheater badge is active.
@@ -118,14 +119,16 @@ func (d *Dashboard) build() {
 	d.sidebar = tview.NewTextView().
 		SetDynamicColors(true).
 		SetText(buildSidebarText(""))
-	d.sidebar.SetBorder(true).SetTitle(" Panels ").SetTitleColor(tcell.ColorGold)
+	d.sidebar.SetBorder(true).SetTitle(" Panels ")
+	theme.Track(func() { d.sidebar.SetTitleColor(theme.Color(theme.RoleAccent)) })
 
 	// Log panel
 	d.logTV = tview.NewTextView().
 		SetDynamicColors(true).
 		SetScrollable(true).
 		SetMaxLines(100)
-	d.logTV.SetBorder(true).SetTitle(" Log ").SetTitleColor(ColorDim)
+	d.logTV.SetBorder(true).SetTitle(" Log ")
+	theme.Track(func() { d.logTV.SetTitleColor(theme.Color(theme.RoleDim)) })
 
 	// Shame badge bar (1 fixed line; text only shown when CheaterBadge is true)
 	d.cheaterTV = tview.NewTextView().
@@ -210,9 +213,11 @@ func (d *Dashboard) build() {
 	// Command input
 	d.inputField = tview.NewInputField().
 		SetLabel("> ").
-		SetFieldWidth(0).
-		SetFieldBackgroundColor(tcell.ColorDefault).
-		SetLabelColor(ColorAccent)
+		SetFieldWidth(0)
+	theme.Track(func() {
+		d.inputField.SetFieldBackgroundColor(theme.Color(theme.RoleBackground)).
+			SetLabelColor(theme.Color(theme.RoleLabel))
+	})
 
 	// Wire up autocomplete
 	d.inputField.SetAutocompleteFunc(NewAutoCompleter(d.engine))
@@ -320,7 +325,8 @@ func (d *Dashboard) build() {
 
 	// Mini worker summary box — sits below the sidebar in the right column
 	d.workerMiniTV = tview.NewTextView().SetDynamicColors(true)
-	d.workerMiniTV.SetBorder(true).SetTitle(" Workers ").SetTitleColor(ColorVillager)
+	d.workerMiniTV.SetBorder(true).SetTitle(" Workers ")
+	theme.Track(func() { d.workerMiniTV.SetTitleColor(theme.Color(theme.RoleAccent)) })
 
 	rightCol := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(d.sidebar, 0, 1, false).
@@ -676,12 +682,14 @@ func (d *Dashboard) showDevUnlockModal() {
 	}
 
 	const devUnlockPage = "__dev_unlock__"
+	// Transient dev-unlock modal: rebuilt each open and removed on close, so it
+	// construction-reads theme.Color without enrolling in Track (theming.md §3.3).
 	field := tview.NewInputField().
 		SetLabel("").
 		SetFieldWidth(40).
 		SetMaskCharacter('·').
-		SetFieldBackgroundColor(tcell.ColorBlack).
-		SetFieldTextColor(tcell.ColorWhite)
+		SetFieldBackgroundColor(theme.Color(theme.RoleBackground)).
+		SetFieldTextColor(theme.Color(theme.RoleText))
 
 	field.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEscape {
@@ -704,8 +712,8 @@ func (d *Dashboard) showDevUnlockModal() {
 	box := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(field, 1, 0, true)
 	box.SetBorder(true).
-		SetBorderColor(tcell.ColorDarkGray).
-		SetBackgroundColor(tcell.ColorBlack)
+		SetBorderColor(theme.Color(theme.RoleDim)).
+		SetBackgroundColor(theme.Color(theme.RoleBackground))
 
 	centered := tview.NewFlex().
 		AddItem(nil, 0, 1, false).

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -268,7 +268,7 @@ func (d *Dashboard) build() {
 				return
 			}
 			if strings.ToLower(cmd) == "theme" { // bare theme — open the live picker (theme list / theme <key> fall through)
-				page := CreateThemePickerPage(d.app, d.pages, "dashboard")
+				page := CreateThemePickerPage(d.app, d.pages, d.engine, "dashboard")
 				d.pages.AddPage(themePickerPage, page, true, true)
 				d.app.SetFocus(page)
 				return

--- a/ui/input.go
+++ b/ui/input.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // CommandResult is the return value of HandleCommand. The caller (Dashboard)
@@ -116,6 +117,8 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 		return cmdLoad(args, engine)
 	case "account", "acct":
 		return cmdAccount(args, engine)
+	case "theme":
+		return cmdTheme(args)
 	default:
 		return CommandResult{
 			Message: fmt.Sprintf("Unknown command: %s. Type 'help' for commands.", cmd),
@@ -839,6 +842,75 @@ func cmdSaveList() CommandResult {
 			s.Name, s.Timestamp.Format("2006-01-02 15:04:05"), age))
 	}
 	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+}
+
+// cmdTheme handles the `theme` command's text paths:
+//   - `theme`        → directs the player to the picker (the interactive picker
+//     page is opened by the dashboard intercept; this fallback covers the
+//     command-table path and tests, which can't open an interactive page).
+//   - `theme list`   → lists every theme (name, key, active marker, accessible note).
+//   - `theme <key>`  → switches directly to a theme by key if it exists, else an
+//     error listing the valid keys.
+//
+// theme.SetActive applies the name-remap + restyle; the dashboard redraws on its
+// next tick, so the switch shows up live without an explicit Draw here.
+func cmdTheme(args []string) CommandResult {
+	if len(args) == 0 {
+		return CommandResult{
+			Message: "Usage: theme list | theme <key>. Type `theme` from the menu (or open it) for the live picker.",
+			Type:    "info",
+		}
+	}
+	if strings.ToLower(args[0]) == "list" {
+		return cmdThemeList()
+	}
+
+	key := strings.ToLower(args[0])
+	t, ok := theme.ByKey(key)
+	if !ok {
+		return CommandResult{
+			Message: fmt.Sprintf("Unknown theme: %s. Valid: %s", key, strings.Join(themeKeys(), ", ")),
+			Type:    "error",
+		}
+	}
+	if err := theme.SetActive(t.Key); err != nil {
+		return CommandResult{Message: err.Error(), Type: "error"}
+	}
+	theme.Restyle()
+	return CommandResult{Message: fmt.Sprintf("Theme set: %s", t.Name), Type: "success"}
+}
+
+// cmdThemeList renders the `theme list` output: one line per theme with its name,
+// key, an active marker, and an "accessible" note.
+func cmdThemeList() CommandResult {
+	activeKey := theme.Active().Key
+	var lines []string
+	lines = append(lines, "[gold]Themes:[-]")
+	for _, t := range theme.All() {
+		marker := "  "
+		if t.Key == activeKey {
+			marker = "[gold]●[-] "
+		}
+		note := ""
+		if t.Accessible {
+			note = "  [cyan](accessible)[-]"
+		}
+		lines = append(lines, fmt.Sprintf("%s[white]%-18s[-] [gray]%s[-]%s",
+			marker, t.Name, t.Key, note))
+	}
+	lines = append(lines, "[gray]Use `theme <key>` to switch.[-]")
+	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
+}
+
+// themeKeys returns every registered theme key in display order, for usage/error
+// messages and autocomplete.
+func themeKeys() []string {
+	all := theme.All()
+	keys := make([]string, 0, len(all))
+	for _, t := range all {
+		keys = append(keys, t.Key)
+	}
+	return keys
 }
 
 func cmdResearch(args []string, engine *game.GameEngine) CommandResult {

--- a/ui/input.go
+++ b/ui/input.go
@@ -872,7 +872,7 @@ func cmdTheme(args []string, engine *game.GameEngine) CommandResult {
 		}
 	}
 	if strings.ToLower(args[0]) == "list" {
-		return cmdThemeList()
+		return cmdThemeList(themeAccount(engine))
 	}
 
 	key := strings.ToLower(args[0])
@@ -911,8 +911,15 @@ func themeAccount(engine *game.GameEngine) *game.Account {
 }
 
 // cmdThemeList renders the `theme list` output: one line per theme with its name,
-// key, an active marker, and an "accessible" note.
-func cmdThemeList() CommandResult {
+// key, an active marker, and a status note. Unlocked themes show "(accessible)" when
+// applicable; a LOCKED flavor theme shows "🔒 <unlock hint>" instead, so the player
+// sees exactly how to earn it (theming.md §5/§7), e.g. "monochrome  🔒 Reach the
+// Information Age".
+//
+// acct may be nil (accountless play / tests): with no account only the always-
+// available set (Accessible + Forge) is unlocked, so the flavor themes correctly
+// render as locked with their hints.
+func cmdThemeList(acct *game.Account) CommandResult {
 	activeKey := theme.Active().Key
 	var lines []string
 	lines = append(lines, "[gold]Themes:[-]")
@@ -922,7 +929,15 @@ func cmdThemeList() CommandResult {
 			marker = "[gold]●[-] "
 		}
 		note := ""
-		if t.Accessible {
+		switch {
+		case !themeAvailable(acct, t):
+			// Locked flavor theme: show the unlock condition rather than nothing.
+			hint := t.UnlockHint
+			if hint == "" {
+				hint = "unlock via a milestone"
+			}
+			note = fmt.Sprintf("  [red]🔒[-] [gray]%s[-]", hint)
+		case t.Accessible:
 			note = "  [cyan](accessible)[-]"
 		}
 		lines = append(lines, fmt.Sprintf("%s[white]%-18s[-] [gray]%s[-]%s",

--- a/ui/input.go
+++ b/ui/input.go
@@ -118,7 +118,7 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 	case "account", "acct":
 		return cmdAccount(args, engine)
 	case "theme":
-		return cmdTheme(args)
+		return cmdTheme(args, engine)
 	default:
 		return CommandResult{
 			Message: fmt.Sprintf("Unknown command: %s. Type 'help' for commands.", cmd),
@@ -702,6 +702,11 @@ func cmdAccount(args []string, engine *game.GameEngine) CommandResult {
 			return CommandResult{Message: err.Error(), Type: "error"}
 		}
 		engine.SetAccount(restored)
+		// Re-resolve the active theme against the now-installed account so the UI
+		// doesn't keep the prior account's theme after an identity swap (theming.md
+		// §6). A recovery code carries identity only, so a fresh restore resolves to
+		// Forge; a restore of an account with a stored theme honors it.
+		applyAccountTheme(engine)
 		return CommandResult{
 			Message: fmt.Sprintf("Identity restored: %s", shortAccountID(restored.AccountID)),
 			Type:    "success",
@@ -854,7 +859,12 @@ func cmdSaveList() CommandResult {
 //
 // theme.SetActive applies the name-remap + restyle; the dashboard redraws on its
 // next tick, so the switch shows up live without an explicit Draw here.
-func cmdTheme(args []string) CommandResult {
+//
+// engine bridges to the account layer (theming.md §6): on a successful switch we
+// persist the new active theme account-wide so a CLI switch survives saves, and the
+// theme is gated through themeAvailable so locked flavor themes (Phase 3) refuse.
+// engine/Account() are nil-guarded — the game must run accountless.
+func cmdTheme(args []string, engine *game.GameEngine) CommandResult {
 	if len(args) == 0 {
 		return CommandResult{
 			Message: "Usage: theme list | theme <key>. Type `theme` from the menu (or open it) for the live picker.",
@@ -873,11 +883,31 @@ func cmdTheme(args []string) CommandResult {
 			Type:    "error",
 		}
 	}
+	// Unlock gate (theming.md §4/§5): refuse a known-but-locked theme. No theme is
+	// locked today (all shipped themes are Accessible/Forge); this is the Phase-3 seam.
+	if !themeAvailable(themeAccount(engine), t) {
+		return CommandResult{Message: themeUnavailableMsg, Type: "error"}
+	}
 	if err := theme.SetActive(t.Key); err != nil {
 		return CommandResult{Message: err.Error(), Type: "error"}
 	}
 	theme.Restyle()
+	// Persist account-wide so a CLI switch survives saves (theming.md §6). Nil-guarded;
+	// the Save error is non-fatal — the theme is already applied, so we report success
+	// regardless rather than rolling back a working visual change over a write hiccup.
+	if acct := themeAccount(engine); acct != nil {
+		_ = acct.SetActiveTheme(t.Key)
+	}
 	return CommandResult{Message: fmt.Sprintf("Theme set: %s", t.Name), Type: "success"}
+}
+
+// themeAccount returns engine's account, or nil when accountless. Mirrors the
+// picker's account() guard so the command + picker share one nil-safe accessor.
+func themeAccount(engine *game.GameEngine) *game.Account {
+	if engine == nil {
+		return nil
+	}
+	return engine.Account()
 }
 
 // cmdThemeList renders the `theme list` output: one line per theme with its name,

--- a/ui/load_game.go
+++ b/ui/load_game.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/espresso20/ageforge/config"
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // loadGamePage is the page name under which the Load Game browser is registered
@@ -71,8 +72,12 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 	// ── Save list ────────────────────────────────────────────────────────────
 	b.list = tview.NewList()
 	b.list.SetBorder(false)
-	b.list.SetSelectedBackgroundColor(tcell.ColorGold)
-	b.list.SetSelectedTextColor(tcell.ColorBlack)
+	// Selection backs light text, so it uses the Selection role (dark slate under
+	// Forge), not Accent — white-on-gold is unreadable (theme/themes_forge.go).
+	theme.Track(func() {
+		b.list.SetSelectedBackgroundColor(theme.Color(theme.RoleSelection)).
+			SetSelectedTextColor(theme.Color(theme.RoleText))
+	})
 	b.list.ShowSecondaryText(false)
 	b.list.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
 		b.updateDetail(index)
@@ -85,18 +90,22 @@ func CreateLoadGamePage(app *tview.Application, pages *tview.Pages, engine *game
 		SetDynamicColors(true).
 		SetText(legendText())
 	legend.SetBorder(true).
-		SetBorderColor(tcell.ColorGold).
-		SetTitle(" Key ").
-		SetTitleColor(tcell.ColorGold)
+		SetTitle(" Key ")
+	theme.Track(func() {
+		legend.SetBorderColor(theme.Color(theme.RoleAccent)).
+			SetTitleColor(theme.Color(theme.RoleAccent))
+	})
 
 	// ── Detail pane ──────────────────────────────────────────────────────────
 	b.detail = tview.NewTextView().
 		SetDynamicColors(true).
 		SetWrap(true)
 	b.detail.SetBorder(true).
-		SetBorderColor(tcell.ColorGold).
-		SetTitle(" Details ").
-		SetTitleColor(tcell.ColorGold)
+		SetTitle(" Details ")
+	theme.Track(func() {
+		b.detail.SetBorderColor(theme.Color(theme.RoleAccent)).
+			SetTitleColor(theme.Color(theme.RoleAccent))
+	})
 
 	// ── Footer ───────────────────────────────────────────────────────────────
 	footer := tview.NewTextView().
@@ -129,7 +138,7 @@ func (b *loadGameBrowser) refresh(wantIdx int) {
 		// Surface it in the detail pane rather than crashing, and show an empty list.
 		b.saves = nil
 		b.list.Clear()
-		b.subtitle.SetText("[#8b949e]" + savesDirLabel() + " — could not read saves[-]")
+		b.subtitle.SetText("[gray]" + savesDirLabel() + " — could not read saves[-]")
 		b.detail.SetText(fmt.Sprintf("[red]Could not read saves: %v[-]", err))
 		return
 	}
@@ -143,12 +152,12 @@ func (b *loadGameBrowser) refresh(wantIdx int) {
 		b.saves[i] = r.Info
 	}
 
-	b.subtitle.SetText(fmt.Sprintf("[#8b949e]%s — %s[-]", savesDirLabel(), pluralSaves(len(saves))))
+	b.subtitle.SetText(fmt.Sprintf("[gray]%s — %s[-]", savesDirLabel(), pluralSaves(len(saves))))
 
 	b.list.Clear()
 	if len(rows) == 0 {
 		// Empty state — the action keys become no-ops (handleKey guards on len).
-		b.detail.SetText("[#8b949e]No saved games found in " + savesDir() + ".\n\nStart a new game to create one.[-]")
+		b.detail.SetText("[gray]No saved games found in " + savesDir() + ".\n\nStart a new game to create one.[-]")
 		return
 	}
 
@@ -293,7 +302,9 @@ func (b *loadGameBrowser) doDelete() {
 			// Keep the selection near where it was; clamp happens in refresh.
 			b.refresh(curIdx)
 		})
-	modal.SetBackgroundColor(tcell.ColorDarkRed)
+	// Transient confirm modal (rebuilt per delete): construction-read the danger
+	// background from the Negative role so it tints with the theme.
+	modal.SetBackgroundColor(theme.Color(theme.RoleNegative))
 	b.pages.AddPage(page, modal, true, true)
 }
 
@@ -357,8 +368,8 @@ func (b *loadGameBrowser) doRename() {
 	}
 
 	okBtn := tview.NewButton("[ OK ]").SetSelectedFunc(submit)
-	okBtn.SetBackgroundColor(tcell.ColorGold)
-	okBtn.SetLabelColor(tcell.ColorBlack)
+	okBtn.SetBackgroundColor(theme.Color(theme.RoleAccent))
+	okBtn.SetLabelColor(theme.Color(theme.RoleBackground))
 	cancelBtn := tview.NewButton("[ Cancel ]").SetSelectedFunc(close)
 
 	// Enter in the input field submits.
@@ -383,8 +394,8 @@ func (b *loadGameBrowser) doRename() {
 		AddItem(btnRow, 1, 0, false)
 	inner.SetBorder(true).
 		SetTitle(" Rename Save ").
-		SetTitleColor(tcell.ColorGold).
-		SetBorderColor(tcell.ColorGold)
+		SetTitleColor(theme.Color(theme.RoleAccent)).
+		SetBorderColor(theme.Color(theme.RoleAccent))
 
 	// Tab cycles input → OK → Cancel; Esc cancels from anywhere on the modal.
 	focusOrder := []tview.Primitive{input, okBtn, cancelBtn}
@@ -460,7 +471,7 @@ func rowLabel(s game.SaveInfo, prefix string, active bool) string {
 	if tag != "" {
 		tag = "   " + tag
 	}
-	return fmt.Sprintf("%s%s   [#8b949e]%s   %s[-]%s", prefix, s.Name, age, relativeTime(s.Timestamp), tag)
+	return fmt.Sprintf("%s%s   [gray]%s   %s[-]%s", prefix, s.Name, age, relativeTime(s.Timestamp), tag)
 }
 
 // rowTag returns the trailing status tag for a (non-corrupt) save row, or "".
@@ -519,7 +530,7 @@ const detailSep = " [gold]·[-] "
 func detailText(s game.SaveInfo, parentPresent bool, currentAccountID string) string {
 	if s.Corrupt {
 		return fmt.Sprintf(
-			"[red]⚠ Corrupt save — cannot be loaded[-]\n[#8b949e]File time: %s[-]",
+			"[red]⚠ Corrupt save — cannot be loaded[-]\n[gray]File time: %s[-]",
 			s.Timestamp.Format("Jan 2, 2006 3:04 PM"),
 		)
 	}
@@ -534,15 +545,15 @@ func detailText(s game.SaveInfo, parentPresent bool, currentAccountID string) st
 	}
 	id = append(id, fmt.Sprintf("[white]%s[-]", ageDisplay(s.Age)))
 	if s.Epoch != "" {
-		id = append(id, fmt.Sprintf("[#8b949e]%s[-]", s.Epoch))
+		id = append(id, fmt.Sprintf("[gray]%s[-]", s.Epoch))
 	}
 	lines = append(lines, strings.Join(id, detailSep))
 
 	// Line 2 — civilisation footprint.
 	lines = append(lines, strings.Join([]string{
-		fmt.Sprintf("[#8b949e]Population[-] [white]%s[-]", commafy(s.Population)),
-		fmt.Sprintf("[#8b949e]Buildings[-] [white]%s[-]", commafy(s.Buildings)),
-		fmt.Sprintf("[#8b949e]Wonders[-] [white]%s[-]", commafy(s.Wonders)),
+		fmt.Sprintf("[gray]Population[-] [white]%s[-]", commafy(s.Population)),
+		fmt.Sprintf("[gray]Buildings[-] [white]%s[-]", commafy(s.Buildings)),
+		fmt.Sprintf("[gray]Wonders[-] [white]%s[-]", commafy(s.Wonders)),
 	}, detailSep))
 
 	// Line 3 — progress markers. Milestones show "done/total" only when the total
@@ -552,15 +563,15 @@ func detailText(s game.SaveInfo, parentPresent bool, currentAccountID string) st
 		milestones = fmt.Sprintf("%s/%s", commafy(s.MilestonesDone), commafy(s.MilestonesTotal))
 	}
 	lines = append(lines, strings.Join([]string{
-		fmt.Sprintf("[#8b949e]Milestones[-] [white]%s[-]", milestones),
-		fmt.Sprintf("[#8b949e]Techs[-] [white]%s[-]", commafy(s.Techs)),
-		fmt.Sprintf("[#8b949e]Soldiers[-] [white]%s[-]", commafy(s.Soldiers)),
+		fmt.Sprintf("[gray]Milestones[-] [white]%s[-]", milestones),
+		fmt.Sprintf("[gray]Techs[-] [white]%s[-]", commafy(s.Techs)),
+		fmt.Sprintf("[gray]Soldiers[-] [white]%s[-]", commafy(s.Soldiers)),
 	}, detailSep))
 
 	// Line 4 — prestige + morale.
 	lines = append(lines, strings.Join([]string{
-		fmt.Sprintf("[#8b949e]Prestige[-] [white]Lv %s[-] [#8b949e](%s pts)[-]", commafy(s.PrestigeLevel), commafy(s.PrestigeTotal)),
-		fmt.Sprintf("[#8b949e]Morale[-] [white]%.0f%%[-]", s.Morale*100),
+		fmt.Sprintf("[gray]Prestige[-] [white]Lv %s[-] [gray](%s pts)[-]", commafy(s.PrestigeLevel), commafy(s.PrestigeTotal)),
+		fmt.Sprintf("[gray]Morale[-] [white]%.0f%%[-]", s.Morale*100),
 	}, detailSep))
 
 	// Line 4b — account attribution. Pre-account/legacy saves show a dash; saves
@@ -568,11 +579,11 @@ func detailText(s game.SaveInfo, parentPresent bool, currentAccountID string) st
 	// "(another account)". Only the short id prefix is shown — never the full id.
 	switch {
 	case s.AccountID == "":
-		lines = append(lines, "[#8b949e]Account:[-] [#8b949e]— (pre-account save)[-]")
+		lines = append(lines, "[gray]Account:[-] [gray]— (pre-account save)[-]")
 	case s.AccountID == currentAccountID && currentAccountID != "":
-		lines = append(lines, fmt.Sprintf("[#8b949e]Account:[-] [white]%s[-] [#8b949e](this account)[-]", shortAccountID(s.AccountID)))
+		lines = append(lines, fmt.Sprintf("[gray]Account:[-] [white]%s[-] [gray](this account)[-]", shortAccountID(s.AccountID)))
 	default:
-		lines = append(lines, fmt.Sprintf("[#8b949e]Account:[-] [white]%s[-] [yellow](another account)[-]", shortAccountID(s.AccountID)))
+		lines = append(lines, fmt.Sprintf("[gray]Account:[-] [white]%s[-] [yellow](another account)[-]", shortAccountID(s.AccountID)))
 	}
 
 	// Line 5 — looming catastrophe warning (omitted entirely when none pending).
@@ -582,7 +593,7 @@ func detailText(s game.SaveInfo, parentPresent bool, currentAccountID string) st
 
 	// Line 6 — save metadata.
 	lines = append(lines, fmt.Sprintf(
-		"[#8b949e]Saved[-] %s [gold]·[-] [#8b949e]%s ticks[-]",
+		"[gray]Saved[-] %s [gold]·[-] [gray]%s ticks[-]",
 		s.Timestamp.Format("Jan 2, 2006 3:04 PM"), commafy(s.Tick),
 	))
 
@@ -590,9 +601,9 @@ func detailText(s game.SaveInfo, parentPresent bool, currentAccountID string) st
 	// present (deleted/renamed) is marked "(detached)" rather than implying a link.
 	if s.ParentName != "" && s.ParentName != s.Name {
 		if parentPresent {
-			lines = append(lines, fmt.Sprintf("[#8b949e]Branched from: %s[-]", s.ParentName))
+			lines = append(lines, fmt.Sprintf("[gray]Branched from: %s[-]", s.ParentName))
 		} else {
-			lines = append(lines, fmt.Sprintf("[#8b949e]Branched from: %s (detached)[-]", s.ParentName))
+			lines = append(lines, fmt.Sprintf("[gray]Branched from: %s (detached)[-]", s.ParentName))
 		}
 	}
 

--- a/ui/newgame_modal.go
+++ b/ui/newgame_modal.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // newGameNamePage is the unique page name for the New Game name-entry modal.
@@ -68,7 +69,7 @@ func showAccountNameConfirmModal(app *tview.Application, pages *tview.Pages, nam
 		})
 	// Opaque background so the modal doesn't bleed the page beneath it, matching the
 	// other button-modals (and the earlier modal-opacity fix).
-	modal.SetBackgroundColor(tcell.ColorBlack)
+	modal.SetBackgroundColor(theme.Color(theme.RoleBackground))
 
 	pages.AddPage(accountNameConfirmPage, modal, true, true)
 	app.SetFocus(modal)
@@ -120,8 +121,8 @@ func showSaveNameModalOpts(app *tview.Application, pages *tview.Pages, title, pa
 		SetFieldWidth(40).
 		// Dark slate field with white text — tview's default light field
 		// background renders the white name near-invisible on the dark modal.
-		SetFieldBackgroundColor(tcell.NewRGBColor(48, 54, 61)).
-		SetFieldTextColor(tcell.ColorWhite)
+		SetFieldBackgroundColor(theme.Color(theme.RoleSelection)).
+		SetFieldTextColor(theme.Color(theme.RoleText))
 
 	escHint := "Esc: cancel"
 	if escAccepts {
@@ -130,7 +131,7 @@ func showSaveNameModalOpts(app *tview.Application, pages *tview.Pages, title, pa
 	hintTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
-		SetText("[#8b949e]Enter: confirm  ·  Tab: reroll name  ·  " + escHint + "[-]")
+		SetText("[gray]Enter: confirm  ·  Tab: reroll name  ·  " + escHint + "[-]")
 
 	// closeAndRestore removes the modal page and restores focus to focusReturn.
 	// Used on cancel (Esc).
@@ -174,7 +175,7 @@ func showSaveNameModalOpts(app *tview.Application, pages *tview.Pages, title, pa
 	// actually draws, so transparent spacers would let the page beneath (the
 	// dashboard, for a Branch save) bleed through; an explicit background paints
 	// them.
-	spacer := func() *tview.Box { return tview.NewBox().SetBackgroundColor(tcell.ColorBlack) }
+	spacer := func() *tview.Box { return tview.NewBox().SetBackgroundColor(theme.Color(theme.RoleBackground)) }
 	inner := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(input, 1, 0, true).
 		AddItem(spacer(), 1, 0, false).
@@ -183,9 +184,9 @@ func showSaveNameModalOpts(app *tview.Application, pages *tview.Pages, title, pa
 		AddItem(hintTV, 1, 0, false)
 	inner.SetBorder(true).
 		SetTitle(title).
-		SetTitleColor(tcell.ColorGold).
-		SetBorderColor(tcell.ColorGold)
-	inner.SetBackgroundColor(tcell.ColorBlack)
+		SetTitleColor(theme.Color(theme.RoleAccent)).
+		SetBorderColor(theme.Color(theme.RoleAccent))
+	inner.SetBackgroundColor(theme.Color(theme.RoleBackground))
 
 	// Esc cancels; Tab rerolls a fresh suggestion. Enter is handled by the field's
 	// DoneFunc above so plain typing keys still reach the input.

--- a/ui/overlay.go
+++ b/ui/overlay.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -70,10 +71,14 @@ func (om *OverlayManager) Register(name, title string, provide OverlayProvider) 
 		SetScrollable(true).
 		SetWrap(true)
 	tv.SetBorder(true).
-		SetBorderColor(tcell.ColorGold).
-		SetTitle(" " + title + " — ESC to close ").
-		SetTitleColor(tcell.ColorGold).
-		SetBackgroundColor(tcell.ColorBlack)
+		SetTitle(" " + title + " — ESC to close ")
+	// Persistent overlay chrome (built once, reused on every Show): enroll so a live
+	// theme switch restyles the border/title/background.
+	theme.Track(func() {
+		tv.SetBorderColor(theme.Color(theme.RoleAccent)).
+			SetTitleColor(theme.Color(theme.RoleAccent)).
+			SetBackgroundColor(theme.Color(theme.RoleBackground))
+	})
 	tv.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEsc {
 			om.Hide()
@@ -130,11 +135,13 @@ func (om *OverlayManager) buildWidgetRoot(we *widgetEntry, prim tview.Primitive)
 	// Use tview.Frame to add the gold border and title around any arbitrary primitive.
 	frame := tview.NewFrame(prim).
 		SetBorders(0, 0, 0, 0, 0, 0)
+	// Rebuilt per Show, so construction-read theme.Color (no Track needed): a later
+	// theme switch re-runs buildWidgetRoot on next open.
 	frame.SetBorder(true).
-		SetBorderColor(tcell.ColorGold).
+		SetBorderColor(theme.Color(theme.RoleAccent)).
 		SetTitle(" " + we.title + " — ESC to close ").
-		SetTitleColor(tcell.ColorGold).
-		SetBackgroundColor(tcell.ColorBlack)
+		SetTitleColor(theme.Color(theme.RoleAccent)).
+		SetBackgroundColor(theme.Color(theme.RoleBackground))
 	frame.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEsc {
 			om.Hide()

--- a/ui/overlay_help.go
+++ b/ui/overlay_help.go
@@ -63,6 +63,9 @@ func helpProvider(_ game.GameState, _ int) string {
 	sb.WriteString("  [cyan]rates[-]                       - Show resource rate breakdown\n")
 	sb.WriteString("  [cyan]status[-]                      - Show detailed status\n")
 	sb.WriteString("  [cyan]speed[-] [1.0|1.5|2.0|...]     - Set game speed (unlocks per wonder built)\n")
+	sb.WriteString("  [cyan]theme[-]                       - Open the theme picker (palettes + accessibility)\n")
+	sb.WriteString("  [cyan]theme[-] list                  - List themes with unlock status\n")
+	sb.WriteString("  [cyan]theme[-] <key>                 - Switch to a theme by key\n")
 	sb.WriteString("  [cyan]save[-] [name]                 - Save game (default: autosave)\n")
 	sb.WriteString("  [cyan]load[-] [name]                 - Load game (default: autosave)\n")
 	sb.WriteString("  [cyan]saves[-]                       - List all save files\n")
@@ -85,6 +88,7 @@ func helpProvider(_ game.GameState, _ int) string {
 		{"history", "Civilization history timeline"},
 		{"buildings", "Built structures by lineage"},
 		{"map", "City map view"},
+		{"theme", "Theme picker — palettes & accessibility"},
 		{"help", "This Help panel"},
 	} {
 		sb.WriteString("  [cyan]" + padRight(p.cmd, 12) + "[-] — " + p.desc + "\n")

--- a/ui/overlay_history.go
+++ b/ui/overlay_history.go
@@ -51,8 +51,8 @@ func renderHistoryOverlay(state game.GameState, w int) string {
 		{"Population", "[cyan]", func(s game.HistorySample) float64 { return s.Population }, "workers", false},
 		{"Food Rate", "[green]", func(s game.HistorySample) float64 { return s.FoodRate }, "/tick", true},
 		{"Knowledge", "[yellow]", func(s game.HistorySample) float64 { return s.KnowRate }, "/tick", true},
-		{"Faith", "[#cc88ff]", func(s game.HistorySample) float64 { return s.Faith }, "", false},
-		{"Morale", "[#ff66cc]", func(s game.HistorySample) float64 { return s.Morale * 100 }, "%", false},
+		{"Faith", "[gold]", func(s game.HistorySample) float64 { return s.Faith }, "", false},
+		{"Morale", "[yellow]", func(s game.HistorySample) float64 { return s.Morale * 100 }, "%", false},
 		{"Prod Bonus", "[orange]", func(s game.HistorySample) float64 { return s.ProdAll * 100 }, "%", false},
 		{"Tick Speed", "[gray]", func(s game.HistorySample) float64 { return s.TickSpeed }, "x", false},
 	}

--- a/ui/overlay_stats.go
+++ b/ui/overlay_stats.go
@@ -50,7 +50,7 @@ func statsProvider(state game.GameState, _ int) string {
 	} else {
 		as := state.AccountStats
 		if as.DisplayName != "" {
-			fmt.Fprintf(&sb, " [#8b949e]Account:[-] [white]%s[-]\n", as.DisplayName)
+			fmt.Fprintf(&sb, " [gray]Account:[-] [white]%s[-]\n", as.DisplayName)
 		}
 		fmt.Fprintf(&sb, " [gold]Total Prestiges:[-]   %d\n", as.TotalPrestiges)
 

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -76,7 +76,7 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 	mainList.AddItem("  ◈  Themes", "", 't', func() {
 		// Opaque full-screen picker, same lifecycle as Load Game — the canvas runs
 		// underneath and is still live when the player returns via Enter/Esc.
-		page := CreateThemePickerPage(app, pages, "splash")
+		page := CreateThemePickerPage(app, pages, engine, "splash")
 		pages.AddPage(themePickerPage, page, true, true)
 		app.SetFocus(page)
 	})
@@ -296,6 +296,10 @@ func showAccountWipeTypeGate(app *tview.Application, pages *tview.Pages, engine 
 				return
 			}
 			engine.SetAccount(newAcct)
+			// A wiped→recreated account starts on its own theme (ActiveTheme "" →
+			// Forge) rather than inheriting the previous account's theme (theming.md
+			// §6). The active theme is process-global, so reset it explicitly here.
+			applyAccountTheme(engine)
 		})
 	}
 

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -73,6 +73,13 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 			})
 		})
 	})
+	mainList.AddItem("  ◈  Themes", "", 't', func() {
+		// Opaque full-screen picker, same lifecycle as Load Game — the canvas runs
+		// underneath and is still live when the player returns via Enter/Esc.
+		page := CreateThemePickerPage(app, pages, "splash")
+		pages.AddPage(themePickerPage, page, true, true)
+		app.SetFocus(page)
+	})
 	mainList.AddItem("  ✗  Quit", "", 'q', func() {
 		canvas.halt()
 		app.Stop()

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // eliteMessages are shown on the splash to players who have achieved the elite badge.
@@ -40,8 +41,12 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 	// ── Single action list ───────────────────────────────────────────────────
 	mainList := tview.NewList()
 	mainList.SetBorder(false)
-	mainList.SetSelectedBackgroundColor(tcell.ColorGold)
-	mainList.SetSelectedTextColor(tcell.ColorBlack)
+	// Selection backs light text → Selection role (dark slate under Forge), not the
+	// gold Accent (white-on-gold is unreadable; see theme/themes_forge.go).
+	theme.Track(func() {
+		mainList.SetSelectedBackgroundColor(theme.Color(theme.RoleSelection)).
+			SetSelectedTextColor(theme.Color(theme.RoleText))
+	})
 	mainList.ShowSecondaryText(false)
 
 	// The Load Game browser lists every save (player-named + autosave) and handles
@@ -113,7 +118,7 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 	footerTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
-		SetText("[#8b949e]Arrow keys · Enter[-]")
+		SetText("[gray]Arrow keys · Enter[-]")
 
 	// ── Menu panel ────────────────────────────────────────────────────────────
 	menuPanel := tview.NewFlex().SetDirection(tview.FlexRow)
@@ -129,11 +134,11 @@ func CreateSplashPage(app *tview.Application, pages *tview.Pages, engine *game.G
 		AddItem(mainList, 9, 0, true).
 		AddItem(versionTV, 1, 0, false).
 		AddItem(footerTV, 1, 0, false)
-	menuPanel.
-		SetBorder(true).
-		SetBorderColor(tcell.ColorGold).
-		SetTitle(" AgeForge ").
-		SetTitleColor(tcell.ColorGold)
+	menuPanel.SetBorder(true).SetTitle(" AgeForge ")
+	theme.Track(func() {
+		menuPanel.SetBorderColor(theme.Color(theme.RoleAccent)).
+			SetTitleColor(theme.Color(theme.RoleAccent))
+	})
 
 	// Centre the menu horizontally (fixed width)
 	menuRow := tview.NewFlex().SetDirection(tview.FlexColumn).
@@ -173,7 +178,7 @@ func showWipeConfirmation(app *tview.Application, pages *tview.Pages, engine *ga
 				pages.AddPage("splash", newSplash, true, true)
 			}
 		})
-	modal.SetBackgroundColor(tcell.ColorDarkRed)
+	modal.SetBackgroundColor(theme.Color(theme.RoleNegative))
 	pages.AddPage("wipe_confirm", modal, true, true)
 }
 
@@ -220,7 +225,7 @@ func showAccountWipeConfirmation(app *tview.Application, pages *tview.Pages, eng
 				showAccountWipeTypeGate(app, pages, engine, name, currentVersion)
 			}
 		})
-	step1.SetBackgroundColor(tcell.ColorDarkRed)
+	step1.SetBackgroundColor(theme.Color(theme.RoleNegative))
 	pages.AddPage(accountWipeConfirmPage, step1, true, true)
 }
 
@@ -237,21 +242,21 @@ func showAccountWipeTypeGate(app *tview.Application, pages *tview.Pages, engine 
 		SetLabel("Account name: ").
 		SetFieldWidth(40).
 		// Dark slate field so white text stays legible on the dark-red modal.
-		SetFieldBackgroundColor(tcell.NewRGBColor(48, 54, 61)).
-		SetFieldTextColor(tcell.ColorWhite)
+		SetFieldBackgroundColor(theme.Color(theme.RoleSelection)).
+		SetFieldTextColor(theme.Color(theme.RoleText))
 
 	promptTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
 		SetText(fmt.Sprintf(
-			"[white]Type this name exactly to confirm:[-]\n[yellow::b]%s[-]\n[#f0a0a0]This permanently deletes your account. It CANNOT be undone.[-]",
+			"[white]Type this name exactly to confirm:[-]\n[yellow::b]%s[-]\n[red]This permanently deletes your account. It CANNOT be undone.[-]",
 			expectedName,
 		))
 
 	hintTV := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
-		SetText("[#f0a0a0]Enter: confirm  ·  Esc: cancel[-]")
+		SetText("[red]Enter: confirm  ·  Esc: cancel[-]")
 
 	// abort removes the type gate and returns to the splash without wiping.
 	abort := func() {
@@ -296,12 +301,12 @@ func showAccountWipeTypeGate(app *tview.Application, pages *tview.Pages, engine 
 	// Paint every interior primitive dark-red so the modal reads as one solid
 	// danger panel, not alternating dark/red bands. The input keeps its slate
 	// field bar (set above) for legibility; only its surrounding box goes red.
-	promptTV.SetBackgroundColor(tcell.ColorDarkRed)
-	errTV.SetBackgroundColor(tcell.ColorDarkRed)
-	hintTV.SetBackgroundColor(tcell.ColorDarkRed)
-	input.SetBackgroundColor(tcell.ColorDarkRed)
+	promptTV.SetBackgroundColor(theme.Color(theme.RoleNegative))
+	errTV.SetBackgroundColor(theme.Color(theme.RoleNegative))
+	hintTV.SetBackgroundColor(theme.Color(theme.RoleNegative))
+	input.SetBackgroundColor(theme.Color(theme.RoleNegative))
 	// Spacers match so the gaps between rows are the same dark-red.
-	spacer := func() *tview.Box { return tview.NewBox().SetBackgroundColor(tcell.ColorDarkRed) }
+	spacer := func() *tview.Box { return tview.NewBox().SetBackgroundColor(theme.Color(theme.RoleNegative)) }
 	inner := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(promptTV, 3, 0, false).
 		AddItem(spacer(), 1, 0, false).
@@ -312,9 +317,9 @@ func showAccountWipeTypeGate(app *tview.Application, pages *tview.Pages, engine 
 		AddItem(hintTV, 1, 0, false)
 	inner.SetBorder(true).
 		SetTitle(" Confirm Account Wipe ").
-		SetTitleColor(tcell.ColorWhite).
-		SetBorderColor(tcell.ColorWhite)
-	inner.SetBackgroundColor(tcell.ColorDarkRed)
+		SetTitleColor(theme.Color(theme.RoleText)).
+		SetBorderColor(theme.Color(theme.RoleText))
+	inner.SetBackgroundColor(theme.Color(theme.RoleNegative))
 
 	// Width fits the longest warning line ("…It CANNOT be undone."). Height
 	// covers 9 content rows (3 prompt + 3 spacers + input + err + hint) + 2

--- a/ui/tab_economy.go
+++ b/ui/tab_economy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/espresso20/ageforge/config"
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // cultureThresholds defines the culture breakpoints at which rewards unlock.
@@ -34,11 +35,11 @@ var cultureThresholdLabels = []string{
 }
 
 // cultureProgressBar returns a 10-char wide bar using ▓/░ characters.
-// Filled portion uses BarFillColor (purple), empty portion uses BarEmptyColor (dark gray).
+// Filled portion uses BarFillColor (Accent role), empty uses BarEmptyColor (Dim role).
 func cultureProgressBar(current, max float64) string {
 	const width = 10
 	if max <= 0 {
-		return "[" + BarEmptyColor + "]" + strings.Repeat("░", width) + "[-]"
+		return BarEmptyColor() + strings.Repeat("░", width) + "[-]"
 	}
 	ratio := current / max
 	if ratio > 1 {
@@ -49,7 +50,7 @@ func cultureProgressBar(current, max float64) string {
 	}
 	filled := int(ratio * float64(width))
 	empty := width - filled
-	return "[" + BarFillColor + "]" + strings.Repeat("▓", filled) + "[" + BarEmptyColor + "]" + strings.Repeat("░", empty) + "[-]"
+	return BarFillColor() + strings.Repeat("▓", filled) + BarEmptyColor() + strings.Repeat("░", empty) + "[-]"
 }
 
 // formatCultureRow builds the culture resource row string.
@@ -152,13 +153,20 @@ func NewEconomyTab() *EconomyTab {
 	t := &EconomyTab{}
 
 	t.resourceTV = tview.NewTextView().SetDynamicColors(true)
-	t.resourceTV.SetBorder(true).SetTitle(" Resources ").SetTitleColor(ColorResource)
+	t.resourceTV.SetBorder(true).SetTitle(" Resources ")
 
 	t.buildingTV = tview.NewTextView().SetDynamicColors(true).SetScrollable(true)
-	t.buildingTV.SetBorder(true).SetTitle(" Buildings ").SetTitleColor(ColorBuilding)
+	t.buildingTV.SetBorder(true).SetTitle(" Buildings ")
 
 	t.constructionTV = tview.NewTextView().SetDynamicColors(true)
-	t.constructionTV.SetBorder(true).SetTitle(" Under Construction ").SetTitleColor(ColorBuilding)
+	t.constructionTV.SetBorder(true).SetTitle(" Under Construction ")
+
+	// Persistent tab chrome: enroll titles so a live theme switch restyles them.
+	theme.Track(func() {
+		t.resourceTV.SetTitleColor(theme.Color(theme.RoleLabel))
+		t.buildingTV.SetTitleColor(theme.Color(theme.RoleHighlight))
+		t.constructionTV.SetTitleColor(theme.Color(theme.RoleHighlight))
+	})
 
 	// Left: resources (tall) + under construction (compact), Right: buildings
 	t.leftCol = tview.NewFlex().SetDirection(tview.FlexRow).
@@ -365,11 +373,11 @@ var domainToLabel = map[string]string{
 }
 
 // workerAssignBar returns a 10-char ▓/░ bar for assigned/capacity.
-// Filled portion uses BarFillColor (purple), empty portion uses BarEmptyColor (dark gray).
+// Filled portion uses BarFillColor (Accent role), empty uses BarEmptyColor (Dim role).
 func workerAssignBar(assigned, capacity int) string {
 	const width = 10
 	if capacity <= 0 {
-		return "[" + BarEmptyColor + "]" + strings.Repeat("░", width) + "[-]"
+		return BarEmptyColor() + strings.Repeat("░", width) + "[-]"
 	}
 	ratio := float64(assigned) / float64(capacity)
 	if ratio > 1 {
@@ -380,7 +388,7 @@ func workerAssignBar(assigned, capacity int) string {
 	}
 	filled := int(ratio * float64(width))
 	empty := width - filled
-	return "[" + BarFillColor + "]" + strings.Repeat("▓", filled) + "[" + BarEmptyColor + "]" + strings.Repeat("░", empty) + "[-]"
+	return BarFillColor() + strings.Repeat("▓", filled) + BarEmptyColor() + strings.Repeat("░", empty) + "[-]"
 }
 
 // resourceBar returns a width-char bar using █/░ characters with color based on fill level.
@@ -468,7 +476,7 @@ func (t *EconomyTab) refreshUnderConstruction(state game.GameState) {
 					filled = barWidth
 				}
 			}
-			bar := "[" + BarFillColor + "]" + strings.Repeat("█", filled) + "[" + BarEmptyColor + "]" + strings.Repeat("░", barWidth-filled) + "[-]"
+			bar := BarFillColor() + strings.Repeat("█", filled) + BarEmptyColor() + strings.Repeat("░", barWidth-filled) + "[-]"
 			fmt.Fprintf(&sb, " [yellow]%-22s[-] %s [gray]%d ticks[-]\n", label, bar, g.minTicks)
 		}
 	}

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -1,31 +1,52 @@
 package ui
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"github.com/gdamore/tcell/v2"
 
-// Color theme
-var (
-	ColorBg       = tcell.ColorDefault
-	ColorFg       = tcell.ColorWhite
-	ColorTitle    = tcell.ColorGold
-	ColorAccent   = tcell.ColorDodgerBlue
-	ColorSuccess  = tcell.ColorGreen
-	ColorWarning  = tcell.ColorYellow
-	ColorError    = tcell.ColorRed
-	ColorDim      = tcell.ColorGray
-	ColorResource = tcell.ColorTeal
-	ColorBuilding = tcell.ColorOrangeRed
-	ColorVillager = tcell.ColorPurple
-	ColorAge      = tcell.ColorGold
+	"github.com/espresso20/ageforge/theme"
 )
 
-// BarFillColor is the tview color tag used for filled progress bar segments.
-// Uses MediumPurple (#9370DB) to match the game's purple accent theme.
-const BarFillColor = "#9370DB"
+// Color theme — bridge over the theme package (design-and-architecture/theming.md
+// §3.3). These were standalone tcell.Color globals; they are now thin accessors
+// over theme.Color(role) so every call site keeps compiling but pulls the ACTIVE
+// theme's color and tracks live theme switches. Under Forge (the default) they
+// resolve to the game's current palette.
+//
+// Role mapping (a deliberate flattening of the old ad-hoc palette onto the ~9-role
+// model): the prior globals carried five distinct accent-ish hues (gold title,
+// DodgerBlue accent, teal resource, orange-red building, purple worker). The role
+// model collapses those to Accent/Label/Highlight — so under non-Forge themes those
+// chrome titles tint coherently instead of being one-off colors. See §3.1/§3.3.
+func ColorBg() tcell.Color       { return theme.Color(theme.RoleBackground) }
+func ColorFg() tcell.Color       { return theme.Color(theme.RoleText) }
+func ColorTitle() tcell.Color    { return theme.Color(theme.RoleAccent) }
+func ColorAccent() tcell.Color   { return theme.Color(theme.RoleLabel) }
+func ColorSuccess() tcell.Color  { return theme.Color(theme.RolePositive) }
+func ColorWarning() tcell.Color  { return theme.Color(theme.RoleHighlight) }
+func ColorError() tcell.Color    { return theme.Color(theme.RoleNegative) }
+func ColorDim() tcell.Color      { return theme.Color(theme.RoleDim) }
+func ColorResource() tcell.Color { return theme.Color(theme.RoleLabel) }
+func ColorBuilding() tcell.Color { return theme.Color(theme.RoleHighlight) }
+func ColorVillager() tcell.Color { return theme.Color(theme.RoleAccent) }
+func ColorAge() tcell.Color      { return theme.Color(theme.RoleAccent) }
 
-// BarEmptyColor is the tview color tag for empty bar segments.
-const BarEmptyColor = "#444444"
+// BarFillColor is the tview color tag for filled progress-bar segments. Formerly a
+// fixed "#9370DB" literal; now role-derived (Accent) and emitted as a live hex tag
+// so bars retint with the theme. theming.md §3.4.
+func BarFillColor() string { return theme.Tag(theme.RoleAccent) }
 
-// AgePalette defines the color theme for an age era
+// BarEmptyColor is the tview color tag for empty bar segments. Role-derived from
+// Dim (was a fixed "#444444"). theming.md §3.4.
+func BarEmptyColor() string { return theme.Tag(theme.RoleDim) }
+
+// AgePalette defines the color theme for an age era.
+//
+// note: retained as data only. The age-palette globals used to be a competing
+// color authority that mutated the chrome colors as the player advanced ages —
+// touching chrome but never the inline [gold]/[cyan]/… body tags, which is why an
+// age advance recolored borders but not text. That half-measure is subsumed by the
+// theme package. ApplyAgePalette is now a no-op; this data is kept for Phase 4,
+// which reframes it as the optional epoch-adaptive Adaptive theme (theming.md §9).
 type AgePalette struct {
 	Title    tcell.Color
 	Accent   tcell.Color
@@ -34,7 +55,7 @@ type AgePalette struct {
 	Dim      tcell.Color
 }
 
-// AgePalettes maps age keys to their color palette
+// AgePalettes maps age keys to their color palette. Inert until §9 (Phase 4).
 var AgePalettes = map[string]AgePalette{
 	// Primitive/Stone: earthy greens and browns
 	"primitive_age": {tcell.ColorDarkGreen, tcell.ColorOlive, tcell.ColorTeal, tcell.ColorSaddleBrown, tcell.ColorDimGray},
@@ -69,17 +90,15 @@ var AgePalettes = map[string]AgePalette{
 	"transcendent_age": {tcell.ColorGold, tcell.ColorWhite, tcell.ColorLightGoldenrodYellow, tcell.ColorGold, tcell.ColorLightGray},
 }
 
-// ApplyAgePalette sets global color variables based on the current age
+// ApplyAgePalette is intentionally a no-op (theming.md §3.3, §9).
+//
+// It used to mutate the chrome color globals on every age advance, fighting the
+// theme as a second color authority. The theme package is now the single source of
+// truth, so this does nothing. Callers (the dashboard age-advance path) are left in
+// place; Phase 4 reframes the age-palette idea as the optional epoch-adaptive
+// "Adaptive" theme that retints role colors through the theme package instead.
 func ApplyAgePalette(ageKey string) {
-	p, ok := AgePalettes[ageKey]
-	if !ok {
-		return
-	}
-	ColorTitle = p.Title
-	ColorAccent = p.Accent
-	ColorResource = p.Resource
-	ColorBuilding = p.Building
-	ColorDim = p.Dim
+	_ = ageKey
 }
 
 // ASCII art for splash screen

--- a/ui/theme_account.go
+++ b/ui/theme_account.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
+)
+
+// This file is the Phase-2 bridge between the leaf `theme` package (pure
+// presentation, no game dependency) and the `game` account layer (theming.md §6,
+// §10). The bridge lives in `ui` precisely so `theme` stays importable without
+// pulling in the engine: ui imports both and wires them together here.
+//
+// Two concerns live here:
+//   1. applyAccountTheme — read the account's persisted active theme at boot and
+//      apply it (routed through the unlock gate) before the first Draw.
+//   2. themeAvailable — the unlock-gating predicate. It is a no-op gate today (all
+//      shipped themes are accessible or Forge), but the picker, boot-apply, and the
+//      `theme <key>` command all route through it so Phase 3's milestone-gated
+//      flavor themes gate correctly with no further wiring.
+
+// themeUnavailableMsg is the player-facing refusal when a theme isn't unlocked yet
+// (a locked flavor theme in Phase 3). No theme is unavailable today.
+const themeUnavailableMsg = "that theme isn't unlocked yet"
+
+// themeAvailable reports whether theme t may be selected/applied for the given
+// account. The policy (theming.md §4/§5/§6):
+//   - Accessible themes are NEVER gated — always available.
+//   - The default theme (Forge) is always available.
+//   - Any other (flavor) theme is available only if the account has unlocked it.
+//
+// acct may be nil — the game must run accountless. With no account, only the
+// always-available set (Accessible + Forge) is available; flavor themes stay locked
+// until an account exists to own the unlock. Since every theme shipped today is
+// Accessible or Forge, this returns true for all of them now.
+func themeAvailable(acct *game.Account, t theme.Theme) bool {
+	if t.Accessible || t.Key == theme.DefaultKey {
+		return true
+	}
+	return acct != nil && acct.HasTheme(t.Key)
+}
+
+// applyAccountTheme resolves and applies the account's persisted active theme at
+// startup (theming.md §6): it must run once, before the first Draw, so the splash
+// already wears the chosen theme.
+//
+// Resolution is defensive — any of these fall back to the default (Forge) without
+// erroring, so a brand-new/wiped account (ActiveTheme == "") or a stale/unknown
+// stored key never crashes and never strands the player on an inapplicable theme:
+//   - no engine / no account → leave the default in place.
+//   - stored key is empty → leave the default in place.
+//   - stored key is unknown to the registry → fall back to default.
+//   - stored theme exists but is NOT available to this account (a locked flavor
+//     theme; impossible today) → fall back to default.
+//
+// It applies via theme.SetActive + theme.Restyle. Any redraw is the caller's job;
+// at boot the first Draw happens after setup, so no explicit redraw is needed here.
+func applyAccountTheme(engine *game.GameEngine) {
+	if engine == nil {
+		applyDefaultTheme()
+		return
+	}
+	acct := engine.Account()
+	if acct == nil {
+		applyDefaultTheme()
+		return
+	}
+	key := acct.ActiveTheme()
+	if key == "" {
+		applyDefaultTheme()
+		return
+	}
+	t, ok := theme.ByKey(key)
+	if !ok || !themeAvailable(acct, t) {
+		applyDefaultTheme()
+		return
+	}
+	_ = theme.SetActive(t.Key)
+	theme.Restyle()
+}
+
+// applyDefaultTheme pins the active theme to the default (Forge). Used as the
+// fallback when no account theme applies, and to reset a freshly-created/wiped
+// account onto its own (empty → default) theme rather than inheriting a previewed
+// or previous one (theming.md §6).
+func applyDefaultTheme() {
+	_ = theme.SetActive(theme.DefaultKey)
+	theme.Restyle()
+}

--- a/ui/theme_account.go
+++ b/ui/theme_account.go
@@ -33,6 +33,16 @@ const themeUnavailableMsg = "that theme isn't unlocked yet"
 // until an account exists to own the unlock. Since every theme shipped today is
 // Accessible or Forge, this returns true for all of them now.
 func themeAvailable(acct *game.Account, t theme.Theme) bool {
+	// Dev affordance: with the developer console active (Ctrl+K passphrase),
+	// every theme is unlocked for preview — the picker drops the 🔒, `theme
+	// <key>` accepts any theme, and nothing is written to the account's unlock
+	// set. It self-kills the moment dev mode is off (gating returns), matching
+	// /god's spirit. Active-theme persistence still applies; if a dev-previewed
+	// flavor theme is left active and dev mode is later off, applyAccountTheme
+	// falls back to Forge (it's no longer available) — by design.
+	if game.DevModeActive {
+		return true
+	}
 	if t.Accessible || t.Key == theme.DefaultKey {
 		return true
 	}

--- a/ui/theme_account_test.go
+++ b/ui/theme_account_test.go
@@ -182,3 +182,29 @@ func TestThemeAvailableGate(t *testing.T) {
 		t.Error("a flavor theme should be available once the account unlocks it")
 	}
 }
+
+// TestThemeAvailableGate_DevBypass verifies the developer-console affordance:
+// while game.DevModeActive is set, every theme is available (for preview),
+// including a locked flavor theme on an account that has not unlocked it; and
+// the bypass disappears the moment dev mode is off.
+func TestThemeAvailableGate_DevBypass(t *testing.T) {
+	prev := game.DevModeActive
+	t.Cleanup(func() { game.DevModeActive = prev })
+
+	locked := theme.Theme{Key: "fake_locked_flavor", Name: "Fake", Accessible: false}
+
+	game.DevModeActive = false
+	if themeAvailable(nil, locked) {
+		t.Fatal("precondition: locked theme must be gated when dev mode is off")
+	}
+
+	game.DevModeActive = true
+	if !themeAvailable(nil, locked) {
+		t.Error("dev mode should unlock every theme for preview, even accountless")
+	}
+
+	game.DevModeActive = false
+	if themeAvailable(nil, locked) {
+		t.Error("the dev bypass must vanish once dev mode is off")
+	}
+}

--- a/ui/theme_account_test.go
+++ b/ui/theme_account_test.go
@@ -1,0 +1,184 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
+)
+
+// Phase-2 bridge tests (theming.md §6): boot-apply, account-wide persistence, and
+// the unlock gate. The active theme is process-global state, so every case that
+// switches it registers restoreForge (theme_picker_test.go) to reset to the default
+// in cleanup, keeping the suite order-independent.
+
+// newIsolatedAccount mints a named account whose data root is an isolated temp dir,
+// so SetActiveTheme writes a throwaway account.json instead of clobbering a real
+// ./data/account.json. The temp dir + override are torn down via t.Cleanup. Returns
+// a real, established account wired through the engine in the persist tests.
+func newIsolatedAccount(t *testing.T) *game.Account {
+	t.Helper()
+	restore := game.SetDataDirForTest(t.TempDir())
+	t.Cleanup(restore)
+	acct, err := game.CreateNamedAccount("Theme Test Empire")
+	if err != nil {
+		t.Fatalf("CreateNamedAccount: %v", err)
+	}
+	return acct
+}
+
+// TestCmdThemePersistsToAccount covers the §6 CLI-persist path: `theme <key>`
+// switches the active theme AND records it on the account, so a CLI switch survives
+// saves. Uses an isolated-data-dir account wired through a real engine.
+func TestCmdThemePersistsToAccount(t *testing.T) {
+	restoreForge(t)
+	const target = "high_contrast"
+	if _, ok := theme.ByKey(target); !ok {
+		t.Fatalf("precondition: theme %q not registered", target)
+	}
+
+	acct := newIsolatedAccount(t)
+	engine := game.NewGameEngine()
+	engine.SetAccount(acct)
+
+	res := cmdTheme([]string{target}, engine)
+	if res.Type != "success" {
+		t.Fatalf("theme %s: got %q %q, want success", target, res.Type, res.Message)
+	}
+	if got := theme.Active().Key; got != target {
+		t.Errorf("active theme = %q after switch, want %q", got, target)
+	}
+	if got := engine.Account().ActiveTheme(); got != target {
+		t.Errorf("account ActiveTheme = %q after `theme %s`, want %q (CLI switch must persist)", got, target, target)
+	}
+}
+
+// TestCmdThemeAccountlessDoesNotPanic confirms the persist path nil-guards: with no
+// account wired, `theme <key>` still switches and reports success, it just doesn't
+// persist. The game must run accountless.
+func TestCmdThemeAccountlessDoesNotPanic(t *testing.T) {
+	restoreForge(t)
+	engine := game.NewGameEngine() // no SetAccount → Account() == nil
+
+	res := cmdTheme([]string{"deuteranopia"}, engine)
+	if res.Type != "success" {
+		t.Errorf("accountless theme switch: got %q %q, want success", res.Type, res.Message)
+	}
+	if got := theme.Active().Key; got != "deuteranopia" {
+		t.Errorf("active theme = %q, want deuteranopia", got)
+	}
+}
+
+// TestApplyAccountThemeAppliesStored covers the §6 boot path: a stored active theme
+// is read off the account and applied before the first Draw. Set the account's
+// active theme to a non-default, call applyAccountTheme, and assert the process-
+// global active theme matches.
+func TestApplyAccountThemeAppliesStored(t *testing.T) {
+	restoreForge(t)
+	const stored = "high_contrast"
+
+	acct := newIsolatedAccount(t)
+	if err := acct.SetActiveTheme(stored); err != nil {
+		t.Fatalf("SetActiveTheme: %v", err)
+	}
+	engine := game.NewGameEngine()
+	engine.SetAccount(acct)
+
+	applyAccountTheme(engine)
+
+	if got := theme.Active().Key; got != stored {
+		t.Errorf("applyAccountTheme: active = %q, want stored %q", got, stored)
+	}
+}
+
+// TestApplyAccountThemeFallsBackToForge covers the §6 defensive fallbacks: an empty
+// stored key (a brand-new account) and an unknown stored key both resolve to the
+// default (Forge), never crashing. nil engine / nil account also fall back.
+func TestApplyAccountThemeFallsBackToForge(t *testing.T) {
+	restoreForge(t)
+
+	// Start from a non-default theme so a real fallback to Forge is observable
+	// (rather than already sitting on the default).
+	if err := theme.SetActive("deuteranopia"); err != nil {
+		t.Fatalf("setup SetActive(deuteranopia): %v", err)
+	}
+
+	// Empty stored key (fresh account) → Forge.
+	acct := newIsolatedAccount(t) // CreateNamedAccount leaves ActiveTheme == ""
+	engine := game.NewGameEngine()
+	engine.SetAccount(acct)
+	applyAccountTheme(engine)
+	if got := theme.Active().Key; got != theme.DefaultKey {
+		t.Errorf("empty stored key: active = %q, want default %q", got, theme.DefaultKey)
+	}
+
+	// Unknown stored key → Forge (and no crash).
+	if err := theme.SetActive("deuteranopia"); err != nil {
+		t.Fatalf("re-setup SetActive(deuteranopia): %v", err)
+	}
+	if err := acct.SetActiveTheme("no_such_theme_zzz"); err != nil {
+		t.Fatalf("SetActiveTheme(unknown): %v", err)
+	}
+	applyAccountTheme(engine)
+	if got := theme.Active().Key; got != theme.DefaultKey {
+		t.Errorf("unknown stored key: active = %q, want default %q", got, theme.DefaultKey)
+	}
+
+	// nil engine → Forge, no panic.
+	if err := theme.SetActive("deuteranopia"); err != nil {
+		t.Fatalf("re-setup SetActive(deuteranopia): %v", err)
+	}
+	applyAccountTheme(nil)
+	if got := theme.Active().Key; got != theme.DefaultKey {
+		t.Errorf("nil engine: active = %q, want default %q", got, theme.DefaultKey)
+	}
+}
+
+// TestThemeAvailableGate covers the unlock-gating predicate (theming.md §4/§5):
+//   - Accessible themes: always available (never gated), even accountless.
+//   - The default theme (Forge): always available.
+//   - A flavor (non-accessible, non-default) theme: available only if the account
+//     has unlocked it; locked otherwise, and locked when accountless.
+//
+// All shipped themes are Accessible/Forge today, so a hypothetical locked flavor key
+// is simulated via a synthetic Theme literal (the registry is unexported; this keeps
+// the test from depending on a not-yet-shipped Phase-3 theme).
+func TestThemeAvailableGate(t *testing.T) {
+	forge, ok := theme.ByKey("forge")
+	if !ok {
+		t.Fatal("precondition: forge not registered")
+	}
+	deut, ok := theme.ByKey("deuteranopia")
+	if !ok {
+		t.Fatal("precondition: deuteranopia not registered")
+	}
+	// Synthetic locked flavor theme: not accessible, not the default key.
+	fakeLocked := theme.Theme{Key: "fake_locked_flavor", Name: "Fake", Accessible: false}
+
+	// Accessible + Forge are available regardless of account (incl. nil).
+	if !themeAvailable(nil, forge) {
+		t.Error("forge should be available accountless (it is the default)")
+	}
+	if !themeAvailable(nil, deut) {
+		t.Error("accessible theme should be available accountless")
+	}
+
+	acct := newIsolatedAccount(t)
+	if !themeAvailable(acct, forge) || !themeAvailable(acct, deut) {
+		t.Error("forge + accessible themes must always be available with an account")
+	}
+
+	// Flavor theme: locked until the account unlocks it; locked when accountless.
+	if themeAvailable(nil, fakeLocked) {
+		t.Error("a flavor theme should be locked accountless")
+	}
+	if themeAvailable(acct, fakeLocked) {
+		t.Error("a flavor theme should be locked before the account unlocks it")
+	}
+	if _, err := acct.UnlockTheme(fakeLocked.Key); err != nil {
+		t.Fatalf("UnlockTheme: %v", err)
+	}
+	if !themeAvailable(acct, fakeLocked) {
+		t.Error("a flavor theme should be available once the account unlocks it")
+	}
+}

--- a/ui/theme_picker.go
+++ b/ui/theme_picker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
+	"github.com/espresso20/ageforge/game"
 	"github.com/espresso20/ageforge/theme"
 )
 
@@ -39,6 +40,12 @@ type themePicker struct {
 	app   *tview.Application
 	pages *tview.Pages
 
+	// engine is the bridge to the account layer (theming.md §6). It may be nil
+	// (accountless play / tests); every account touch nil-guards both the engine
+	// and engine.Account(). It also drives the unlock gate (themeAvailable) so
+	// Phase-3 locked flavor themes can't be previewed/confirmed.
+	engine *game.GameEngine
+
 	root   *tview.Flex
 	list   *tview.List
 	detail *tview.TextView
@@ -65,10 +72,15 @@ type themePicker struct {
 // Esc can revert it; Enter keeps the previewed theme.
 //
 // returnPage names the page to return to on confirm (Enter) or cancel (Esc).
-func CreateThemePickerPage(app *tview.Application, pages *tview.Pages, returnPage string) tview.Primitive {
+//
+// engine bridges to the account layer for persistence + unlock gating (theming.md
+// §6); it may be nil for accountless play/tests, in which case confirm simply
+// doesn't persist and every theme in the always-available set stays selectable.
+func CreateThemePickerPage(app *tview.Application, pages *tview.Pages, engine *game.GameEngine, returnPage string) tview.Primitive {
 	p := &themePicker{
 		app:         app,
 		pages:       pages,
+		engine:      engine,
 		returnPage:  returnPage,
 		themes:      theme.All(),
 		originalKey: theme.Active().Key,
@@ -96,7 +108,7 @@ func CreateThemePickerPage(app *tview.Application, pages *tview.Pages, returnPag
 	})
 	p.list.ShowSecondaryText(false)
 	for _, th := range p.themes {
-		p.list.AddItem(themeRowLabel(th, p.originalKey), "", 0, nil)
+		p.list.AddItem(themeRowLabel(th, p.originalKey, themeAvailable(p.account(), th)), "", 0, nil)
 	}
 
 	// ── Detail pane ──────────────────────────────────────────────────────────
@@ -196,13 +208,41 @@ func (p *themePicker) handleKey(event *tcell.EventKey) *tcell.EventKey {
 	return event
 }
 
-// confirm keeps the currently-previewed theme (it is already applied) and returns
-// to the page the picker was opened from.
+// account returns the picker's account, or nil when accountless. Centralizes the
+// engine→account nil-guarding the persist/gate paths share.
+func (p *themePicker) account() *game.Account {
+	if p.engine == nil {
+		return nil
+	}
+	return p.engine.Account()
+}
+
+// confirm keeps the currently-previewed theme and persists it account-wide
+// (theming.md §6). The previewed theme is already applied process-locally via the
+// live preview; here we make it durable.
+//
+// Unlock gate (theming.md §4/§5): if the highlighted theme isn't available to this
+// account (a locked flavor theme — impossible today since all shipped themes are
+// Accessible/Forge), confirming it would be wrong, so we revert to the open-time
+// theme instead of keeping/persisting the locked preview. Preview-on-highlight is
+// still allowed to show it; only Enter is gated.
 func (p *themePicker) confirm() {
-	// Phase 2 seam: persist the chosen theme account-wide here. The theme is
-	// already applied process-locally via the live preview; Phase 2 drops in:
-	//   account.SetActiveTheme(theme.Active().Key)
-	// (account-wide persistence is out of scope for Phase 1c — see theming.md §6).
+	idx := p.list.GetCurrentItem()
+	if idx >= 0 && idx < len(p.themes) {
+		th := p.themes[idx]
+		if !themeAvailable(p.account(), th) {
+			// Locked: don't keep the preview. Fall back to the open-time theme and
+			// don't persist. (No theme is locked today; this is the Phase-3 path.)
+			p.cancel()
+			return
+		}
+		// Persist the chosen theme account-wide. Nil-guarded for accountless play;
+		// the Save error is non-fatal (theme is a preference, not empire state) so we
+		// keep the applied theme regardless and let the account layer log/return it.
+		if acct := p.account(); acct != nil {
+			_ = acct.SetActiveTheme(theme.Active().Key)
+		}
+	}
 	p.close()
 }
 
@@ -228,16 +268,24 @@ func (p *themePicker) close() {
 // ── Pure helpers (formatting) ───────────────────────────────────────────────
 
 // themeRowLabel renders one list row: the theme name, a "(current)" marker on the
-// theme that was active when the picker opened, and an accessible tag if so. The
+// theme that was active when the picker opened, an accessible tag if so, and a
+// "locked" marker when the theme isn't available to this account. The current
 // marker tracks the open-time active theme (not the live preview) so the row stays
 // stable as the player arrows through previews.
-func themeRowLabel(t theme.Theme, activeKey string) string {
+//
+// available routes through themeAvailable (theming.md §4/§5): locked flavor themes
+// still LIST (and can preview on highlight) but are visually marked and refused on
+// confirm. No theme is locked today, so this renders the plain row for all of them.
+func themeRowLabel(t theme.Theme, activeKey string, available bool) string {
 	label := t.Name
 	if t.Key == activeKey {
 		label = "[gold]● " + t.Name + " (current)[-]"
 	}
 	if t.Accessible {
 		label += "   [cyan]accessible[-]"
+	}
+	if !available {
+		label += "   [gray]🔒 locked[-]"
 	}
 	return label
 }

--- a/ui/theme_picker.go
+++ b/ui/theme_picker.go
@@ -140,12 +140,14 @@ func CreateThemePickerPage(app *tview.Application, pages *tview.Pages, engine *g
 	// UI. SetChangedFunc fires on every interactive selection move, so it both
 	// applies the theme AND forces a redraw so the player sees the retint at once.
 	p.list.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
+		// Apply the highlighted theme for real (remap + restyle) so the whole UI
+		// retints to it. This callback runs on the tview MAIN goroutine, where tview
+		// redraws automatically after the input event — so the live retint shows
+		// without an explicit redraw. We must NOT call QueueUpdateDraw here: it blocks
+		// until the main loop drains its update queue, but we ARE the main loop
+		// mid-callback, so it would deadlock the entire app (frozen, no keys). This
+		// was the freeze-on-arrow bug (Trello TCGiSWYX).
 		p.applyAndDetail(index)
-		if p.app != nil {
-			// Retint the whole UI live — the picker is itself a sample of the running
-			// theme (theming.md §7). QueueUpdateDraw is safe from the tview goroutine.
-			p.app.QueueUpdateDraw(func() {})
-		}
 	})
 	p.list.SetInputCapture(p.handleKey)
 
@@ -173,10 +175,11 @@ func (p *themePicker) currentIndex() int {
 }
 
 // applyAndDetail applies the theme at index for real (remap + restyle) and
-// refreshes the detail pane. It does NOT queue a redraw — that's the caller's job,
-// because the construction-time seed runs before the event loop and would block on
-// QueueUpdateDraw, while the interactive SetChangedFunc path does want a redraw.
-// Out-of-range is a no-op.
+// refreshes the detail pane. It deliberately does NOT redraw: both callers run on
+// the main goroutine (the construction-time seed before the loop, and the
+// SetChangedFunc live preview during it), and tview redraws automatically after the
+// input event — so an explicit QueueUpdateDraw here would be redundant at best and a
+// whole-app deadlock at worst (Trello TCGiSWYX). Out-of-range is a no-op.
 func (p *themePicker) applyAndDetail(index int) {
 	if index < 0 || index >= len(p.themes) {
 		return
@@ -252,9 +255,10 @@ func (p *themePicker) cancel() {
 	if theme.Active().Key != p.originalKey {
 		_ = theme.SetActive(p.originalKey)
 		theme.Restyle()
-		if p.app != nil {
-			p.app.QueueUpdateDraw(func() {})
-		}
+		// No QueueUpdateDraw: cancel() runs from the key handler on the main
+		// goroutine, where QueueUpdateDraw deadlocks (see SetChangedFunc above /
+		// Trello TCGiSWYX). close() switches pages and tview redraws after the event,
+		// so the reverted theme paints automatically.
 	}
 	p.close()
 }

--- a/ui/theme_picker.go
+++ b/ui/theme_picker.go
@@ -1,0 +1,302 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/espresso20/ageforge/theme"
+)
+
+// themePickerPage is the page name under which the theme picker is registered on
+// the root Pages. Added on demand (from the splash menu or a bare `theme`
+// command) and removed on confirm/cancel so it's always rebuilt fresh.
+const themePickerPage = "theme_picker"
+
+// swatchRoles is the role set rendered as colored blocks in the detail pane, in
+// display order. Selection backs a row rather than text, but we show it too so the
+// player can see the highlight color a theme will use. Matches the §7 spec set.
+var swatchRoles = []struct {
+	role  theme.Role
+	label string
+}{
+	{theme.RoleBackground, "Background"},
+	{theme.RoleText, "Text"},
+	{theme.RoleAccent, "Accent"},
+	{theme.RolePositive, "Positive"},
+	{theme.RoleNegative, "Negative"},
+	{theme.RoleHighlight, "Highlight"},
+	{theme.RoleDim, "Dim"},
+	{theme.RoleSelection, "Selection"},
+}
+
+// themePicker holds the widgets and live state for the theme picker screen. It is
+// modeled on the load-game browser (load_game.go): a list on the left, a detail
+// pane on the right, and live preview wired through SetChangedFunc.
+type themePicker struct {
+	app   *tview.Application
+	pages *tview.Pages
+
+	root   *tview.Flex
+	list   *tview.List
+	detail *tview.TextView
+
+	themes []theme.Theme // rows, 1:1 with list items (theme.All() order)
+
+	// returnPage is the page to return to on confirm/cancel ("splash" from the
+	// menu, "dashboard" when opened mid-game).
+	returnPage string
+
+	// originalKey is the theme that was active when the picker opened. Esc reverts
+	// to it; Enter keeps whatever is currently previewed (it's already applied).
+	originalKey string
+}
+
+// CreateThemePickerPage builds the full-screen theme picker and returns its root
+// primitive. The caller registers it (pages.AddPage(themePickerPage, ...)) and
+// focuses the returned primitive. The screen is self-contained: all key handling
+// lives on the list.
+//
+// Live preview is apply-on-highlight: moving the selection calls theme.SetActive
+// for real, so the whole UI (the picker plus whatever's behind it) retints to the
+// highlighted theme instantly. We capture the originally-active theme on open so
+// Esc can revert it; Enter keeps the previewed theme.
+//
+// returnPage names the page to return to on confirm (Enter) or cancel (Esc).
+func CreateThemePickerPage(app *tview.Application, pages *tview.Pages, returnPage string) tview.Primitive {
+	p := &themePicker{
+		app:         app,
+		pages:       pages,
+		returnPage:  returnPage,
+		themes:      theme.All(),
+		originalKey: theme.Active().Key,
+	}
+
+	// ── Title ────────────────────────────────────────────────────────────────
+	title := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("[gold]═══ Themes ═══[-]")
+
+	subtitle := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("[gray]Preview applies live — pick a theme that reads well in your terminal.[-]")
+
+	// ── Theme list ───────────────────────────────────────────────────────────
+	p.list = tview.NewList()
+	p.list.SetBorder(false)
+	// Selection backs light text, so it uses the Selection role (like load_game),
+	// not Accent — white-on-gold is unreadable (theme/themes_forge.go).
+	theme.Track(func() {
+		p.list.SetSelectedBackgroundColor(theme.Color(theme.RoleSelection)).
+			SetSelectedTextColor(theme.Color(theme.RoleText))
+	})
+	p.list.ShowSecondaryText(false)
+	for _, th := range p.themes {
+		p.list.AddItem(themeRowLabel(th, p.originalKey), "", 0, nil)
+	}
+
+	// ── Detail pane ──────────────────────────────────────────────────────────
+	p.detail = tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(true)
+	p.detail.SetBorder(true).
+		SetTitle(" Details ")
+	theme.Track(func() {
+		p.detail.SetBorderColor(theme.Color(theme.RoleAccent)).
+			SetTitleColor(theme.Color(theme.RoleAccent))
+	})
+
+	// ── Footer ───────────────────────────────────────────────────────────────
+	footer := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText(themeFooterBar())
+
+	// ── Layout ───────────────────────────────────────────────────────────────
+	p.root = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(title, 1, 0, false).
+		AddItem(subtitle, 1, 0, false).
+		AddItem(p.list, 0, 1, true).    // weighted — takes remaining space
+		AddItem(p.detail, 13, 0, false). // blurb + accessible note + 8 swatch rows + border
+		AddItem(footer, 1, 0, false)
+
+	// Live preview: highlighting a theme applies it for real and retints the whole
+	// UI. SetChangedFunc fires on every interactive selection move, so it both
+	// applies the theme AND forces a redraw so the player sees the retint at once.
+	p.list.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
+		p.applyAndDetail(index)
+		if p.app != nil {
+			// Retint the whole UI live — the picker is itself a sample of the running
+			// theme (theming.md §7). QueueUpdateDraw is safe from the tview goroutine.
+			p.app.QueueUpdateDraw(func() {})
+		}
+	})
+	p.list.SetInputCapture(p.handleKey)
+
+	// Start on the active theme's row so the picker opens on what's already in use
+	// (no spurious preview-flicker to a different theme). We set this BEFORE the
+	// detail seed so GetCurrentItem reflects the right row.
+	p.list.SetCurrentItem(p.currentIndex())
+	// Seed the detail pane (and re-apply the active theme, a no-op) without queuing
+	// a redraw: at construction the event loop may not be running yet, and
+	// AddPage/focus triggers the first Draw. Forcing QueueUpdateDraw here would
+	// block on an un-run app (and is redundant when it is running).
+	p.applyAndDetail(p.list.GetCurrentItem())
+
+	return p.root
+}
+
+// currentIndex returns the list index of the originally-active theme, or 0.
+func (p *themePicker) currentIndex() int {
+	for i, th := range p.themes {
+		if th.Key == p.originalKey {
+			return i
+		}
+	}
+	return 0
+}
+
+// applyAndDetail applies the theme at index for real (remap + restyle) and
+// refreshes the detail pane. It does NOT queue a redraw — that's the caller's job,
+// because the construction-time seed runs before the event loop and would block on
+// QueueUpdateDraw, while the interactive SetChangedFunc path does want a redraw.
+// Out-of-range is a no-op.
+func (p *themePicker) applyAndDetail(index int) {
+	if index < 0 || index >= len(p.themes) {
+		return
+	}
+	th := p.themes[index]
+	// SetActive sets the active theme + applies the name-remap + re-runs the
+	// restyle registry; the caller owns any redraw.
+	_ = theme.SetActive(th.Key)
+	theme.Restyle()
+	p.detail.SetText(themeDetailText(th))
+}
+
+// handleKey routes the picker's action keys. tview.List handles ↑/↓ natively; we
+// intercept Enter (confirm) and Esc/q (cancel/revert).
+func (p *themePicker) handleKey(event *tcell.EventKey) *tcell.EventKey {
+	switch event.Key() {
+	case tcell.KeyEnter:
+		p.confirm()
+		return nil
+	case tcell.KeyEsc:
+		p.cancel()
+		return nil
+	case tcell.KeyRune:
+		if r := event.Rune(); r == 'q' || r == 'Q' {
+			p.cancel()
+			return nil
+		}
+	}
+	return event
+}
+
+// confirm keeps the currently-previewed theme (it is already applied) and returns
+// to the page the picker was opened from.
+func (p *themePicker) confirm() {
+	// Phase 2 seam: persist the chosen theme account-wide here. The theme is
+	// already applied process-locally via the live preview; Phase 2 drops in:
+	//   account.SetActiveTheme(theme.Active().Key)
+	// (account-wide persistence is out of scope for Phase 1c — see theming.md §6).
+	p.close()
+}
+
+// cancel reverts to the theme that was active when the picker opened (undoing any
+// live preview) and returns to the page the picker was opened from.
+func (p *themePicker) cancel() {
+	if theme.Active().Key != p.originalKey {
+		_ = theme.SetActive(p.originalKey)
+		theme.Restyle()
+		if p.app != nil {
+			p.app.QueueUpdateDraw(func() {})
+		}
+	}
+	p.close()
+}
+
+// close removes the picker page and returns to the page it was opened from.
+func (p *themePicker) close() {
+	p.pages.RemovePage(themePickerPage)
+	p.pages.SwitchToPage(p.returnPage)
+}
+
+// ── Pure helpers (formatting) ───────────────────────────────────────────────
+
+// themeRowLabel renders one list row: the theme name, a "(current)" marker on the
+// theme that was active when the picker opened, and an accessible tag if so. The
+// marker tracks the open-time active theme (not the live preview) so the row stays
+// stable as the player arrows through previews.
+func themeRowLabel(t theme.Theme, activeKey string) string {
+	label := t.Name
+	if t.Key == activeKey {
+		label = "[gold]● " + t.Name + " (current)[-]"
+	}
+	if t.Accessible {
+		label += "   [cyan]accessible[-]"
+	}
+	return label
+}
+
+// themeDetailText renders the detail pane for a theme: name, blurb, an accessible
+// note (with the gain/loss glyphs so the redundant ± encoding is visible), and the
+// palette swatch rows.
+func themeDetailText(t theme.Theme) string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("[gold]%s[-]", t.Name))
+	if t.Blurb != "" {
+		lines = append(lines, "[gray]"+t.Blurb+"[-]")
+	}
+	if t.Accessible {
+		note := "[cyan]Accessible[-] [gray]— colorblind-safe / high-contrast, always unlocked[-]"
+		if t.GainGlyph != "" || t.LossGlyph != "" {
+			// Show the signed glyphs so the shape-based ± encoding is visible in the
+			// picker itself (theming.md §7).
+			note += fmt.Sprintf(" [gray](gain %s / loss %s)[-]", t.GainGlyph, t.LossGlyph)
+		}
+		lines = append(lines, note)
+	}
+	lines = append(lines, "") // blank spacer before the swatch block
+	lines = append(lines, themeSwatches(t))
+	return strings.Join(lines, "\n")
+}
+
+// themeSwatches renders the theme's palette as one labeled colored-block row per
+// role. Each block uses the theme's OWN literal color (not the active remap) via a
+// hex tag, so every row in the list shows its true palette even though only the
+// highlighted theme is the live-applied one.
+func themeSwatches(t theme.Theme) string {
+	rows := make([]string, 0, len(swatchRoles))
+	for _, sr := range swatchRoles {
+		hex := colorHexTag(t.Color(sr.role))
+		// ███ block in the role's literal color, then a gray label.
+		rows = append(rows, fmt.Sprintf("%s███[-]  [gray]%s[-]", hex, sr.label))
+	}
+	return strings.Join(rows, "\n")
+}
+
+// colorHexTag renders a tcell.Color as a tview "[#rrggbb]" inline tag from its
+// literal RGB. Themes are built with NewRGBColor, so Hex() yields the true RGB;
+// an invalid/default color (Hex() < 0) falls back to a neutral gray tag so the
+// swatch never emits a malformed tag.
+func colorHexTag(c tcell.Color) string {
+	h := c.Hex()
+	if h < 0 {
+		return "[#808080]"
+	}
+	return fmt.Sprintf("[#%06x]", h)
+}
+
+// themeFooterBar is the picker action bar: keycap buttons matching the load-game
+// footer idiom (footerButton lives in load_game.go).
+func themeFooterBar() string {
+	return "  " + strings.Join([]string{
+		footerButton("↑↓", "Preview"),
+		footerButton("Enter", "Keep"),
+		footerButton("Esc", "Cancel"),
+	}, "  ") + "  "
+}

--- a/ui/theme_picker.go
+++ b/ui/theme_picker.go
@@ -186,7 +186,7 @@ func (p *themePicker) applyAndDetail(index int) {
 	// restyle registry; the caller owns any redraw.
 	_ = theme.SetActive(th.Key)
 	theme.Restyle()
-	p.detail.SetText(themeDetailText(th))
+	p.detail.SetText(themeDetailText(th, themeAvailable(p.account(), th)))
 }
 
 // handleKey routes the picker's action keys. tview.List handles ↑/↓ natively; we
@@ -293,7 +293,12 @@ func themeRowLabel(t theme.Theme, activeKey string, available bool) string {
 // themeDetailText renders the detail pane for a theme: name, blurb, an accessible
 // note (with the gain/loss glyphs so the redundant ± encoding is visible), and the
 // palette swatch rows.
-func themeDetailText(t theme.Theme) string {
+//
+// available reports whether this theme is unlocked for the current account
+// (themeAvailable). A LOCKED theme shows a "🔒 Locked — <UnlockHint>" line above the
+// swatches (theming.md §7); the swatches still render as a preview of what the player
+// will get, so the locked theme is enticing rather than blank.
+func themeDetailText(t theme.Theme, available bool) string {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("[gold]%s[-]", t.Name))
 	if t.Blurb != "" {
@@ -307,6 +312,17 @@ func themeDetailText(t theme.Theme) string {
 			note += fmt.Sprintf(" [gray](gain %s / loss %s)[-]", t.GainGlyph, t.LossGlyph)
 		}
 		lines = append(lines, note)
+	}
+	if !available {
+		// Locked flavor theme: surface the unlock condition. Fall back to a generic
+		// line if the theme somehow has no hint (the registry-consistency test makes
+		// that impossible for gated themes, but the detail pane shouldn't render an
+		// empty "Locked —" tail if it ever happens).
+		hint := t.UnlockHint
+		if hint == "" {
+			hint = "unlock via a milestone"
+		}
+		lines = append(lines, fmt.Sprintf("[red]🔒 Locked[-] [gray]— %s[-]", hint))
 	}
 	lines = append(lines, "") // blank spacer before the swatch block
 	lines = append(lines, themeSwatches(t))

--- a/ui/theme_picker_test.go
+++ b/ui/theme_picker_test.go
@@ -29,7 +29,7 @@ func TestCmdThemeListShowsAllThemes(t *testing.T) {
 		t.Fatalf("setup SetActive(%q) failed: %v", theme.DefaultKey, err)
 	}
 
-	res := cmdTheme([]string{"list"})
+	res := cmdTheme([]string{"list"}, nil)
 	if res.Type == "error" {
 		t.Fatalf("theme list returned an error: %q", res.Message)
 	}
@@ -51,7 +51,7 @@ func TestCmdThemeListShowsAllThemes(t *testing.T) {
 func TestCmdThemeBareIsInfoNotError(t *testing.T) {
 	// Bare `theme` (no args) directs the player rather than erroring — the
 	// interactive picker is opened by the dashboard intercept, not this path.
-	res := cmdTheme(nil)
+	res := cmdTheme(nil, nil)
 	if res.Type == "error" {
 		t.Errorf("bare theme should not be an error, got %q: %q", res.Type, res.Message)
 	}
@@ -65,7 +65,7 @@ func TestCmdThemeValidKeySwitchesActive(t *testing.T) {
 		t.Fatalf("test precondition: theme %q not registered", target)
 	}
 
-	res := cmdTheme([]string{target})
+	res := cmdTheme([]string{target}, nil)
 	if res.Type != "success" {
 		t.Errorf("theme %s should succeed, got %q: %q", target, res.Type, res.Message)
 	}
@@ -83,7 +83,7 @@ func TestCmdThemeBadKeyIsErrorAndDoesNotSwitch(t *testing.T) {
 	}
 	before := theme.Active().Key
 
-	res := cmdTheme([]string{"no_such_theme_xyz"})
+	res := cmdTheme([]string{"no_such_theme_xyz"}, nil)
 	if res.Type != "error" {
 		t.Errorf("unknown theme should be an error, got %q: %q", res.Type, res.Message)
 	}
@@ -155,18 +155,24 @@ func TestThemeDetailShowsAccessibleNoteAndGlyphs(t *testing.T) {
 
 func TestThemeRowLabelMarksActive(t *testing.T) {
 	forge, _ := theme.ByKey("forge")
-	// Marked when it's the active (open-time) theme.
-	if got := themeRowLabel(forge, "forge"); !strings.Contains(got, "current") {
+	// Marked when it's the active (open-time) theme. All shipped themes are
+	// available today, so pass available=true.
+	if got := themeRowLabel(forge, "forge", true); !strings.Contains(got, "current") {
 		t.Errorf("themeRowLabel for active theme should mark (current)\ngot: %q", got)
 	}
 	// Not marked when a different theme is active.
-	if got := themeRowLabel(forge, "high_contrast"); strings.Contains(got, "current") {
+	if got := themeRowLabel(forge, "high_contrast", true); strings.Contains(got, "current") {
 		t.Errorf("themeRowLabel for non-active theme should not mark current\ngot: %q", got)
 	}
 	// Accessible themes carry the accessible tag.
 	deut, _ := theme.ByKey("deuteranopia")
-	if got := themeRowLabel(deut, "forge"); !strings.Contains(got, "accessible") {
+	if got := themeRowLabel(deut, "forge", true); !strings.Contains(got, "accessible") {
 		t.Errorf("themeRowLabel for accessible theme should tag it\ngot: %q", got)
+	}
+	// An unavailable theme carries the locked marker (Phase-3 path; simulated here
+	// by passing available=false).
+	if got := themeRowLabel(forge, "forge", false); !strings.Contains(got, "locked") {
+		t.Errorf("themeRowLabel for unavailable theme should mark it locked\ngot: %q", got)
 	}
 }
 
@@ -180,7 +186,8 @@ func TestCreateThemePickerPageRegisters(t *testing.T) {
 	app := tview.NewApplication()
 	pages := tview.NewPages()
 
-	page := CreateThemePickerPage(app, pages, "splash")
+	// nil engine → accountless picker (construction must not require an account).
+	page := CreateThemePickerPage(app, pages, nil, "splash")
 	if page == nil {
 		t.Fatal("CreateThemePickerPage returned nil")
 	}

--- a/ui/theme_picker_test.go
+++ b/ui/theme_picker_test.go
@@ -137,14 +137,14 @@ func TestThemeSwatchesLabelsEveryRole(t *testing.T) {
 }
 
 func TestThemeDetailShowsAccessibleNoteAndGlyphs(t *testing.T) {
-	// Forge is not accessible — no glyph note.
+	// Forge is not accessible — no glyph note. (Forge is always available.)
 	forge, _ := theme.ByKey("forge")
-	if d := themeDetailText(forge); strings.Contains(d, "Accessible") {
+	if d := themeDetailText(forge, true); strings.Contains(d, "Accessible") {
 		t.Errorf("forge detail should not claim Accessible\ngot: %s", d)
 	}
 	// An accessible theme shows the note and its signed glyphs.
 	deut, _ := theme.ByKey("deuteranopia")
-	d := themeDetailText(deut)
+	d := themeDetailText(deut, true)
 	if !strings.Contains(d, "Accessible") {
 		t.Errorf("deuteranopia detail should show the Accessible note\ngot: %s", d)
 	}

--- a/ui/theme_picker_test.go
+++ b/ui/theme_picker_test.go
@@ -3,7 +3,9 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/espresso20/ageforge/theme"
@@ -194,5 +196,91 @@ func TestCreateThemePickerPageRegisters(t *testing.T) {
 	pages.AddPage(themePickerPage, page, true, true)
 	if !pages.HasPage(themePickerPage) {
 		t.Errorf("picker page %q not registered after AddPage", themePickerPage)
+	}
+}
+
+// TestThemePicker_NoDeadlockOnNavigate is the regression guard for Trello TCGiSWYX:
+// the live-preview SetChangedFunc must NOT call QueueUpdateDraw, which deadlocks the
+// whole app when run from the main goroutine — the freeze-on-arrow the player hit.
+// The pre-fix unit tests used an un-run app, so they never exercised live
+// navigation; this one runs a real tview event loop on a SimulationScreen, injects a
+// Down arrow (firing the live preview), waits for the preview to actually land, then
+// probes loop liveness with a QueueUpdateDraw from a non-main goroutine — which times
+// out (and fails the test) if the picker has wedged the loop.
+//
+// Scope is the arrow/SetChangedFunc path only: cancel() carries the identical
+// no-QueueUpdateDraw fix, but driving Esc through a simulated loop proved
+// order-dependent (focus/timing), and an order-dependent test is worse than none.
+func TestThemePicker_NoDeadlockOnNavigate(t *testing.T) {
+	restoreForge(t)
+
+	app := tview.NewApplication()
+	app.SetScreen(tcell.NewSimulationScreen("")) // app.Run() Inits it.
+
+	pages := tview.NewPages()
+	pages.AddPage("home", tview.NewBox(), true, false)
+	picker := CreateThemePickerPage(app, pages, nil, "home") // nil engine: accountless is fine
+	pages.AddPage(themePickerPage, picker, true, true)
+	app.SetRoot(pages, true)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- app.Run() }()
+	defer func() {
+		app.Stop()
+		// Best-effort drain. If the loop is wedged (the very bug under test), Stop()
+		// can't unblock it and Run() never returns — so don't hang teardown on it, or
+		// a correct t.Fatal detection turns into a slow test-timeout kill.
+		select {
+		case <-runErr:
+		case <-time.After(2 * time.Second):
+		}
+	}()
+
+	// alive reports whether the event loop can still process an update within d. Run
+	// from this (non-main) goroutine, QueueUpdateDraw blocks until the loop drains it
+	// — so a loop wedged on a main-goroutine QueueUpdateDraw (the TCGiSWYX bug) makes
+	// this time out. The probe goroutine is allowed to leak on failure (it can't be
+	// unblocked); the test fails via the timeout, which is the point.
+	alive := func(d time.Duration) bool {
+		done := make(chan struct{})
+		go func() { app.QueueUpdateDraw(func() {}); close(done) }()
+		select {
+		case <-done:
+			return true
+		case <-time.After(d):
+			return false
+		}
+	}
+	// waitTheme polls the (mutex-guarded) active theme until want(key) holds or d
+	// elapses, returning the last-seen key. We wait for an injected key's EFFECT to
+	// land before probing liveness, so the liveness check isn't racing the key
+	// handler (and so the buggy path fails fast on the alive() timeout rather than on
+	// channel-ordering luck).
+	waitTheme := func(want func(string) bool, d time.Duration) string {
+		deadline := time.Now().Add(d)
+		for {
+			k := theme.Active().Key
+			if want(k) || time.Now().After(deadline) {
+				return k
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if !alive(3 * time.Second) {
+		t.Fatal("event loop never became responsive")
+	}
+
+	// Down fires the live-preview SetChangedFunc — the primary deadlock site.
+	// applyAndDetail (which moves the active theme off the opening Forge row) runs
+	// BEFORE the buggy QueueUpdateDraw, so the theme change lands even on the broken
+	// code; we wait for it (proving we reached SetChangedFunc), THEN probe liveness —
+	// which is where the bug strands the loop.
+	app.QueueEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	if k := waitTheme(func(s string) bool { return s != "forge" }, 3*time.Second); k == "forge" {
+		t.Fatal("preview never applied after Down — test did not reach SetChangedFunc")
+	}
+	if !alive(3 * time.Second) {
+		t.Fatal("event loop deadlocked in live preview (Trello TCGiSWYX regression)")
 	}
 }

--- a/ui/theme_picker_test.go
+++ b/ui/theme_picker_test.go
@@ -1,0 +1,191 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rivo/tview"
+
+	"github.com/espresso20/ageforge/theme"
+)
+
+// restoreForge resets the process-global active theme back to the default after a
+// test mutates it, so the switched theme doesn't leak into other cases (the remap
+// is process-wide state). Registered via t.Cleanup by every test that switches.
+func restoreForge(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := theme.SetActive(theme.DefaultKey); err != nil {
+			t.Fatalf("restoreForge: SetActive(%q) failed: %v", theme.DefaultKey, err)
+		}
+	})
+}
+
+func TestCmdThemeListShowsAllThemes(t *testing.T) {
+	// Pin the active theme so the marker assertion is independent of test order
+	// (the active theme is process-global; another case may have switched it).
+	restoreForge(t)
+	if err := theme.SetActive(theme.DefaultKey); err != nil {
+		t.Fatalf("setup SetActive(%q) failed: %v", theme.DefaultKey, err)
+	}
+
+	res := cmdTheme([]string{"list"})
+	if res.Type == "error" {
+		t.Fatalf("theme list returned an error: %q", res.Message)
+	}
+	// Every registered theme's name and key must appear in the listing.
+	for _, th := range theme.All() {
+		if !strings.Contains(res.Message, th.Name) {
+			t.Errorf("theme list missing name %q\ngot: %s", th.Name, res.Message)
+		}
+		if !strings.Contains(res.Message, th.Key) {
+			t.Errorf("theme list missing key %q\ngot: %s", th.Key, res.Message)
+		}
+	}
+	// The active theme must carry the active marker.
+	if !strings.Contains(res.Message, "●") {
+		t.Errorf("theme list missing active marker ●\ngot: %s", res.Message)
+	}
+}
+
+func TestCmdThemeBareIsInfoNotError(t *testing.T) {
+	// Bare `theme` (no args) directs the player rather than erroring — the
+	// interactive picker is opened by the dashboard intercept, not this path.
+	res := cmdTheme(nil)
+	if res.Type == "error" {
+		t.Errorf("bare theme should not be an error, got %q: %q", res.Type, res.Message)
+	}
+}
+
+func TestCmdThemeValidKeySwitchesActive(t *testing.T) {
+	restoreForge(t)
+	// Pick a non-default accessible theme so the switch is observable.
+	const target = "high_contrast"
+	if _, ok := theme.ByKey(target); !ok {
+		t.Fatalf("test precondition: theme %q not registered", target)
+	}
+
+	res := cmdTheme([]string{target})
+	if res.Type != "success" {
+		t.Errorf("theme %s should succeed, got %q: %q", target, res.Type, res.Message)
+	}
+	if got := theme.Active().Key; got != target {
+		t.Errorf("after `theme %s`, active = %q, want %q", target, got, target)
+	}
+}
+
+func TestCmdThemeBadKeyIsErrorAndDoesNotSwitch(t *testing.T) {
+	restoreForge(t)
+	// Start from a known non-default theme to prove a bad key doesn't revert or
+	// otherwise mutate the active theme.
+	if err := theme.SetActive("deuteranopia"); err != nil {
+		t.Fatalf("setup SetActive(deuteranopia) failed: %v", err)
+	}
+	before := theme.Active().Key
+
+	res := cmdTheme([]string{"no_such_theme_xyz"})
+	if res.Type != "error" {
+		t.Errorf("unknown theme should be an error, got %q: %q", res.Type, res.Message)
+	}
+	// The error should hint the valid keys.
+	if !strings.Contains(res.Message, theme.DefaultKey) {
+		t.Errorf("unknown-theme error should list valid keys (e.g. %q)\ngot: %s", theme.DefaultKey, res.Message)
+	}
+	if got := theme.Active().Key; got != before {
+		t.Errorf("a bad key changed the active theme: %q → %q", before, got)
+	}
+}
+
+func TestThemeKeysCoversRegistry(t *testing.T) {
+	keys := themeKeys()
+	if len(keys) != len(theme.All()) {
+		t.Fatalf("themeKeys() returned %d keys, want %d", len(keys), len(theme.All()))
+	}
+	want := map[string]bool{}
+	for _, th := range theme.All() {
+		want[th.Key] = true
+	}
+	for _, k := range keys {
+		if !want[k] {
+			t.Errorf("themeKeys() returned unexpected key %q", k)
+		}
+	}
+}
+
+func TestColorHexTag(t *testing.T) {
+	// A swatch tag is a valid tview hex tag built from the role's literal RGB.
+	forge, _ := theme.ByKey("forge")
+	tag := colorHexTag(forge.Color(theme.RoleAccent))
+	// Forge accent is gold #ffd700.
+	if tag != "[#ffd700]" {
+		t.Errorf("colorHexTag(forge accent) = %q, want [#ffd700]", tag)
+	}
+}
+
+func TestThemeSwatchesLabelsEveryRole(t *testing.T) {
+	forge, _ := theme.ByKey("forge")
+	sw := themeSwatches(forge)
+	for _, sr := range swatchRoles {
+		if !strings.Contains(sw, sr.label) {
+			t.Errorf("themeSwatches missing role label %q\ngot: %s", sr.label, sw)
+		}
+		// Each row must render a colored block, not bare text.
+		if !strings.Contains(sw, "███") {
+			t.Errorf("themeSwatches missing swatch block ███\ngot: %s", sw)
+		}
+	}
+}
+
+func TestThemeDetailShowsAccessibleNoteAndGlyphs(t *testing.T) {
+	// Forge is not accessible — no glyph note.
+	forge, _ := theme.ByKey("forge")
+	if d := themeDetailText(forge); strings.Contains(d, "Accessible") {
+		t.Errorf("forge detail should not claim Accessible\ngot: %s", d)
+	}
+	// An accessible theme shows the note and its signed glyphs.
+	deut, _ := theme.ByKey("deuteranopia")
+	d := themeDetailText(deut)
+	if !strings.Contains(d, "Accessible") {
+		t.Errorf("deuteranopia detail should show the Accessible note\ngot: %s", d)
+	}
+	if deut.GainGlyph != "" && !strings.Contains(d, deut.GainGlyph) {
+		t.Errorf("deuteranopia detail should show the gain glyph %q\ngot: %s", deut.GainGlyph, d)
+	}
+}
+
+func TestThemeRowLabelMarksActive(t *testing.T) {
+	forge, _ := theme.ByKey("forge")
+	// Marked when it's the active (open-time) theme.
+	if got := themeRowLabel(forge, "forge"); !strings.Contains(got, "current") {
+		t.Errorf("themeRowLabel for active theme should mark (current)\ngot: %q", got)
+	}
+	// Not marked when a different theme is active.
+	if got := themeRowLabel(forge, "high_contrast"); strings.Contains(got, "current") {
+		t.Errorf("themeRowLabel for non-active theme should not mark current\ngot: %q", got)
+	}
+	// Accessible themes carry the accessible tag.
+	deut, _ := theme.ByKey("deuteranopia")
+	if got := themeRowLabel(deut, "forge"); !strings.Contains(got, "accessible") {
+		t.Errorf("themeRowLabel for accessible theme should tag it\ngot: %q", got)
+	}
+}
+
+// TestCreateThemePickerPageRegisters mirrors the load-game add-page check: the
+// picker builds without a running app and registers under its page name. We use a
+// real (un-run) tview.Application + Pages so the construction path (Track closures,
+// list build, initial preview) executes end to end. restoreForge resets the active
+// theme afterward since the initial preview applies the default for real.
+func TestCreateThemePickerPageRegisters(t *testing.T) {
+	restoreForge(t)
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+
+	page := CreateThemePickerPage(app, pages, "splash")
+	if page == nil {
+		t.Fatal("CreateThemePickerPage returned nil")
+	}
+	pages.AddPage(themePickerPage, page, true, true)
+	if !pages.HasPage(themePickerPage) {
+		t.Errorf("picker page %q not registered after AddPage", themePickerPage)
+	}
+}

--- a/ui/theme_unlock.go
+++ b/ui/theme_unlock.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
+)
+
+// Milestone-gated theme unlocking — the UI side of theming.md §5.
+//
+// WHY THIS LIVES IN THE UI GOROUTINE, NOT THE ENGINE:
+// account.UnlockTheme persists the account (file I/O via Save). The documented
+// Bus-deadlock rule (CLAUDE.md / MEMORY.md) forbids file I/O — and any
+// lock-acquiring engine call — inside a Bus handler or under the engine write lock.
+// So the unlock check runs in the dashboard's per-refresh path, which executes
+// inside app.QueueUpdateDraw on the tview goroutine and does NOT hold ge.mu (it
+// reads a GetState() snapshot). That makes the Save here safe.
+//
+// FIRST-SYNC / RETROACTIVE UNLOCKS:
+// On the first refresh after a load, every already-completed milestone/chain looks
+// "new to this process," so we must unlock their mapped themes (a player who reached
+// the Cyberpunk Age before this update still earns Cyberpunk) WITHOUT firing a toast
+// per retroactive unlock — that would spam the log on every launch. The mechanism:
+// the dashboard's themeSyncDone flag is false on the first pass, so unlocks happen
+// silently; it flips true afterward, and only unlocks during live play toast.
+
+// themeUnlockResult is the decision for one completed milestone/chain key.
+type themeUnlockResult struct {
+	// Toast is true only when a genuinely-new unlock happened during live play (not
+	// the first retroactive sync). The caller AddLogs iff Toast.
+	Toast bool
+	// ThemeName is the unlocked theme's display name, for the toast text. Set only
+	// when Toast is true.
+	ThemeName string
+}
+
+// evaluateThemeUnlock decides what to do with a single completed milestone/chain key
+// (theming.md §5). It is the pure-ish core, split out from the dashboard method so it
+// can be unit-tested without a tview app:
+//
+//   - If completedKey maps to no theme → no-op (the common case).
+//   - If it maps to a theme and acct != nil → unlock it via account.UnlockTheme.
+//     Toast iff the unlock was genuinely NEW (newly==true) AND this isn't the
+//     first-sync pass (firstSync==false). UnlockTheme is idempotent, so replaying a
+//     key returns newly==false and never re-toasts.
+//   - acct == nil (accountless play) → nothing to unlock; no toast.
+//
+// The account Save inside UnlockTheme is acceptable here: callers invoke this from
+// the UI goroutine, never under the engine lock or in a Bus handler.
+func evaluateThemeUnlock(acct *game.Account, completedKey string, firstSync bool) themeUnlockResult {
+	themeKey, ok := theme.UnlockedBy(completedKey)
+	if !ok {
+		return themeUnlockResult{} // this milestone/chain grants no theme
+	}
+	if acct == nil {
+		// Accountless: no store to own the unlock. The flavor theme stays locked until
+		// an account exists; nothing to toast.
+		return themeUnlockResult{}
+	}
+	newly, _ := acct.UnlockTheme(themeKey)
+	// UnlockTheme's error is the account Save error — non-fatal here (the unlock is
+	// already in memory and the theme is cosmetic), so we don't surface it: a write
+	// hiccup must not block play, and the next FlushIfDirty/Save retries it.
+	if !newly || firstSync {
+		// Already owned (replayed check), or a retroactive first-sync unlock we grant
+		// silently to avoid a toast-per-already-earned-theme on every launch.
+		return themeUnlockResult{}
+	}
+	name := themeKey
+	if th, found := theme.ByKey(themeKey); found {
+		name = th.Name
+	}
+	return themeUnlockResult{Toast: true, ThemeName: name}
+}
+
+// themeUnlockToast renders the unlock notification text (theming.md §7). The accent
+// color comes from the active theme's role tag so the toast reads in whatever theme
+// is live. Kept separate (and pure) so the message format is testable.
+func themeUnlockToast(themeName string) string {
+	return fmt.Sprintf("%s🎨 New theme unlocked: %s! Type 'theme' to use it.[-]",
+		theme.Tag(theme.RoleAccent), themeName)
+}
+
+// completedUnlockKeys gathers every completed milestone key AND completed chain key
+// from a GameState snapshot — the universe of keys that might grant a theme. It does
+// not touch the account or the registry; it's just the snapshot read, isolated so
+// the dashboard hook (and its test) share one definition of "completed."
+func completedUnlockKeys(ms game.MilestoneState) []string {
+	keys := make([]string, 0, len(ms.Milestones)+len(ms.Chains))
+	for key, info := range ms.Milestones {
+		if info.Completed {
+			keys = append(keys, key)
+		}
+	}
+	for _, ch := range ms.Chains {
+		if ch.Complete {
+			keys = append(keys, ch.Key)
+		}
+	}
+	return keys
+}

--- a/ui/theme_unlock_test.go
+++ b/ui/theme_unlock_test.go
@@ -1,0 +1,210 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
+)
+
+// Milestone-gated theme unlock tests (theming.md §5). These exercise the pure-ish
+// evaluateThemeUnlock helper (theme_unlock.go) rather than the dashboard method, so
+// no tview app is needed; the dashboard just loops this helper over completed keys.
+
+// cyberpunkUnlockKey is the milestone key that grants the Cyberpunk theme. Pulled
+// from the registry so the test tracks the mapping rather than hard-coding it twice.
+func cyberpunkUnlockKey(t *testing.T) (milestoneKey, themeKey string) {
+	t.Helper()
+	cp, ok := theme.ByKey("cyberpunk")
+	if !ok {
+		t.Fatal("precondition: cyberpunk theme not registered")
+	}
+	if cp.UnlockMilestone == "" {
+		t.Fatal("precondition: cyberpunk theme has no UnlockMilestone")
+	}
+	return cp.UnlockMilestone, cp.Key
+}
+
+// TestEvaluateThemeUnlockNewThenReplay is the core idempotency case: a milestone the
+// account doesn't yet own unlocks the mapped theme (newly → toast); replaying the
+// same key is a no-op (already owned → no toast, no double-unlock).
+func TestEvaluateThemeUnlockNewThenReplay(t *testing.T) {
+	msKey, themeKey := cyberpunkUnlockKey(t)
+	acct := newIsolatedAccount(t)
+
+	if acct.HasTheme(themeKey) {
+		t.Fatalf("precondition: account already has %q", themeKey)
+	}
+
+	// Live play (firstSync=false): a genuinely-new unlock toasts.
+	res := evaluateThemeUnlock(acct, msKey, false)
+	if !res.Toast {
+		t.Errorf("first unlock of %q should toast", themeKey)
+	}
+	if !acct.HasTheme(themeKey) {
+		t.Errorf("after evaluateThemeUnlock, account should have %q unlocked", themeKey)
+	}
+	if !strings.Contains(res.ThemeName, "Cyberpunk") {
+		t.Errorf("toast theme name = %q, want it to contain the theme's display name", res.ThemeName)
+	}
+
+	// Replay the same completed key: UnlockTheme is idempotent (newly==false), so no
+	// re-toast and the theme stays unlocked exactly once.
+	res2 := evaluateThemeUnlock(acct, msKey, false)
+	if res2.Toast {
+		t.Errorf("replaying %q must not re-toast an already-owned theme", msKey)
+	}
+	if got := acct.UnlockedThemes(); countOccurrences(got, themeKey) != 1 {
+		t.Errorf("theme %q should be unlocked exactly once, got set %v", themeKey, got)
+	}
+}
+
+// TestEvaluateThemeUnlockFirstSyncSilent covers retroactive grants: on the first sync
+// after load, an already-completed milestone unlocks its theme SILENTLY (no toast),
+// so a player who reached the age before this update gets the theme without a launch-
+// time toast spam. The unlock still happens — only the toast is suppressed.
+func TestEvaluateThemeUnlockFirstSyncSilent(t *testing.T) {
+	msKey, themeKey := cyberpunkUnlockKey(t)
+	acct := newIsolatedAccount(t)
+
+	res := evaluateThemeUnlock(acct, msKey, true) // firstSync=true
+	if res.Toast {
+		t.Errorf("first-sync (retroactive) unlock of %q must NOT toast", themeKey)
+	}
+	if !acct.HasTheme(themeKey) {
+		t.Errorf("first-sync should still UNLOCK %q (silent grant), but account lacks it", themeKey)
+	}
+}
+
+// TestEvaluateThemeUnlockUnmappedKey: a completed milestone that grants no theme is a
+// no-op and never toasts.
+func TestEvaluateThemeUnlockUnmappedKey(t *testing.T) {
+	acct := newIsolatedAccount(t)
+	res := evaluateThemeUnlock(acct, "first_shelter", false)
+	if res.Toast {
+		t.Errorf("an unmapped milestone (first_shelter) must not toast")
+	}
+	if got := acct.UnlockedThemes(); len(got) != 0 {
+		t.Errorf("an unmapped milestone must not unlock anything, got %v", got)
+	}
+}
+
+// TestEvaluateThemeUnlockNilAccount: accountless play has no store, so a mapped key
+// unlocks nothing and never toasts (must not panic).
+func TestEvaluateThemeUnlockNilAccount(t *testing.T) {
+	msKey, _ := cyberpunkUnlockKey(t)
+	res := evaluateThemeUnlock(nil, msKey, false)
+	if res.Toast {
+		t.Errorf("accountless unlock must not toast")
+	}
+}
+
+// TestCompletedUnlockKeysGathersBoth verifies the snapshot reader collects completed
+// milestone keys AND completed chain keys, and skips incomplete ones.
+func TestCompletedUnlockKeysGathersBoth(t *testing.T) {
+	ms := game.MilestoneState{
+		Milestones: map[string]game.MilestoneInfo{
+			"done_ms":    {Completed: true},
+			"pending_ms": {Completed: false},
+		},
+		Chains: []game.ChainInfo{
+			{Key: "done_chain", Complete: true},
+			{Key: "pending_chain", Complete: false},
+		},
+	}
+	got := completedUnlockKeys(ms)
+	if !sliceContains(got, "done_ms") {
+		t.Errorf("completed milestone done_ms missing from %v", got)
+	}
+	if !sliceContains(got, "done_chain") {
+		t.Errorf("completed chain done_chain missing from %v", got)
+	}
+	if sliceContains(got, "pending_ms") || sliceContains(got, "pending_chain") {
+		t.Errorf("incomplete keys must be excluded, got %v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected exactly 2 completed keys, got %v", got)
+	}
+}
+
+// TestThemeUnlockToastFormat checks the toast text carries the cue and theme name.
+func TestThemeUnlockToastFormat(t *testing.T) {
+	restoreForge(t) // pin the active theme so the accent tag is deterministic
+	msg := themeUnlockToast("Cyberpunk")
+	if !strings.Contains(msg, "Cyberpunk") {
+		t.Errorf("toast missing theme name: %q", msg)
+	}
+	if !strings.Contains(msg, "theme") {
+		t.Errorf("toast should tell the player to use `theme`: %q", msg)
+	}
+	if !strings.Contains(msg, "🎨") {
+		t.Errorf("toast missing the 🎨 cue: %q", msg)
+	}
+}
+
+// TestThemeDetailShowsLockCondition: a LOCKED flavor theme's detail pane shows the
+// 🔒 Locked line with its unlock hint, and still renders swatches as a preview.
+func TestThemeDetailShowsLockCondition(t *testing.T) {
+	cp, ok := theme.ByKey("cyberpunk")
+	if !ok {
+		t.Fatal("precondition: cyberpunk theme not registered")
+	}
+	// available=false → locked detail.
+	d := themeDetailText(cp, false)
+	if !strings.Contains(d, "🔒") || !strings.Contains(d, "Locked") {
+		t.Errorf("locked detail should show a lock marker\ngot: %s", d)
+	}
+	if !strings.Contains(d, cp.UnlockHint) {
+		t.Errorf("locked detail should show the unlock hint %q\ngot: %s", cp.UnlockHint, d)
+	}
+	// Swatch preview still present (the role label "Accent" appears in the swatch rows).
+	if !strings.Contains(d, "Accent") {
+		t.Errorf("locked detail should still show swatch preview\ngot: %s", d)
+	}
+	// available=true → no lock line.
+	if d := themeDetailText(cp, true); strings.Contains(d, "Locked") {
+		t.Errorf("available detail must not show a Locked line\ngot: %s", d)
+	}
+}
+
+// TestCmdThemeListShowsLockHints: `theme list` for an account without the flavor
+// themes shows the 🔒 hint on each locked theme and the accessible note on the
+// always-available accessible ones.
+func TestCmdThemeListShowsLockHints(t *testing.T) {
+	restoreForge(t)
+	acct := newIsolatedAccount(t) // owns only the default-unlock set
+	res := cmdThemeList(acct)
+	if res.Type == "error" {
+		t.Fatalf("theme list errored: %q", res.Message)
+	}
+	// Cyberpunk is a gated flavor theme this account hasn't unlocked → its hint shows.
+	cp, _ := theme.ByKey("cyberpunk")
+	if !strings.Contains(res.Message, cp.UnlockHint) {
+		t.Errorf("theme list should show locked %q's hint %q\ngot: %s", cp.Key, cp.UnlockHint, res.Message)
+	}
+	if !strings.Contains(res.Message, "🔒") {
+		t.Errorf("theme list should show a 🔒 marker for locked themes\ngot: %s", res.Message)
+	}
+}
+
+// --- small slice helpers (test-local) ---
+
+func sliceContains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func countOccurrences(s []string, v string) int {
+	n := 0
+	for _, x := range s {
+		if x == v {
+			n++
+		}
+	}
+	return n
+}

--- a/ui/villager_panel.go
+++ b/ui/villager_panel.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/espresso20/ageforge/config"
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // WorkerPanel shows a compact workers summary grouped by building domain.
@@ -23,7 +24,8 @@ func NewWorkerPanel() *WorkerPanel {
 	vp.root = tview.NewTextView().
 		SetDynamicColors(true).
 		SetScrollable(true)
-	vp.root.SetBorder(true).SetTitle(" Workers ").SetTitleColor(ColorVillager)
+	vp.root.SetBorder(true).SetTitle(" Workers ")
+	theme.Track(func() { vp.root.SetTitleColor(theme.Color(theme.RoleAccent)) })
 	return vp
 }
 
@@ -264,7 +266,7 @@ func renderVillagerPanel(tv *tview.TextView, state *game.GameState) {
 // name (the morale band colour) rather than the fixed assignment fill colour.
 func moraleBandBar(filled, total, w int, fillColor string) string {
 	if total <= 0 {
-		return "[" + BarEmptyColor + "]" + strings.Repeat("░", w) + "[-]"
+		return BarEmptyColor() + strings.Repeat("░", w) + "[-]"
 	}
 	f := (filled * w) / total
 	if f > w {
@@ -273,13 +275,13 @@ func moraleBandBar(filled, total, w int, fillColor string) string {
 	if f < 0 {
 		f = 0
 	}
-	return "[" + fillColor + "]" + strings.Repeat("█", f) + "[" + BarEmptyColor + "]" + strings.Repeat("░", w-f) + "[-]"
+	return "[" + fillColor + "]" + strings.Repeat("█", f) + BarEmptyColor() + strings.Repeat("░", w-f) + "[-]"
 }
 
 // assignBar renders a small tview-colored progress bar of width w.
 func assignBar(filled, total, w int) string {
 	if total <= 0 {
-		return "[" + BarEmptyColor + "]" + strings.Repeat("░", w) + "[-]"
+		return BarEmptyColor() + strings.Repeat("░", w) + "[-]"
 	}
 	f := (filled * w) / total
 	if f > w {
@@ -288,5 +290,5 @@ func assignBar(filled, total, w int) string {
 	if f < 0 {
 		f = 0
 	}
-	return "[" + BarFillColor + "]" + strings.Repeat("█", f) + "[" + BarEmptyColor + "]" + strings.Repeat("░", w-f) + "[-]"
+	return BarFillColor() + strings.Repeat("█", f) + BarEmptyColor() + strings.Repeat("░", w-f) + "[-]"
 }

--- a/ui/widgets.go
+++ b/ui/widgets.go
@@ -8,10 +8,10 @@ import (
 )
 
 // ProgressBar returns a text-based progress bar with colored segments.
-// Filled portion uses BarFillColor (purple), empty portion uses BarEmptyColor (dark gray).
+// Filled portion uses BarFillColor (Accent role), empty uses BarEmptyColor (Dim role).
 func ProgressBar(current, max float64, width int) string {
 	if max <= 0 {
-		return "[" + BarEmptyColor + "]" + strings.Repeat("░", width) + "[-]"
+		return BarEmptyColor() + strings.Repeat("░", width) + "[-]"
 	}
 	ratio := current / max
 	if ratio > 1 {
@@ -22,7 +22,7 @@ func ProgressBar(current, max float64, width int) string {
 	}
 	filled := int(ratio * float64(width))
 	empty := width - filled
-	return "[" + BarFillColor + "]" + strings.Repeat("█", filled) + "[" + BarEmptyColor + "]" + strings.Repeat("░", empty) + "[-]"
+	return BarFillColor() + strings.Repeat("█", filled) + BarEmptyColor() + strings.Repeat("░", empty) + "[-]"
 }
 
 // suffixes for large number formatting

--- a/ui/wonder_gallery.go
+++ b/ui/wonder_gallery.go
@@ -9,17 +9,18 @@ import (
 
 	"github.com/espresso20/ageforge/config"
 	"github.com/espresso20/ageforge/game"
+	"github.com/espresso20/ageforge/theme"
 )
 
 // wonderProgressBar returns a simple fill bar with colored segments.
-// Filled portion uses BarFillColor (purple), empty portion uses BarEmptyColor (dark gray).
+// Filled portion uses BarFillColor (Accent role), empty uses BarEmptyColor (Dim role).
 func wonderProgressBar(pct float64, width int) string {
 	filled := int(pct * float64(width))
 	if filled > width {
 		filled = width
 	}
 	empty := width - filled
-	return "[" + BarFillColor + "]" + strings.Repeat("█", filled) + "[" + BarEmptyColor + "]" + strings.Repeat("░", empty) + "[-]"
+	return BarFillColor() + strings.Repeat("█", filled) + BarEmptyColor() + strings.Repeat("░", empty) + "[-]"
 }
 
 // wonderInfo holds config + state for a wonder
@@ -66,7 +67,8 @@ type WonderPanel struct {
 func NewWonderPanel() *WonderPanel {
 	wp := &WonderPanel{}
 	wp.root = tview.NewFlex().SetDirection(tview.FlexColumn)
-	wp.root.SetBorder(true).SetTitle(" Wonder ").SetTitleColor(ColorTitle)
+	wp.root.SetBorder(true).SetTitle(" Wonder ")
+	theme.Track(func() { wp.root.SetTitleColor(theme.Color(theme.RoleAccent)) })
 	return wp
 }
 


### PR DESCRIPTION
# Theme system — palettes, accessibility, account-wide unlocks

The full theming project from `design-and-architecture/theming.md`, built across 6 commits on one branch (Phases 1–3; Phase 4 is "Stretch/Future" per the doc and deferred). **9 themes, switching live.**

## What a player gets
- A `theme` command + main-menu **Themes** picker with **live preview** (highlight to see the whole UI retint, Enter keeps, Esc reverts) and palette **swatches**.
- **9 themes:** Forge (default) · **Deuteranopia / Protanopia / High-Contrast** (accessibility, unlocked from day one) · Parchment, Bronze, Cyberpunk, Monochrome, Cosmic (flavor, milestone-unlocked).
- Theme choice + unlocks **persist per account, across every save** (via the account API), never in save files.
- Flavor themes unlock by reaching milestones (Bronze Age → Bronze, Renaissance → Parchment, Information → Monochrome, Cyberpunk → Cyberpunk, Galactic → Cosmic) with a one-time toast; the picker shows the unlock condition for locked ones.

## How it works (the load-bearing bits)
- **`theme` leaf package** (tcell-only): a ~9-role model (Accent/Text/Positive/…); Forge maps roles to today's colors, so the default looks identical.
- **Path A (text):** verified that `tview` re-resolves named colors per-frame via the mutable `tcell.ColorNames` map, so remapping `gold`/`cyan`/… retints ~915 inline tags **with no edits**. A render-based guard test (TextView → SimulationScreen → assert the cell fg) fails loudly if a future tview ever caches.
- **Path B (chrome):** the ~42 `Set*Color` sites route through `theme.Color(role)`; persistent chrome enrolls via `theme.Track` so a live switch restyles borders/bgs/selection. Pre-ship audit found no stray named-color resolution.
- **23 hex tags → role tokens** (no hex literals left in retintable text; map/art stay fixed).
- **Accessibility is real, not relabeled:** accessible themes use blue/orange (not red/green) for ±, plus ▲/▼ glyphs; a contrast guard asserts WCAG AA (Text/Bg ≥ 4.5) for every theme AND deuteranopia/protanopia distinguishability (CIEDE2000) for the accessible ones — enforced in CI tests.
- **Lock-safe unlocks:** the milestone→theme hook runs in the dashboard's refresh (UI goroutine), so `account.UnlockTheme`'s Save never touches the engine write lock / a Bus handler.

## Commits
1a spine (model/remap/restyle/contrast/4 themes + guard tests) · 1b UI wiring (Path A+B, audit) · 1c picker + `theme` command + preview · 2 account persistence + gating seam · 3a 5 flavor themes · 3b milestone unlocks.

`go build/vet/test` green throughout; Forge renders identically to today. **Worth a playtest:** `theme` (or main-menu Themes) → arrow through the 9 themes and watch the whole UI retint live; the accessibility ones should read clearly and distinguish ± without red/green.

## Deferred (Phase 4, stretch per the doc)
Epoch-adaptive "Adaptive" theme (the `ApplyAgePalette` data is kept inert for it), the semantic-token cleanup (`theme.Tag`) as the remap fallback, and user-authored `data/themes/*.json`. Say the word and I'll do any of them.

Trello: Theme project epic.
