### PR TITLE
balance(storage): every tier affordable to its build cap (card mnrHFcwa)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to AgeForge are documented here.
 - Flattened building cost curves and raised age-advancement requirements.
 - Capped age-transition carryover to a starter head-start.
 - `gather` yield raised 10 → 25 and disabled past the Medieval age.
+- Storage lineage: every tier stays affordable to its build cap — the cost of copy N never outruns the storage those copies provide (the old stash-deadlock class of bug, lineage-wide). Storage buildings cap at 25 copies (stash 50), and several under-provisioned vault caps were raised. Guarded by a regression test.
 
 ### Fixed
 - Theme picker no longer deadlocks the app on arrow/Esc.

--- a/config/buildings.go
+++ b/config/buildings.go
@@ -78,12 +78,16 @@ func baseBuildingsRaw() []BuildingDef {
 		// ===== STONE AGE (costs: 200-1000) =====
 		{
 			Name: "Storage Pit", Key: "storage_pit", Category: "storage",
+			// note: cap raised 500->600 so the first (most expensive) copy stays
+			// affordable within the storage it provides; MaxCount caps the stack
+			// before the flattened 1.13 curve outruns the cap. See storage_cost_curve_test.go.
 			BaseCost:    map[string]float64{"wood": 300, "stone": 200},
 			CostScale:   1.2,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 500}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 600}},
 			BuildTicks:  60,
 			RequiredAge: "stone_age",
-			Description: "A hole in the ground to stash things. +500 storage.",
+			Description: "A hole in the ground to stash things. +600 storage.",
 		},
 
 		// ===== BRONZE AGE (costs: 1500-5000) =====
@@ -91,10 +95,11 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Warehouse", Key: "warehouse", Category: "storage",
 			BaseCost:    map[string]float64{"wood": 2000, "stone": 1500, "iron": 300},
 			CostScale:   1.2,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 3000}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 4000}},
 			BuildTicks:  80,
 			RequiredAge: "bronze_age",
-			Description: "Proper storage building. +3000 storage.",
+			Description: "Proper storage building. +4000 storage.",
 		},
 
 		// ===== IRON AGE (costs: 8k-25k) =====
@@ -102,10 +107,11 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Granary", Key: "granary", Category: "storage",
 			BaseCost:    map[string]float64{"wood": 8000, "stone": 6000},
 			CostScale:   1.2,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 12000}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 15000}},
 			BuildTicks:  120,
 			RequiredAge: "iron_age",
-			Description: "Organized supply storage. +12000 storage.",
+			Description: "Organized supply storage. +15000 storage.",
 		},
 
 		// ===== CLASSICAL AGE (costs: 40k-120k) =====
@@ -113,21 +119,26 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Classical Vault", Key: "classical_vault", Category: "storage",
 			BaseCost:    map[string]float64{"stone": 50000, "iron": 12000, "gold": 10000},
 			CostScale:   1.2,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 25000}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 100000}},
 			BuildTicks:  150,
 			RequiredAge: "classical_age",
-			Description: "Stone vault for valuables. +25000 storage.",
+			Description: "Stone vault for valuables. +100000 storage.",
 		},
 
 		// ===== MEDIEVAL AGE (costs: 200k-600k) =====
 		{
 			Name: "Keep", Key: "keep", Category: "storage",
+			// note: cap was badly under-provisioned (60k vs a ~340k normalized stone
+			// cost) — copy #1 cost ~5.7x the storage it gave. Raised to 400k so the
+			// keep delivers storage worthy of its (unchanged) high price.
 			BaseCost:    map[string]float64{"stone": 200000, "iron": 60000, "gold": 40000},
 			CostScale:   1.2,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 60000}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 400000}},
 			BuildTicks:  200,
 			RequiredAge: "medieval_age",
-			Description: "Fortified storehouse. +60000 storage.",
+			Description: "Fortified storehouse. +400000 storage.",
 		},
 
 		// ===== RENAISSANCE AGE (costs: 1M-3M) =====
