### PR TITLE
balance(milestones): rebalance chains — normalized boosts, Trade 3→5, broad capstones (card moYvpYY9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to AgeForge are documented here.
 - Flattened building cost curves and raised age-advancement requirements.
 - Capped age-transition carryover to a starter head-start.
 - `gather` yield raised 10 → 25 and disabled past the Medieval age.
+- Milestone chains rebalanced: completion speed-boosts normalized across all six chains (Military was 18× weaker than Settlement — now in line); the Trade chain expanded 3 → 5 milestones; and Military/Trade/Scholar capstones now pay out broad `production_all` instead of domain-only bonuses, so finishing any chain helps your whole economy.
 
 ### Fixed
 - Theme picker no longer deadlocks the app on arrow/Esc.

--- a/config/milestones.go
+++ b/config/milestones.go
@@ -82,8 +82,8 @@ func MilestoneChains() []MilestoneChainDef {
 				"grand_architect", "wonder_collector",
 			},
 			Title:         "The Architects",
-			BoostValue:    1.5,
-			BoostDuration: 90,
+			BoostValue:    2.5,
+			BoostDuration: 150,
 		},
 		{
 			Name:     "Military Chain",
@@ -94,19 +94,20 @@ func MilestoneChains() []MilestoneChainDef {
 				"fortress_state", "military_superpower",
 			},
 			Title:         "The Conquerors",
-			BoostValue:    0.5,
-			BoostDuration: 60,
+			BoostValue:    2.5,
+			BoostDuration: 150,
 		},
 		{
 			Name:     "Trade Chain",
 			Key:      "trade_chain",
 			Category: "trade",
 			MilestoneKeys: []string{
-				"first_market", "merchant_guild", "trade_empire",
+				"first_market", "merchant_guild", "caravan_network",
+				"merchant_princes", "trade_empire",
 			},
 			Title:         "The Merchants",
-			BoostValue:    1.0,
-			BoostDuration: 90,
+			BoostValue:    2.5,
+			BoostDuration: 150,
 		},
 		{
 			Name:     "Ancient Ages Chain",
@@ -480,7 +481,8 @@ func Milestones() []MilestoneDef {
 				{Type: "permanent_bonus", Target: "knowledge_rate", Value: 0.15},
 			},
 		},
-		// tech_master: raised to 50 techs; industrial age gated
+		// tech_master: raised to 50 techs; industrial age gated.
+		// Capstone broadened — keeps research_speed, adds a touch of production_all.
 		{
 			Name: "Tech Master", Key: "tech_master",
 			Description: "Research 50 technologies.",
@@ -488,7 +490,8 @@ func Milestones() []MilestoneDef {
 			MinAge:       "industrial_age",
 			MinTechCount: 50,
 			Rewards: []Effect{
-				{Type: "permanent_bonus", Target: "research_speed", Value: 0.15},
+				{Type: "permanent_bonus", Target: "research_speed", Value: 0.10},
+				{Type: "permanent_bonus", Target: "production_all", Value: 0.05},
 			},
 		},
 		// NEW: tech_ascendant — all 52 techs; quantum age gated
@@ -538,7 +541,8 @@ func Milestones() []MilestoneDef {
 				{Type: "permanent_bonus", Target: "military_power", Value: 0.05},
 			},
 		},
