### PR TITLE
feat(ui): main-screen overhaul — contrast, onboarding, command bar, log, age strip

### DIFF
--- a/game/engine.go
+++ b/game/engine.go
@@ -181,16 +181,9 @@ func NewGameEngine() *GameEngine {
 	// Give starting resources — enough for first hut + a little food
 	ge.Resources.Add("food", 25)
 	ge.Resources.Add("wood", 50)
-	// Startup tutorial
+	// Startup flavor — the step-by-step onboarding now lives in the Buildings panel
+	// (main-screen polish part 1), so the log stays clean for live events.
 	ge.addLog("event", "Welcome to AgeForge! You have nothing but your hands.")
-	ge.addLog("info", "[gold]Getting Started:[-]")
-	ge.addLog("info", "  1. [cyan]gather wood 5[-] — collect wood by hand")
-	ge.addLog("info", "  2. [cyan]gather food[-] — forage for food")
-	ge.addLog("info", "  3. [cyan]build hut[-] — build shelter (costs 10 wood)")
-	ge.addLog("info", "  4. [cyan]recruit worker[-] — recruit your first worker")
-	ge.addLog("event", "★ Wonder available: Sacred Grove — build it to unlock +0.5x speed!")
-	ge.addLog("info", "  5. Later: [cyan]assign food gathering_camp 3[-] — assign workers to buildings!")
-	ge.addLog("info", "  Type [cyan]help[-] for all commands.")
 	// Subscribe to age advances to record markers in history.
 	// IMPORTANT: Bus handlers run under the engine write lock — do NOT call GetState().
 	ge.Bus.Subscribe(EventAgeAdvanced, func(e EventData) {

--- a/theme/themes_forge.go
+++ b/theme/themes_forge.go
@@ -9,7 +9,7 @@ import "github.com/gdamore/tcell/v2"
 //
 // Role → color rationale:
 //   - Accent  gold (#FFD700)  — titles, borders, brand
-//   - Dim     #8b949e         — the existing dim-hint gray
+//   - Dim     #a8b3c0         — secondary text/hints; lifted from old #8b949e, legible but still SECONDARY to Text
 //   - Label   cyan (#39C5CF)  — field labels/values (slightly deepened from pure
 //                               cyan so it clears AA on the dark bg with margin)
 //   - Positive green (#3FB950) — gains
@@ -29,7 +29,7 @@ var Forge = Theme{
 	Colors: [numRoles]tcell.Color{
 		RoleBackground: tcell.NewRGBColor(0x0d, 0x11, 0x17),
 		RoleText:       tcell.NewRGBColor(0xff, 0xff, 0xff),
-		RoleDim:        tcell.NewRGBColor(0x8b, 0x94, 0x9e),
+		RoleDim:        tcell.NewRGBColor(0xa8, 0xb3, 0xc0),
 		RoleLabel:      tcell.NewRGBColor(0x39, 0xc5, 0xcf),
 		RoleAccent:     tcell.NewRGBColor(0xff, 0xd7, 0x00),
 		RoleHighlight:  tcell.NewRGBColor(0xf2, 0xcc, 0x60),

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -227,11 +227,15 @@ func (d *Dashboard) build() {
 
 	// Command input
 	d.inputField = tview.NewInputField().
-		SetLabel("> ").
+		SetLabel("❯ ").
 		SetFieldWidth(0)
+	d.inputField.SetBorder(true).SetTitle(" Command ")
 	theme.Track(func() {
 		d.inputField.SetFieldBackgroundColor(theme.Color(theme.RoleBackground)).
-			SetLabelColor(theme.Color(theme.RoleLabel))
+			SetLabelColor(theme.Color(theme.RoleHighlight))
+		// Frame the command bar so it reads as a first-class element, not an afterthought.
+		d.inputField.SetBorderColor(theme.Color(theme.RoleAccent)).
+			SetTitleColor(theme.Color(theme.RoleAccent))
 	})
 
 	// Wire up autocomplete
@@ -369,7 +373,7 @@ func (d *Dashboard) build() {
 		AddItem(d.toastTV, 1, 0, false).
 		AddItem(d.ageTV, 2, 0, false).
 		AddItem(d.contentArea, 0, 1, false).
-		AddItem(d.inputField, 1, 0, true)
+		AddItem(d.inputField, 3, 0, true) // 3 rows: 1 content + 2 border
 
 	// Global key handling
 	d.root.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
@@ -667,12 +671,12 @@ func (d *Dashboard) refreshAgeProgress(state game.GameState) {
 		if rs, ok := state.Resources[key]; ok {
 			current = rs.Amount
 		}
-		color := "red"
+		// ✓ when met / ✗ when not — readable at a glance, no micro-bar noise.
+		mark, color := "✗", "red"
 		if current >= req {
-			color = "green"
+			mark, color = "✓", "green"
 		}
-		bar := ProgressBar(current, req, 8)
-		fmt.Fprintf(&sb, "[%s]%s:%.0f/%.0f %s[-]  ", color, key, current, req, bar)
+		fmt.Fprintf(&sb, "[%s]%s[-] %s %s/%s  ", color, mark, key, FormatNumber(current), FormatNumber(req))
 	}
 
 	// Building requirements
@@ -681,26 +685,23 @@ func (d *Dashboard) refreshAgeProgress(state game.GameState) {
 		bldKeys = append(bldKeys, k)
 	}
 	sort.Strings(bldKeys)
-	if len(bldKeys) > 0 {
-		sb.WriteString(" ")
-		for _, key := range bldKeys {
-			req := state.NextAgeBldReqs[key]
-			current := 0
-			if bs, ok := state.Buildings[key]; ok {
-				current = bs.Count
-			}
-			color := "red"
-			if current >= req {
-				color = "green"
-			}
-			bar := ProgressBar(float64(current), float64(req), 8)
-			fmt.Fprintf(&sb, "[%s]%s:%d/%d %s[-]  ", color, key, current, req, bar)
+	for _, key := range bldKeys {
+		req := state.NextAgeBldReqs[key]
+		current := 0
+		if bs, ok := state.Buildings[key]; ok {
+			current = bs.Count
 		}
+		mark, color := "✗", "red"
+		if current >= req {
+			mark, color = "✓", "green"
+		}
+		fmt.Fprintf(&sb, "[%s]%s[-] %s %d/%d  ", color, mark, key, current, req)
 	}
 
-	// Wonder gate: show if current age wonder must still be completed
+	// Wonder gate: show if current age wonder must still be completed.
+	// CurrentAgeWonderKey is cleared once the wonder is built, so its presence == not yet built.
 	if state.CurrentAgeWonderKey != "" {
-		fmt.Fprintf(&sb, "[red]✗ Wonder required: %s[-]  ", state.CurrentAgeWonderName)
+		fmt.Fprintf(&sb, "[red]✗ Wonder: %s[-]  ", state.CurrentAgeWonderName)
 	}
 
 	d.ageTV.SetText(sb.String())
@@ -719,6 +720,9 @@ func (d *Dashboard) refreshLog(state game.GameState) {
 	if len(visible) > 20 {
 		start = len(visible) - 20
 	}
+	// Tick stamp rendered in the theme's Dim (brighter post part-1) so it recedes
+	// without going illegible; message color keys off entry type for scannability.
+	dim := theme.Tag(theme.RoleDim)
 	for _, entry := range visible[start:] {
 		color := "white"
 		switch entry.Type {
@@ -733,7 +737,7 @@ func (d *Dashboard) refreshLog(state game.GameState) {
 		case "info":
 			color = "cyan"
 		}
-		fmt.Fprintf(&sb, "[gray]T%d[-] [%s]%s[-]\n", entry.Tick, color, entry.Message)
+		fmt.Fprintf(&sb, "%sT%d[-] [%s]%s[-]\n", dim, entry.Tick, color, entry.Message)
 	}
 	d.logTV.SetText(sb.String())
 	d.logTV.ScrollToEnd()

--- a/ui/tab_economy.go
+++ b/ui/tab_economy.go
@@ -13,6 +13,24 @@ import (
 	"github.com/espresso20/ageforge/theme"
 )
 
+// earlyGameAges lists the age keys during which the "Getting Started" onboarding
+// block renders in the Buildings panel. Re-homed here out of the startup log so the
+// otherwise-empty early-game panel does useful work; it auto-retires once the
+// player advances past these ages. Tunable: trim to just {"primitive_age"} for a
+// shorter intro, or extend it if later ages still warrant hand-holding.
+var earlyGameAges = []string{"primitive_age", "stone_age"}
+
+// isEarlyGame reports whether the given age key is one of the early-game ages that
+// should show the onboarding block.
+func isEarlyGame(ageKey string) bool {
+	for _, k := range earlyGameAges {
+		if k == ageKey {
+			return true
+		}
+	}
+	return false
+}
+
 // cultureThresholds defines the culture breakpoints at which rewards unlock.
 // The bar displayed in the economy tab measures progress towards the next threshold.
 var cultureThresholds = []float64{
@@ -147,16 +165,17 @@ type EconomyTab struct {
 
 // NewEconomyTab constructs the economy tab widget tree. The left column stacks
 // resources / construction at a 3:1 height ratio (the Dashboard injects the log
-// below at weight 2 → 3:1:2). The building panel takes a 4:5 column ratio against
-// the left column — the left is kept a bit wider so the resource rows and log
-// text don't wrap.
+// below at weight 2 → 3:1:2). The building panel takes a 1:1 column ratio against
+// the left column (50:50) — narrowed from the old 4:5 so the building panel is
+// tighter (descriptions word-wrap cleanly) and the left column (resources /
+// construction / log) gets more room, improving log readability.
 func NewEconomyTab() *EconomyTab {
 	t := &EconomyTab{}
 
 	t.resourceTV = tview.NewTextView().SetDynamicColors(true)
 	t.resourceTV.SetBorder(true).SetTitle(" Resources ")
 
-	t.buildingTV = tview.NewTextView().SetDynamicColors(true).SetScrollable(true)
+	t.buildingTV = tview.NewTextView().SetDynamicColors(true).SetScrollable(true).SetWordWrap(true)
 	t.buildingTV.SetBorder(true).SetTitle(" Buildings ")
 
 	t.constructionTV = tview.NewTextView().SetDynamicColors(true)
@@ -177,8 +196,8 @@ func NewEconomyTab() *EconomyTab {
 		AddItem(t.constructionTV, 0, 1, false)
 
 	t.root = tview.NewFlex().SetDirection(tview.FlexColumn).
-		AddItem(t.leftCol, 0, 4, false).
-		AddItem(t.buildingTV, 0, 5, false)
+		AddItem(t.leftCol, 0, 1, false).
+		AddItem(t.buildingTV, 0, 1, false)
 
 	return t
 }
@@ -348,6 +367,22 @@ func (t *EconomyTab) refreshBuildings(state game.GameState) {
 	if sb.Len() == 0 {
 		sb.WriteString(" [gray]No buildings unlocked yet[-]")
 	}
+
+	// Early-game onboarding: fill the otherwise-empty lower Buildings space with a
+	// first-steps guide (re-homed out of the startup log). Auto-retires once the
+	// player advances past the early ages. Colors are deliberately legible — gold
+	// header + cyan command names + white prose — not muddy gray.
+	if isEarlyGame(state.Age) {
+		sb.WriteString("\n [gold]─── Getting Started ───[-]\n")
+		sb.WriteString(" [white]New here? Walk the first steps:[-]\n")
+		sb.WriteString(" [white]1.[-] [cyan]gather wood 5[-] [white]/[-] [cyan]gather food[-] — collect by hand\n")
+		sb.WriteString(" [white]2.[-] [cyan]build hut[-] — shelter; raises your population cap\n")
+		sb.WriteString(" [white]3.[-] [cyan]recruit worker[-] — bring in your first worker\n")
+		sb.WriteString(" [white]4.[-] [cyan]assign gathering_camp 3[-] — put workers to work\n")
+		sb.WriteString(" [white]5.[-] [cyan]build[-] the age's [gold]wonder[-] — unlocks a speed bonus\n")
+		sb.WriteString(" [white]Type[-] [cyan]help[-] [white]for all commands.[-]\n")
+	}
+
 	t.buildingTV.SetText(sb.String())
 }
 


### PR DESCRIPTION
# Main-screen UI overhaul

Addresses the full critique of the main screen — the "feels off" was two compounding root causes plus the specific nits.

## The two root causes
- **Monotone secondary text.** Everything non-headline used the same muted gray (`#8b949e`) — descriptions, log timestamps, separators, hints — so there was no hierarchy and dense areas read as noise. **Forge `RoleDim` → `#a8b3c0`** (Dim/Bg contrast 6.2 → 8.9). One change, legible everywhere; contrast guard still green.
- **Early-game emptiness.** Proportional panels are always full-height, so Primitive Age = mostly-empty bordered boxes. **The Getting-Started tutorial moved out of the log and into the empty Buildings space** as an onboarding block (gold header, cyan commands, white prose) that auto-retires once you leave the first two ages. The void becomes useful guidance.

## The specific nits
- **Command bar** — the bare 1-row input now has a border + " Command " title and a colored `❯ ` prompt. Reads as a deliberate command bar.
- **Buildings** — `SetWordWrap(true)` so long descriptions wrap at word boundaries, and the column ratio went `4:5 → 1:1` (narrower Buildings, wider left column — which also helps the log).
- **Log** — tutorial wall gone (it was half of what you were reading), timestamps use the brighter theme-tracked Dim. Live events only now.
- **Age strip** — the 5 crammed micro-bars became scannable `✓/✗ name cur/target` tokens (green check met, red x unmet), so you can see at a glance what's gating the next age.

Two commits, pure presentation (no balance/command/mechanic change, so no wiki impact). `go build/vet/test` green. Worth an eyeball on a real terminal — especially the onboarding block filling the early-game Buildings panel and the framed command bar.