@@ -135,6 +146,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Renaissance Vault", Key: "renaissance_vault", Category: "storage",
 			BaseCost:    map[string]float64{"stone": 250000, "gold": 150000, "iron": 60000},
 			CostScale:   1.2,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 500000}},
 			BuildTicks:  250,
 			RequiredAge: "renaissance_age",
@@ -146,6 +158,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Colonial Warehouse", Key: "colonial_warehouse", Category: "storage",
 			BaseCost:    map[string]float64{"wood": 1.5e6, "stone": 1e6, "gold": 600000},
 			CostScale:   1.2,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 10e6}},
 			BuildTicks:  300,
 			RequiredAge: "colonial_age",
@@ -157,6 +170,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Industrial Depot", Key: "industrial_depot", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 15e6, "iron": 20e6, "coal": 10e6},
 			CostScale:   1.2,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 50e6}},
 			BuildTicks:  400,
 			RequiredAge: "industrial_age",
@@ -168,6 +182,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Victorian Vault", Key: "victorian_vault", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 125e6, "gold": 100e6, "iron": 75e6},
 			CostScale:   1.2,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 350e6}},
 			BuildTicks:  500,
 			RequiredAge: "victorian_age",
@@ -179,6 +194,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Electric Warehouse", Key: "electric_warehouse", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 750e6, "electricity": 125e6, "iron": 500e6},
 			CostScale:   1.2,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 3.5e9}},
 			BuildTicks:  600,
 			RequiredAge: "electric_age",
@@ -188,12 +204,16 @@ func baseBuildingsRaw() []BuildingDef {
 		// ===== ATOMIC AGE (costs: 3B-10B) =====
 		{
 			Name: "Atomic Vault", Key: "atomic_vault", Category: "storage",
+			// note: 1.25 scale inflated the normalized stone cost to ~19B vs a 15B cap,
+			// so copy #1 walled immediately. Cap raised to 20B (still cheaper per-copy
+			// than its cost is high). MaxCount caps the stack under the flattened curve.
 			BaseCost:    map[string]float64{"steel": 5e9, "stone": 7.5e9, "iron": 3e9},
 			CostScale:   1.25,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 15e9}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 20e9}},
 			BuildTicks:  700,
 			RequiredAge: "atomic_age",
-			Description: "Radiation-shielded storage. +15B storage.",
+			Description: "Radiation-shielded storage. +20B storage.",
 		},
 
 		// ===== MODERN AGE (costs: 15B-50B) =====
@@ -201,10 +221,11 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Modern Depot", Key: "modern_depot", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 35e9, "gold": 25e9, "electricity": 8e9},
 			CostScale:   1.25,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 45e9}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 90e9}},
 			BuildTicks:  800,
 			RequiredAge: "modern_age",
-			Description: "Automated logistics center. +45B storage.",
+			Description: "Automated logistics center. +90B storage.",
 		},
 
 		// ===== INFORMATION AGE (costs: 75B-250B) =====
@@ -212,10 +233,11 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Info Vault", Key: "info_vault", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 100e9, "electricity": 40e9, "data": 625e6},
 			CostScale:   1.25,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 250e9}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 260e9}},
 			BuildTicks:  900,
 			RequiredAge: "information_age",
-			Description: "Digital-physical storage hybrid. +250B storage.",
+			Description: "Digital-physical storage hybrid. +260B storage.",
 		},
 
 		// ===== DIGITAL AGE (costs: 400B-1.2T) =====
@@ -223,6 +245,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Digital Archive", Key: "digital_archive", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 500e9, "data": 10e9, "electricity": 150e9},
 			CostScale:   1.25,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 1.5e12}},
 			BuildTicks:  1000,
 			RequiredAge: "digital_age",
@@ -234,10 +257,11 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Cyber Vault", Key: "cyber_vault", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 3e12, "data": 60e9, "crypto": 10e9},
 			CostScale:   1.25,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 5e12}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 8e12}},
 			BuildTicks:  1400,
 			RequiredAge: "cyberpunk_age",
-			Description: "Encrypted digital vault. +5T storage.",
+			Description: "Encrypted digital vault. +8T storage.",
 		},
 
 		// ===== FUSION AGE (costs: 10T-30T) =====