-		// iron_legion: raised to 500 soldiers + 10 barracks; classical age
+		// iron_legion: 500 soldiers + 10 barracks; classical age.
+		// Broadened to production_all so the chain helps the whole economy.
 		{
 			Name: "Iron Legion", Key: "iron_legion",
 			Description:  "Train 500 soldiers and build 10 Barracks.",
@@ -546,10 +550,11 @@ func Milestones() []MilestoneDef {
 			MinAge:       "classical_age",
 			MinBuildings: map[string]int{"barracks": 10},
 			Rewards: []Effect{
-				{Type: "permanent_bonus", Target: "military_power", Value: 0.10},
+				{Type: "permanent_bonus", Target: "production_all", Value: 0.05},
 			},
 		},
-		// fortress_state: raised to 20 castle keeps; medieval age
+		// fortress_state: 20 castle keeps; medieval age. Dual payout —
+		// keeps a military_power bonus but adds broad production_all.
 		{
 			Name: "Fortress State", Key: "fortress_state",
 			Description:  "Build 20 Castle Keeps.",
@@ -558,16 +563,18 @@ func Milestones() []MilestoneDef {
 			MinBuildings: map[string]int{"castle_keep": 20},
 			Rewards: []Effect{
 				{Type: "permanent_bonus", Target: "military_power", Value: 0.10},
+				{Type: "permanent_bonus", Target: "production_all", Value: 0.05},
 			},
 		},
-		// military_superpower: raised to 2,000 soldiers; industrial age
+		// military_superpower: 2,000 soldiers; industrial age.
+		// Capstone broadened to production_all (was military_power).
 		{
 			Name: "Military Superpower", Key: "military_superpower",
 			Description: "Field 2,000 soldiers.",
 			Category:    "military", Hidden: true,
 			MinAge:      "industrial_age",
 			Rewards: []Effect{
-				{Type: "permanent_bonus", Target: "military_power", Value: 0.15},
+				{Type: "permanent_bonus", Target: "production_all", Value: 0.15},
 			},
 		},
 
@@ -597,15 +604,39 @@ func Milestones() []MilestoneDef {
 				{Type: "permanent_bonus", Target: "gold_rate", Value: 0.05},
 			},
 		},
-		// trade_empire: raised to 20 trading posts + 8 merchant quarters; medieval age
+		// caravan_network: 5 trading posts; classical age (trading_post unlocks iron age)
 		{
-			Name: "Trade Empire", Key: "trade_empire",
-			Description:  "Build 20 Trading Posts and 8 Merchant Quarters.",
-			Category:     "trade", Hidden: true,
-			MinAge:       "medieval_age",
-			MinBuildings: map[string]int{"trading_post": 20, "merchant_quarter": 8},
+			Name: "Caravan Network", Key: "caravan_network",
+			Description:  "Operate 5 Trading Posts.",
+			Category:     "trade",
+			MinAge:       "classical_age",
+			MinBuildings: map[string]int{"trading_post": 5},
 			Rewards: []Effect{
 				{Type: "permanent_bonus", Target: "gold_rate", Value: 0.10},
+			},
+		},
+		// merchant_princes: 12 trading posts + 4 merchant quarters; medieval age.
+		// Broadened to production_all so the mid-chain payout helps the whole economy.
+		{
+			Name: "Merchant Princes", Key: "merchant_princes",
+			Description:  "Build 12 Trading Posts and 4 Merchant Quarters.",
+			Category:     "trade", Hidden: true,
+			MinAge:       "medieval_age",
+			MinBuildings: map[string]int{"trading_post": 12, "merchant_quarter": 4},
+			Rewards: []Effect{
+				{Type: "permanent_bonus", Target: "production_all", Value: 0.05},
+			},
+		},
+		// trade_empire: capstone scaled to 30 trading posts + 12 merchant quarters;
+		// renaissance age. Broadened to production_all (was gold_rate).
+		{
+			Name: "Trade Empire", Key: "trade_empire",
+			Description:  "Build 30 Trading Posts and 12 Merchant Quarters.",
+			Category:     "trade", Hidden: true,
+			MinAge:       "renaissance_age",
+			MinBuildings: map[string]int{"trading_post": 30, "merchant_quarter": 12},
+			Rewards: []Effect{
+				{Type: "permanent_bonus", Target: "production_all", Value: 0.10},
 			},
 		},
 		// guildhall_master — 10 guildhalls; renaissance age

--- a/game/milestones_test.go
+++ b/game/milestones_test.go
@@ -2,6 +2,8 @@ package game
 
 import (
 	"testing"
+
+	"github.com/espresso20/ageforge/config"
 )
 
 // fullAgeOrder returns a complete age order map for tests
@@ -228,4 +230,180 @@ func TestMilestoneManager_SaveLoadRoundTrip(t *testing.T) {
 	if mm2.currentTitle != "The Conquerors" {
 		t.Errorf("loaded title = %v, want The Conquerors", mm2.currentTitle)
 	}
+}
+
+// TestMilestoneChain_CompletionBoosts guards the chain rebalance: every chain's
+// completion speed-boost must match the normalized values. Military used to be
+// 18x weaker than Settlement; this pins all six so a future edit can't silently
+// regress the balance.
+func TestMilestoneChain_CompletionBoosts(t *testing.T) {
+	want := map[string]struct {
+		value    float64
+		duration int
+	}{
+		"settlement_chain":   {3.0, 180},
+		"scholar_chain":      {3.0, 180},
+		"builder_chain":      {2.5, 150},
+		"military_chain":     {2.5, 150},
+		"trade_chain":        {2.5, 150},
+		"ancient_ages_chain": {2.5, 150},
+	}
+
+	chains := config.MilestoneChainByKey()
+	if len(chains) != len(want) {
+		t.Fatalf("chain count = %d, want %d", len(chains), len(want))
+	}
+	for key, exp := range want {
+		c, ok := chains[key]
+		if !ok {
+			t.Errorf("missing chain %q", key)
+			continue
+		}
+		if c.BoostValue != exp.value {
+			t.Errorf("%s BoostValue = %v, want %v", key, c.BoostValue, exp.value)
+		}
+		if c.BoostDuration != exp.duration {
+			t.Errorf("%s BoostDuration = %v, want %v", key, c.BoostDuration, exp.duration)
+		}
+	}
+}
+
+// TestTradeChain_Structure verifies the Trade chain was expanded from 3 to 5
+// milestones in the correct order, and that the two new milestones exist, are
+// categorized as trade, and map back to trade_chain.
+func TestTradeChain_Structure(t *testing.T) {
+	chain := config.MilestoneChainByKey()["trade_chain"]
+	wantKeys := []string{
+		"first_market", "merchant_guild", "caravan_network",
+		"merchant_princes", "trade_empire",
+	}
+	if len(chain.MilestoneKeys) != len(wantKeys) {
+		t.Fatalf("trade_chain has %d milestones, want %d", len(chain.MilestoneKeys), len(wantKeys))
+	}
+	for i, k := range wantKeys {
+		if chain.MilestoneKeys[i] != k {
+			t.Errorf("trade_chain key[%d] = %q, want %q", i, chain.MilestoneKeys[i], k)
+		}
+	}
+
+	byKey := config.MilestoneByKey()
+	for _, k := range []string{"caravan_network", "merchant_princes"} {
+		def, ok := byKey[k]
+		if !ok {
+			t.Errorf("new trade milestone %q not found in Milestones()", k)
+			continue
+		}
+		if def.Category != "trade" {
+			t.Errorf("%s category = %q, want trade", k, def.Category)
+		}
+	}
+}
+
+// TestTradeChain_NewMilestonesComplete drives the two new Trade milestones
+// through the real engine check path: they must stay incomplete below threshold
+// and complete once buildings + age conditions are met.
+func TestTradeChain_NewMilestonesComplete(t *testing.T) {
+	mm := NewMilestoneManager()
+	rm := NewResourceManager()
+	bm := NewBuildingManager()
+	ageOrder := fullAgeOrder()
+
+	// caravan_network: classical_age + 5 trading_post.
+	// Below threshold (4 posts, classical) → no completion.
+	bm.counts["trading_post"] = 4
+	completed := mm.CheckMilestones(1, "classical_age", ageOrder, rm, bm, 0, 0, 0, nil, 0, 0, 0)
+	for _, ms := range completed {
+		if ms.Key == "caravan_network" {
+			t.Error("caravan_network should not complete with only 4 trading posts")
+		}
+	}
+
+	// 5 posts but still iron_age → age gate blocks it.
+	bm.counts["trading_post"] = 5
+	completed = mm.CheckMilestones(2, "iron_age", ageOrder, rm, bm, 0, 0, 0, nil, 0, 0, 0)
+	for _, ms := range completed {
+		if ms.Key == "caravan_network" {
+			t.Error("caravan_network should not complete before classical_age")
+		}
+	}
+
+	// 5 posts in classical_age → completes.
+	completed = mm.CheckMilestones(3, "classical_age", ageOrder, rm, bm, 0, 0, 0, nil, 0, 0, 0)
+	if !containsKey(completed, "caravan_network") {
+		t.Error("caravan_network should complete with 5 trading posts in classical_age")
+	}
+
+	// merchant_princes: medieval_age + 12 trading_post + 4 merchant_quarter.
+	bm.counts["trading_post"] = 12
+	bm.counts["merchant_quarter"] = 3 // one short
+	completed = mm.CheckMilestones(4, "medieval_age", ageOrder, rm, bm, 0, 0, 0, nil, 0, 0, 0)
+	for _, ms := range completed {
+		if ms.Key == "merchant_princes" {
+			t.Error("merchant_princes should not complete with only 3 merchant quarters")
+		}
+	}
+
+	bm.counts["merchant_quarter"] = 4
+	completed = mm.CheckMilestones(5, "medieval_age", ageOrder, rm, bm, 0, 0, 0, nil, 0, 0, 0)
+	if !containsKey(completed, "merchant_princes") {
+		t.Error("merchant_princes should complete with 12 trading posts + 4 merchant quarters in medieval_age")
+	}
+}
+
+// TestMilestoneChain_InjectsBoostEvent reproduces the engine's chain-completion
+// path (CheckChains -> InjectEvent) and asserts the injected tick_speed event
+// carries the chain's normalized BoostValue and BoostDuration. Previously the
+// boost injection had no test coverage.
+func TestMilestoneChain_InjectsBoostEvent(t *testing.T) {
+	mm := NewMilestoneManager()
+	em := NewEventManager()
+
+	// Complete the military chain (now 2.5 / 150).
+	for _, k := range []string{
+		"first_soldiers", "war_machine", "iron_legion",
+		"fortress_state", "military_superpower",
+	} {
+		mm.completed[k] = true
+	}
+
+	newChains := mm.CheckChains()
+	if len(newChains) != 1 || newChains[0].Key != "military_chain" {
+		t.Fatalf("expected military_chain to complete, got %v", newChains)
+	}
+
+	// Mirror engine.go: inject the speed boost for each newly completed chain.
+	for _, chain := range newChains {
+		em.InjectEvent(ActiveEvent{
+			Key:       chain.Key + "_boost",
+			Name:      chain.Name + " Speed Boost",
+			TicksLeft: chain.BoostDuration,
+			Effects: []config.Effect{
+				{Type: "tick_speed", Target: "tick_speed", Value: chain.BoostValue},
+			},
+		})
+	}
+
+	// The injected event must expose a tick_speed effect of +2.5.
+	var found bool
+	for _, eff := range em.GetActiveEffects() {
+		if eff.Type == "tick_speed" {
+			found = true
+			if eff.Value != 2.5 {
+				t.Errorf("military chain boost value = %v, want 2.5", eff.Value)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a tick_speed effect from the injected chain boost")
+	}
+}
+
+// containsKey reports whether a completed-milestone slice includes the given key.
+func containsKey(defs []config.MilestoneDef, key string) bool {
+	for _, d := range defs {
+		if d.Key == key {
+			return true
+		}
+	}
+	return false
 }

--- a/site/docs/milestones.md
+++ b/site/docs/milestones.md
@@ -1,6 +1,6 @@
 # Milestones & Chains
 
-74 milestones are grouped into 6 chains. Completing all milestones in a chain grants your civilization a **title** and a **temporary speed boost**. Some milestones are hidden until you make progress toward them.
+76 milestones are grouped into 6 chains. Completing all milestones in a chain grants your civilization a **title** and a **temporary speed boost**. Some milestones are hidden until you make progress toward them.
 
 ---
 
@@ -12,9 +12,9 @@ When a chain is completed, its title overrides any count-based fallback:
 |---|---|---|
 | Settlement | "The Founders" | +3.0× for 180 ticks |
 | Scholar | "The Enlightened" | +3.0× for 180 ticks |
-| Builder | "The Architects" | +1.5× for 90 ticks |
-| Military | "The Conquerors" | +0.5× for 60 ticks |
-| Trade | "The Merchants" | +1.0× for 90 ticks |
+| Builder | "The Architects" | +2.5× for 150 ticks |
+| Military | "The Conquerors" | +2.5× for 150 ticks |
+| Trade | "The Merchants" | +2.5× for 150 ticks |
 | Ancient Ages | "The Ancients" | +2.5× for 150 ticks |
 
 If no chain is completed, fallback titles apply:
@@ -37,11 +37,11 @@ If no chain is completed, fallback titles apply:
 | Milestone | Condition | Reward |
 |---|---|---|
 | First Shelter | Build 1 Hut | +10 food |
-| Small Village | Population: 200 | +50 wood |
-| Bustling Town | Population: 5,000 | +0.05 food rate |
-| Growing City | Population: 50,000 | +0.10 food rate |
-| Metropolis *(hidden)* | Population: 1,000,000 | +10% all production |
-| Megalopolis *(hidden)* | Population: 50,000,000 | +20% all production |
+| Small Village | Population: 5,000 | +50 wood |
+| Bustling Town | Population: 50,000 | +5% food rate |
+| Growing City | Population: 500,000 (Bronze Age) | +10% food rate |
+| Metropolis *(hidden)* | Population: 10,000,000 (Iron Age) | +10% all production |
+| Megalopolis *(hidden)* | Population: 1,000,000,000 (Classical Age) | +20% all production |
 
 **Chain reward:** Title: "The Founders" · Speed boost ×3.0 for 180 ticks
 
@@ -53,12 +53,12 @@ If no chain is completed, fallback titles apply:
 
 | Milestone | Condition | Reward |
 |---|---|---|
-| Knowledge Seeker | Accumulate 200 knowledge | +0.05 knowledge rate |
+| Knowledge Seeker | Accumulate 10,000 knowledge | +5% knowledge rate |
 | First Research | Complete 1 technology | +50 knowledge |
-| Tech Pioneer | Complete 8 technologies | +0.05 research speed |
-| Scholar's Haven | Build 3 Libraries + 50 knowledge workers | +0.10 knowledge rate |
-| Renaissance Mind *(hidden)* | Complete 20 technologies | +0.10 research speed |
-| Tech Master *(hidden)* | Complete 30 technologies | +0.10 research speed |
+| Tech Pioneer | Complete 15 technologies | +5% research speed |
+| Scholar's Haven | Build 3 Libraries + 50 knowledge workers | +10% knowledge rate |
+| Renaissance Mind *(hidden)* | Complete 42 technologies | +10% research speed |
+| Tech Master *(hidden)* | Complete 50 technologies | +10% research speed, +5% all production |
 
 **Chain reward:** Title: "The Enlightened" · Speed boost ×3.0 for 180 ticks
 
@@ -70,15 +70,15 @@ If no chain is completed, fallback titles apply:
 
 | Milestone | Condition | Reward |
 |---|---|---|
-| Stone Mason | Build 5 Stone Pits | +0.10 stone rate |
-| Master Builder | Build 500 total structures | -5% build cost |
+| Stone Mason | Build 50 Stone Pits | +10% stone rate |
+| Master Builder | Build 5,000 total structures | -5% build cost |
 | Wonder Builder *(hidden)* | Complete 1 wonder | +5% all production |
-| Grand Architect *(hidden)* | Build 1,000 structures | -5% build cost, +5% production |
-| Wonder Collector *(hidden)* | Construct 3 Wonders | +10% all production |
+| Grand Architect *(hidden)* | Build 20,000 structures (Medieval Age) | -5% build cost, +5% all production |
+| Wonder Collector *(hidden)* | Construct 8 Wonders (Colonial Age) | +10% all production |
 
 The `-5% build cost` rewards here (Master Builder, Grand Architect) are functional, not flavor: they reduce the actual cumulative cost of every building you queue, and the saving shows up in the cost the build menu displays. Stacked with the other build-cost rewards across the game (and the Civil Engineering tech), the reductions currently reach roughly −24%, floored at 10% of base. See [Buildings](buildings.md#build-cost-reductions).
 
-**Chain reward:** Title: "The Architects" · Speed boost ×1.5 for 90 ticks
+**Chain reward:** Title: "The Architects" · Speed boost ×2.5 for 150 ticks
 
 ---
 
@@ -88,13 +88,15 @@ The `-5% build cost` rewards here (Master Builder, Grand Architect) are function
 
 | Milestone | Condition | Reward |
 |---|---|---|
-| First Soldiers | Train 5 soldiers | +5% military power |
+| First Soldiers | Train 5 soldiers (Iron Age) | +5% military power |
 | War Machine | Train 250 soldiers | +10% military power |
-| Iron Legion *(hidden)* | 500 soldiers + 10 Barracks | +10% military power |
-| Fortress State *(hidden)* | 20 Castle Keeps | +10% military power |
-| Military Superpower *(hidden)* | 2,000 soldiers | +15% military power |
+| Iron Legion *(hidden)* | 500 soldiers + 10 Barracks (Classical Age) | +5% all production |
+| Fortress State *(hidden)* | 20 Castle Keeps (Medieval Age) | +10% military power, +5% all production |
+| Military Superpower *(hidden)* | 2,000 soldiers (Industrial Age) | +15% all production |
 
-**Chain reward:** Title: "The Conquerors" · Speed boost ×0.5 for 60 ticks
+**Chain reward:** Title: "The Conquerors" · Speed boost ×2.5 for 150 ticks
+
+The late tiers now pay out broad `all production` rather than `military power` only, so finishing the Military chain accelerates your whole economy — not just expeditions and combat.
 
 > **Note:** Standing Army (100 soldiers + 10 Barracks, Classical Age) is a standalone military milestone and not part of the chain.
 
@@ -106,11 +108,15 @@ The `-5% build cost` rewards here (Master Builder, Grand Architect) are function
 
 | Milestone | Condition | Reward |
 |---|---|---|
-| First Market | Build 1 Market | +25 gold |
-| Merchant Guild | Build 5 Markets | +5% gold rate |
-| Trade Empire *(hidden)* | 3 Trading Posts + Merchant Quarter | +10% gold rate |
+| First Market | Build 1 Market (Bronze Age) | +25 gold |
+| Merchant Guild | Operate 8 Markets (Iron Age) | +5% gold rate |
+| Caravan Network | Operate 5 Trading Posts (Classical Age) | +10% gold rate |
+| Merchant Princes *(hidden)* | 12 Trading Posts + 4 Merchant Quarters (Medieval Age) | +5% all production |
+| Trade Empire *(hidden)* | 30 Trading Posts + 12 Merchant Quarters (Renaissance Age) | +10% all production |
 
-**Chain reward:** Title: "The Merchants" · Speed boost ×1.0 for 90 ticks
+**Chain reward:** Title: "The Merchants" · Speed boost ×2.5 for 150 ticks
+
+The Trade chain expanded from 3 to 5 milestones, and its two capstones now grant broad `all production` instead of `gold rate` only — completing it lifts every resource, not just your coffers.
 
 ---
 
@@ -123,8 +129,8 @@ The `-5% build cost` rewards here (Master Builder, Grand Architect) are function
 | Bronze Age Pioneer | Bronze Age | +30 iron, +30 gold |
 | Iron Forged | Iron Age | +40 coal, +10% iron rate |
 | Classical Scholar | Classical Age | +150 knowledge, +10% knowledge rate |
-| Medieval Lord | Medieval Age | — |
-| Enlightened | Renaissance Age | — |
+| Medieval Lord | Medieval Age | +50 faith, +25 steel |
+| Enlightened | Renaissance Age | +75 culture, +15% knowledge rate |
 
 **Chain reward:** Title: "The Ancients" · Speed boost ×2.5 for 150 ticks
 
@@ -136,21 +142,21 @@ The `-5% build cost` rewards here (Master Builder, Grand Architect) are function
 
 | Milestone | Age required | Reward |
 |---|---|---|
-| Colonial Power *(hidden)* | Colonial Age | — |
-| Industrial Revolution *(hidden)* | Industrial Age | — |
-| Victorian Innovation *(hidden)* | Victorian Age | — |
-| Electric Dawn *(hidden)* | Electric Age | — |
-| Atomic Pioneer *(hidden)* | Atomic Age | — |
-| Modern Era *(hidden)* | Modern Age | — |
-| Information Pioneer *(hidden)* | Information Age | — |
-| Digital Native *(hidden)* | Digital Age | — |
-| Cyberpunk *(hidden)* | Cyberpunk Age | — |
-| Fusion Pioneer *(hidden)* | Fusion Age | — |
-| Space Explorer *(hidden)* | Space Age | — |
-| Star Voyager *(hidden)* | Interstellar Age | — |
-| Galactic Emperor *(hidden)* | Galactic Age | — |
-| Quantum Master *(hidden)* | Quantum Age | — |
-| Transcended *(hidden)* | Transcendent Age | — |
+| Colonial Power *(hidden)* | Colonial Age | +15% gold rate, +10% expedition reward |
+| Industrial Revolution *(hidden)* | Industrial Age | +15% all production |
+| Victorian Innovation *(hidden)* | Victorian Age | +10% all production |
+| Electric Dawn *(hidden)* | Electric Age | +15% all production |
+| Atomic Pioneer *(hidden)* | Atomic Age | +15% all production |
+| Modern Era *(hidden)* | Modern Age | +20% all production |
+| Information Pioneer *(hidden)* | Information Age | +20% knowledge rate |
+| Digital Native *(hidden)* | Digital Age | +20% all production |
+| Cyberpunk *(hidden)* | Cyberpunk Age | +15% gather rate |
+| Fusion Pioneer *(hidden)* | Fusion Age | +20% all production |
+| Space Explorer *(hidden)* | Space Age | +20% all production, +20% expedition reward |
+| Star Voyager *(hidden)* | Interstellar Age | +20% all production |
+| Galactic Emperor *(hidden)* | Galactic Age | +20% all production |
+| Quantum Master *(hidden)* | Quantum Age | +20% all production |
+| Transcended *(hidden)* | Transcendent Age | +50% all production |
 
 ---
 
@@ -174,10 +180,10 @@ Additional milestones outside the main chains cover faith, trade, epoch longevit
 
 ## Tips
 
-- **Prioritise Scholar and Settlement chains** — their speed boosts are enormous (+3.0× for 3 minutes) and the milestones align naturally with good play
+- **Scholar and Settlement chains** carry the biggest boosts (+3.0× for 3 minutes), but every chain is now worth finishing — Builder, Military, Trade, and Ancient Ages all grant +2.5× for 150 ticks
 - **Hidden milestones** appear in the Milestones panel once you have >50% progress toward them or have completed the preceding age
 - Chain speed boosts stack with milestone bonuses and prestige upgrades — when multiple boosts fire at once, the multiplication is dramatic
-- The **Trade Chain** is new — build Markets early to unlock it alongside the Builder chain for efficient mid-game momentum
+- The **Military, Trade, and Scholar** capstones now pay out broad `all production` bonuses, so completing any chain helps your whole economy — not just its own domain
 
 ---
 

--- a/site/docs/military.md
+++ b/site/docs/military.md
@@ -10,7 +10,7 @@ The military system does four things:
 
 - **Campaigns** — spend stockpiled soldiers on timed military missions that return resources, gold, and knowledge on success (waged with `campaign <key>`). Soldier-free **scouting expeditions** (`expedition <key>`) cover the same ground without troops — see [§4](#4-expeditions).
 - **Defense rating** — a passive stat derived from soldier count and military bonuses that reduces damage from hostile epoch events.
-- **Milestones** — five military milestones grant permanent `military_power` bonuses and chain into a title reward.
+- **Milestones** — five military milestones chain into a title reward; the early tiers grant permanent `military_power`, while the late tiers now pay out broad `all production`.
 - **Prestige** — prestige upgrades `military_power` and `expedition_loot` carry over through resets, compounding across runs.
 
 **Soldiers are a resource** (the 26th), not a worker domain count. They are *produced and stored by your military buildings*: assign military-domain workers to a War Camp or Barracks and it generates the `soldiers` resource every tick, the same way a Farm generates food. The military domain — and the soldiers resource — unlock at the **Iron Age**. Before then, the **scouting** expeditions (see [§4](#4-expeditions)) let you explore for resources without any soldiers at all.
@@ -248,7 +248,7 @@ Sources, stacked additively:
 | Source | How to get it | Bonus per step |
 |--------|-------------|---------------|
 | **Research techs** | Various military-flavored techs grant `military_power` bonus | +0.2 to +1.5 per tech |
-| **Permanent bonuses** (milestones) | Complete military milestones | +0.05 to +0.15 each |
+| **Permanent bonuses** (milestones) | Complete military milestones | +0.05 to +0.10 each (`military_power`) |
 | **Prestige upgrade** | `prestige buy military_power` (5 tiers, 2/3/5/8/10 pts each) | +5% per tier |
 
 There is no hard cap on `military_power`, but effective expedition difficulty is floored at **0.05** (5% chance of failure minimum), so stacking beyond ~2.5–3.0 bonus yields diminishing returns against failure rates.
@@ -259,15 +259,15 @@ The `expedition_reward` bonus (from research, prestige `expedition_loot`, and ce
 
 ## 7. Military Milestones
 
-The five military milestones form a chain. Completing the full chain grants a permanent title and a cumulative **+0.50 military_power** bonus.
+The five military milestones form a chain. Completing the full chain grants a permanent title plus, cumulatively, **+0.25 military_power** and **+0.25 production_all** — the late tiers now broaden into all-production bonuses so the chain lifts your whole economy, not just combat.
 
 | Key | Name | Requirement | Age Gate | Reward |
 |-----|------|-------------|----------|--------|
 | `first_soldiers` | First Soldiers | 5 soldiers | Iron Age | +0.05 military_power |
 | `war_machine` | War Machine | 250 soldiers | Iron Age | +0.10 military_power |
-| `iron_legion` | Iron Legion | 500 soldiers + 10 Barracks | Classical Age | +0.10 military_power |
-| `fortress_state` | Fortress State | 20 Castle Keeps | Medieval Age | +0.10 military_power |
-| `military_superpower` | Military Superpower | 2,000 soldiers | Industrial Age | +0.15 military_power |
+| `iron_legion` | Iron Legion | 500 soldiers + 10 Barracks | Classical Age | +0.05 production_all |
+| `fortress_state` | Fortress State | 20 Castle Keeps | Medieval Age | +0.10 military_power, +0.05 production_all |
+| `military_superpower` | Military Superpower | 2,000 soldiers | Industrial Age | +0.15 production_all |
 
 `iron_legion`, `fortress_state`, and `military_superpower` are **hidden** until their prerequisites are visible (progress > 50% or you're in the preceding age). Don't be surprised when they appear mid-game.
 

--- a/site/docs/workers-and-domains.md
+++ b/site/docs/workers-and-domains.md
@@ -470,7 +470,7 @@ Once food is stable, assign some workers to `story_circle` (knowledge) to begin 
 
 - Assign workers to lumber and masonry buildings as soon as they are built — stone and wood extraction gate most building costs
 - Unlock the military domain (Iron Age) by building `war_camp`, then staff it with military workers — it produces the `soldiers` resource you spend on expeditions
-- Knowledge workers in libraries become critical — `scholars_haven` milestone requires 20 knowledge workers assigned to libraries
+- Knowledge workers in libraries become critical — `scholars_haven` milestone requires 50 knowledge workers assigned to libraries
 
 ### Late game
 


### PR DESCRIPTION
Resolves the **Milestone System Full Revamp** balance card.

**The imbalances (confirmed by audit of all 6 chains):**
- Completion speed-boosts spanned **18×** — Military 0.5×/60t (product 30) vs Settlement 3.0×/180t (540).
- Trade had only **3 milestones** (others 5–6).
- Military and Trade peaked at **domain-only** rewards (military_power / gold_rate) — finishing them did nothing for your broader economy.

**The rebalance:**
- **Completion boosts normalized** — 6-milestone chains stay 3.0×/180t; all 5-milestone chains → **2.5×/150t**. Military gets a deserved ~12× buff; the spread collapses from 18× to ~1.4×.
- **Trade 3 → 5 milestones** — adds `caravan_network` (classical) and `merchant_princes` (medieval); `trade_empire` scaled up to renaissance / 30 trading posts / 12 merchant quarters.
- **Hollow capstones broadened to `production_all`** — Military (iron_legion / fortress_state / superpower), Trade's two capstones, and Scholar's tech_master now boost the whole economy.
- **Reward shape by tier:** instant resource (early) → domain rate (mid) → broad production (late) → completion speed boost.

4 new tests (normalized-boost guard, Trade structure, new-milestone completion, boost-event injection — the last was previously untested). Wiki got a **full milestones.md accuracy pass** (corrected long-standing threshold drift — Small Village read 200 vs the real 5,000, etc. — and filled every blank reward cell); military.md + workers-and-domains.md reconciled.

`go build/vet/test` green. No engine changes — works within the existing reward types.