### PR TITLE
feat(ui): more headspace in the Log panel

### DIFF
--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -341,8 +341,9 @@ func (d *Dashboard) build() {
 		}
 	})
 
-	// Inject log panel into the economy tab's left column (below Under Construction)
-	d.economyTab.AddToLeftColumn(d.logTV, 0, 1)
+	// Inject log panel into the economy tab's left column (below Under Construction).
+	// Weight 2 (vs resources 3 / construction 1) gives the log more headspace.
+	d.economyTab.AddToLeftColumn(d.logTV, 0, 2)
 
 	// Mini worker summary box — sits below the sidebar in the right column
 	d.workerMiniTV = tview.NewTextView().SetDynamicColors(true)

--- a/ui/tab_economy.go
+++ b/ui/tab_economy.go
@@ -168,9 +168,11 @@ func NewEconomyTab() *EconomyTab {
 		t.constructionTV.SetTitleColor(theme.Color(theme.RoleHighlight))
 	})
 
-	// Left: resources (tall) + under construction (compact), Right: buildings
+	// Left: resources + under construction (compact); the log is injected below
+	// (Dashboard.AddToLeftColumn). Column weights resolve to 3:1:2
+	// resources:construction:log — trimmed resources to give the log more headspace.
 	t.leftCol = tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(t.resourceTV, 0, 4, false).
+		AddItem(t.resourceTV, 0, 3, false).
 		AddItem(t.constructionTV, 0, 1, false)
 
 	t.root = tview.NewFlex().SetDirection(tview.FlexColumn).


### PR DESCRIPTION
Rebalances the economy-tab left column from **4:1:1 → 3:1:2** (resources:construction:log).

The Log was stuck at 1/6 of the column height — cramped enough that a multi-line entry wrapped past the visible area — while Resources held 2/3, most of it dead space in the early game. Now: Resources 50%, Under Construction 17%, Log 33%.

Two-line change: [tab_economy.go:173](ui/tab_economy.go#L173) resources weight 4→3, [dashboard.go:345](ui/dashboard.go#L345) log weight 1→2. Pure layout; no behavior change.