@@ -245,6 +269,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Fusion Vault", Key: "fusion_vault", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 10e12, "plasma": 500e9, "electricity": 5e12},
 			CostScale:   1.25,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 30e12}},
 			BuildTicks:  2000,
 			RequiredAge: "fusion_age",
@@ -256,6 +281,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Orbital Depot", Key: "orbital_depot", Category: "storage",
 			BaseCost:    map[string]float64{"steel": 50e12, "plasma": 6e12, "electricity": 30e12},
 			CostScale:   1.3,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 200e12}},
 			BuildTicks:  4000,
 			RequiredAge: "space_age",
@@ -267,6 +293,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Stellar Vault", Key: "stellar_vault", Category: "storage",
 			BaseCost:    map[string]float64{"titanium": 60e12, "plasma": 50e12, "electricity": 80e12},
 			CostScale:   1.3,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 500e12}},
 			BuildTicks:  6000,
 			RequiredAge: "interstellar_age",
@@ -278,6 +305,7 @@ func baseBuildingsRaw() []BuildingDef {
 			Name: "Galactic Vault", Key: "galactic_vault", Category: "storage",
 			BaseCost:    map[string]float64{"dark_matter": 100e12, "titanium": 500e12, "plasma": 200e12},
 			CostScale:   1.3,
+			MaxCount:    25,
 			Effects:     []Effect{{Type: "storage", Target: "all", Value: 2e15}},
 			BuildTicks:  10000,
 			RequiredAge: "galactic_age",
@@ -287,12 +315,15 @@ func baseBuildingsRaw() []BuildingDef {
 		// ===== QUANTUM AGE (costs: 6Q-20Q) =====
 		{
 			Name: "Quantum Vault", Key: "quantum_vault", Category: "storage",
+			// note: the steepest raw scale (1.35) inflated the normalized dark_matter
+			// cost to ~9.9Q vs a 5Q cap — copy #1 walled. Cap raised to 10Q to match.
 			BaseCost:    map[string]float64{"antimatter": 1e15, "dark_matter": 2e15, "titanium": 500e12},
 			CostScale:   1.35,
-			Effects:     []Effect{{Type: "storage", Target: "all", Value: 5e15}},
+			MaxCount:    25,
+			Effects:     []Effect{{Type: "storage", Target: "all", Value: 10e15}},
 			BuildTicks:  12000,
 			RequiredAge: "quantum_age",
-			Description: "Stores matter in quantum superposition. +5Q storage.",
+			Description: "Stores matter in quantum superposition. +10Q storage.",
 		},
 
 		// ===== TRANSCENDENT AGE =====

--- a/config/storage_cost_curve_test.go
+++ b/config/storage_cost_curve_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"math"
+	"testing"
+)
+
+// storageCapPerCopy returns the per-copy storage cap a storage building adds
+// (its "storage" Effect value), and whether such an effect exists.
+func storageCapPerCopy(d BuildingDef) (float64, bool) {
+	for _, e := range d.Effects {
+		if e.Type == "storage" {
+			return e.Value, true
+		}
+	}
+	return 0, false
+}
+
+// dominantBaseCost returns the largest single-resource cost in BaseCost. Because
+// storage buildings raise the cap of *every* resource equally (Effect.Target ==
+// "all"), the binding affordability constraint is always the most expensive
+// resource: if you can save up for that one, you can save up for the rest.
+func dominantBaseCost(d BuildingDef) float64 {
+	var max float64
+	for _, v := range d.BaseCost {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+// TestStorage_CostNeverWallsAboveCapProvided enforces the storage-lineage design
+// invariant for EVERY storage building at its runtime (post-normalizeCostCurves)
+// values: the cost of the N-th copy must never exceed the storage that N copies
+// provide, so a player can always save up for the next one and a storage building
+// never becomes an unaffordable wall.
+//
+// Literal, self-contained form (per the balance card):
+//
+//	cost(N) = dominantBaseCost × CostScale^(N-1)  ≤  N × capPerCopy
+//
+// for every N from 1 to MaxCount. This generalizes the single-building
+// TestStash_FirstCopyAffordableWithinBaseWoodCap guard to the whole lineage so a
+// future re-tune of any storage cost, cap, or MaxCount re-surfaces the regression
+// loudly. (This is the same class of bug as the old stash deadlock.)
+func TestStorage_CostNeverWallsAboveCapProvided(t *testing.T) {
+	// If a storage building is unlimited (MaxCount 0) or absurdly high, we can't
+	// loop forever — scan to this bound and additionally require the curve to stay
+	// affordable for at least minUnlimitedStack copies (a meaningful stack).
+	const (
+		unlimitedScanBound = 200
+		minUnlimitedStack  = 20
+	)
+
+	for key, d := range BuildingByKey() {
+		if d.Category != "storage" {
+			continue
+		}
+
+		cap, ok := storageCapPerCopy(d)
+		if !ok || cap <= 0 {
+			t.Errorf("storage building %q has no positive storage Effect — cannot provide cap", key)
+			continue
+		}
+		dom := dominantBaseCost(d)
+		if dom <= 0 {
+			t.Errorf("storage building %q has no positive build cost", key)
+			continue
+		}
+
+		// Decide how far to walk the cost curve.
+		limit := d.MaxCount
+		unlimited := d.MaxCount == 0 || d.MaxCount > unlimitedScanBound
+		if unlimited {
+			limit = unlimitedScanBound
+		}
+
+		// Walk every copy 1..limit and assert cost(N) <= N*cap.
+		firstWall := -1
+		for n := 1; n <= limit; n++ {
+			cost := dom * math.Pow(d.CostScale, float64(n-1))
+			capProvided := float64(n) * cap
+			if cost > capProvided {
+				firstWall = n
+				break
+			}
+		}
+
+		if firstWall != -1 {
+			if unlimited {
+				// Unlimited building: a wall anywhere short of a meaningful stack is
+				// a softlock waiting to happen. (Walls >= minUnlimitedStack are still
+				// unreachable in practice but cap MaxCount to be safe — see below.)
+				if firstWall < minUnlimitedStack {
+					t.Errorf("storage %q (MaxCount=0/unlimited) walls at copy %d: "+
+						"cost %.0f > %d × capPerCopy %.0f — set MaxCount below the wall, "+
+						"lower BaseCost, or raise the cap",
+						key, firstWall, dom*math.Pow(d.CostScale, float64(firstWall-1)), firstWall, cap)
+				} else {
+					// Affordable for a meaningful stack but technically unbounded —
+					// the design now caps every storage building, so flag the gap.
+					t.Errorf("storage %q has MaxCount=0 (unlimited) and would wall at "+
+						"copy %d — set an explicit MaxCount below the wall so the building "+
+						"cannot be built into the unaffordable zone", key, firstWall)
+				}
+			} else {
+				// Bounded building must stay affordable across its ENTIRE allowed range.
+				t.Errorf("storage %q walls at copy %d of MaxCount %d: cost %.0f > %d × "+
+					"capPerCopy %.0f — lower MaxCount below the wall, lower BaseCost, or "+
+					"raise the cap",
+					key, firstWall, d.MaxCount,
+					dom*math.Pow(d.CostScale, float64(firstWall-1)), firstWall, cap)
+			}
+		}
+	}
+}

--- a/site/docs/buildings.md
+++ b/site/docs/buildings.md
@@ -282,29 +282,31 @@ Your 20 Gathering Camps stay as Gathering Camps — producing at their full rate
 
 Storage buildings form their own lineage and expand your resource cap for **every** resource simultaneously. Unlike production buildings, storage buildings require no workers — just build them and the caps go up.
 
-| Building | Age | Effect |
-|----------|-----|--------|
-| Stash | Primitive | +300 all storage (hard-capped at 50) |
-| Storage Pit | Stone | +500 all storage |
-| Warehouse | Bronze | +3,000 all storage |
-| Granary | Iron | +12,000 all storage |
-| Classical Vault | Classical | +25,000 all storage |
-| Keep | Medieval | +60,000 all storage |
-| Renaissance Vault | Renaissance | +500,000 all storage |
-| Colonial Warehouse | Colonial | +10M all storage |
-| Industrial Depot | Industrial | +50M all storage |
-| Victorian Vault | Victorian | +350M all storage |
-| Electric Warehouse | Electric | +3.5B all storage |
-| Atomic Vault | Atomic | +15B all storage |
-| Modern Depot | Modern | +45B all storage |
-| Info Vault | Information | +250B all storage |
-| Digital Archive | Digital | +1.5T all storage |
-| Cyber Vault | Cyberpunk | +5T all storage |
-| Fusion Vault | Fusion | +30T all storage |
-| Orbital Depot | Space | +200T all storage |
-| Stellar Vault | Interstellar | +500T all storage |
-| Galactic Vault | Galactic | +2Q all storage |
-| Quantum Vault | Quantum | +5Q all storage |
+Every storage building is **capped at 25 copies** (Stash at 50). The cap exists by design: each tier's storage-per-copy is at least its dominant build cost, so a full stack always provides more cap than it costs and a storage building never becomes an unaffordable wall — but the flattened cost curve would eventually outrun even that, so the stack is bounded just below where it would. Advance to the next tier instead of over-stacking.
+
+| Building | Age | Effect | Max |
+|----------|-----|--------|-----|
+| Stash | Primitive | +300 all storage | 50 |
+| Storage Pit | Stone | +600 all storage | 25 |
+| Warehouse | Bronze | +4,000 all storage | 25 |
+| Granary | Iron | +15,000 all storage | 25 |
+| Classical Vault | Classical | +100,000 all storage | 25 |
+| Keep | Medieval | +400,000 all storage | 25 |
+| Renaissance Vault | Renaissance | +500,000 all storage | 25 |
+| Colonial Warehouse | Colonial | +10M all storage | 25 |
+| Industrial Depot | Industrial | +50M all storage | 25 |
+| Victorian Vault | Victorian | +350M all storage | 25 |
+| Electric Warehouse | Electric | +3.5B all storage | 25 |
+| Atomic Vault | Atomic | +20B all storage | 25 |
+| Modern Depot | Modern | +90B all storage | 25 |
+| Info Vault | Information | +260B all storage | 25 |
+| Digital Archive | Digital | +1.5T all storage | 25 |
+| Cyber Vault | Cyberpunk | +8T all storage | 25 |
+| Fusion Vault | Fusion | +30T all storage | 25 |
+| Orbital Depot | Space | +200T all storage | 25 |
+| Stellar Vault | Interstellar | +500T all storage | 25 |
+| Galactic Vault | Galactic | +2Q all storage | 25 |
+| Quantum Vault | Quantum | +10Q all storage | 25 |
 
 > **Tip:** Stash is hard-capped at 50. Transition to Storage Pit the moment you enter the Stone Age. Storage bottlenecks stop all late-game resource accumulation dead — build storage first when entering every new age.
 


### PR DESCRIPTION
Resolves the **Storage lineage cost curve** balance card.

**The surprise:** the cost-curve flattening earlier this release fixed storage *scales* (all 1.13) — but not affordability. `normalizeCostCurves` multiplies BaseCost by `(oldScale/1.13)^9`, which **inflated** the steep late vaults' base costs past their storage caps, and several caps were under-provisioned. Audit of all 21 storage buildings: **20 failed** the card's principle (cost of copy N must not exceed the storage N copies provide) — some walling at copy 1 (genuine deadlock), others at copy ~29-43 with unlimited MaxCount.

**Fix:** MaxCount **25** for all storage (stash stays 50) — below every wall, above a ~20-copy floor; plus raised caps on the deadlock-class tiers so copy 1 is affordable. CostScale stays 1.13. A new test asserts `cost(N) ≤ N × capPerCopy` for every storage building across its whole build range — generalizes the stash deadlock guard to the lineage.

⚠️ **Gameplay note:** storage is now capped at 25/building (was unlimited for most). Per-copy caps are big, you build many tiers, and you advance — total storage stays ample — but it's a real change the card explicitly invited ("Consider whether MaxCount needs adjusting per tier").

`go build/vet/test` green. Changelog + wiki updated.