### PR TITLE
feat(nanobots): production path + techs + consumption (card 0kLti5GR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to AgeForge are documented here.
 - **Expeditions and Army, split** — scouting Expeditions and military Campaigns are now separate systems; soldiers are a real produced/stored resource, with concurrent per-category expedition slots.
 - **Help panel** — `help` opens a panel instead of dumping inline text.
 - **Main-screen UI overhaul** — a framed command bar, a scannable ✓/✗ age-progress strip, a cleaner log, lifted secondary-text contrast, an early-game onboarding panel, and rebalanced panel widths.
+- Nanobots are a real resource now — a Modern-age producer building (Nano Foundry, +80 nanobots/tick), 3 nanobot techs (Nanofabrication cuts build costs −8%, Medical Nanobots boosts population and food, Self-Replication ramps nanobot output), and several digital/cyberpunk buildings now cost nanobots to construct.
 
 ### Balance
 - Flattened building cost curves and raised age-advancement requirements.

--- a/config/ages.go
+++ b/config/ages.go
@@ -157,7 +157,7 @@ func Ages() []AgeDef {
 			Description:     "Technology and innovation define the era.",
 			ResourceReqs:    map[string]float64{"electricity": 26250000, "uranium": 5500000, "steel": 378125000},
 			BuildingReqs:    map[string]int{"nuclear_reactor": 30, "bunker_complex": 30, "research_campus": 15},
-			UnlockBuildings: []string{"tower_block", "modern_depot", "agri_complex", "oil_platform", "titanium_mine", "think_tank", "meditation_center", "special_ops_hq", "investment_firm", "power_grid_hub", "titanium_smelter", "oil_refinery", "tv_studio", "space_program"},
+			UnlockBuildings: []string{"tower_block", "modern_depot", "agri_complex", "oil_platform", "titanium_mine", "think_tank", "meditation_center", "special_ops_hq", "investment_firm", "power_grid_hub", "titanium_smelter", "oil_refinery", "tv_studio", "space_program", "nano_foundry"},
 			UnlockResources: []string{"data", "nanobots"},
 		},
 		// === 13: INFORMATION AGE (Digital Era) ===

--- a/config/buildings_lineage_energy.go
+++ b/config/buildings_lineage_energy.go
@@ -102,7 +102,7 @@ func buildingsLineageEnergy() []BuildingDef {
 	// tier 6 — digital_age  output=electricity  rate=800
 	b = append(b, BuildingDef{
 		Name: "Quantum Battery Array", Key: "quantum_battery_array", Category: "production",
-		BaseCost:    map[string]float64{"electricity": 490e9, "data": 62e9, "steel": 720e9},
+		BaseCost:    map[string]float64{"electricity": 490e9, "data": 62e9, "steel": 720e9, "nanobots": 3200},
 		CostScale:   1.35,
 		Effects:     []Effect{{Type: "production", Target: "electricity", Value: 800}},
 		BuildTicks:  500000,
@@ -115,7 +115,7 @@ func buildingsLineageEnergy() []BuildingDef {
 	// tier 7 — cyberpunk_age  output=electricity  rate=1600
 	b = append(b, BuildingDef{
 		Name: "Dark Energy Tap", Key: "dark_energy_tap", Category: "production",
-		BaseCost:    map[string]float64{"data": 240e9, "crypto": 1.25e12, "electricity": 2.5e12},
+		BaseCost:    map[string]float64{"data": 240e9, "crypto": 1.25e12, "electricity": 2.5e12, "nanobots": 36000},
 		CostScale:   1.35,
 		Effects:     []Effect{{Type: "production", Target: "electricity", Value: 1600}},
 		BuildTicks:  1000000,

--- a/config/buildings_lineage_engineering.go
+++ b/config/buildings_lineage_engineering.go
@@ -176,7 +176,7 @@ func buildingsLineageEngineering() []BuildingDef {
 	// tier 12 — digital_age  output=electricity  rate=409.60
 	b = append(b, BuildingDef{
 		Name: "Neural Grid", Key: "neural_grid", Category: "production",
-		BaseCost:    map[string]float64{"electricity": 480e9, "data": 60e9, "steel": 700e9},
+		BaseCost:    map[string]float64{"electricity": 480e9, "data": 60e9, "steel": 700e9, "nanobots": 3500},
 		CostScale:   1.35,
 		Effects:     []Effect{{Type: "production", Target: "electricity", Value: 409.60}},
 		BuildTicks:  3600,
@@ -189,7 +189,7 @@ func buildingsLineageEngineering() []BuildingDef {
 	// tier 13 — cyberpunk_age  output=plasma+electricity  rate: plasma=819.20, electricity=500
 	b = append(b, BuildingDef{
 		Name: "Augmentation Foundry", Key: "augmentation_foundry", Category: "production",
-		BaseCost:  map[string]float64{"data": 230e9, "crypto": 1.2e12, "electricity": 2.4e12},
+		BaseCost:  map[string]float64{"data": 230e9, "crypto": 1.2e12, "electricity": 2.4e12, "nanobots": 38000},
 		CostScale: 1.35,
 		Effects: []Effect{
 			{Type: "production", Target: "plasma", Value: 819.20},

--- a/config/buildings_lineage_hacker.go
+++ b/config/buildings_lineage_hacker.go
@@ -27,7 +27,7 @@ func buildingsLineageHacker() []BuildingDef {
 	// tier 1 — digital_age  rate=4.0
 	b = append(b, BuildingDef{
 		Name: "Data Center", Key: "data_center", Category: "production",
-		BaseCost:    map[string]float64{"electricity": 470e9, "data": 58e9, "steel": 685e9},
+		BaseCost:    map[string]float64{"electricity": 470e9, "data": 58e9, "steel": 685e9, "nanobots": 3000},
 		CostScale:   1.35,
 		Effects:     []Effect{{Type: "production", Target: "data", Value: 4.0}},
 		BuildTicks:  500000,
@@ -40,7 +40,7 @@ func buildingsLineageHacker() []BuildingDef {
 	// tier 2 — cyberpunk_age  rate=8.0
 	b = append(b, BuildingDef{
 		Name: "Cyber Hub", Key: "cyber_hub", Category: "production",
-		BaseCost:    map[string]float64{"data": 225e9, "crypto": 1.18e12, "electricity": 2.35e12},
+		BaseCost:    map[string]float64{"data": 225e9, "crypto": 1.18e12, "electricity": 2.35e12, "nanobots": 35000},
 		CostScale:   1.35,
 		Effects:     []Effect{{Type: "production", Target: "data", Value: 8.0}},
 		BuildTicks:  1000000,

--- a/config/buildings_lineage_metallurgy.go
+++ b/config/buildings_lineage_metallurgy.go
@@ -165,7 +165,7 @@ func buildingsLineageMetallurgy() []BuildingDef {
 	// tier 11 — digital_age  output=titanium  rate=2.0
 	b = append(b, BuildingDef{
 		Name: "Nano Alloy Plant", Key: "nano_alloy_plant", Category: "production",
-		BaseCost:    map[string]float64{"electricity": 460e9, "data": 57e9, "steel": 670e9},
+		BaseCost:    map[string]float64{"electricity": 460e9, "data": 57e9, "steel": 670e9, "nanobots": 4000},
 		CostScale:   1.35,
 		Effects:     []Effect{{Type: "production", Target: "titanium", Value: 2.0}},
 		BuildTicks:  30000,

--- a/config/buildings_lineage_organic_extraction.go
+++ b/config/buildings_lineage_organic_extraction.go
@@ -287,5 +287,26 @@ func buildingsLineageOrganicExtraction() []BuildingDef {
 		EpochKey: "cosmic_era", OutputResource: "quantum_flux",
 	})
 
+	// =========================================================================
+	// NANOBOT PRODUCER (standalone — not part of the lineage tier chain).
+	// Nanobots unlock as a resource in the Modern Age, but the lineage's first
+	// nanobot output (Bio Fabrication Lab) doesn't arrive until the Digital Age,
+	// two ages later. This dedicated foundry closes that gap so nanobots have a
+	// real production path the moment they're unlocked. No LineageKey/OutputResource
+	// so it is never remapped on age transition — it always makes nanobots.
+	// Costed to the Modern tier (cf. power_grid_hub); engineering domain workers.
+	// =========================================================================
+	b = append(b, BuildingDef{
+		Name: "Nano Foundry", Key: "nano_foundry", Category: "production",
+		BaseCost:     map[string]float64{"steel": 40e9, "electricity": 16e9, "data": 2e9},
+		CostScale:    1.35,
+		Effects:      []Effect{{Type: "production", Target: "nanobots", Value: 80.0}},
+		BuildTicks:   3600,
+		RequiredAge:  "modern_age",
+		Description:  "Molecular assembly line printing self-organising nanobots. +80.00 nanobots/tick (12 workers).",
+		WorkerDomain: "engineering", WorkerCapacity: 12,
+		EpochKey: "digital_era",
+	})
+
 	return b
 }

--- a/config/nanobots_test.go
+++ b/config/nanobots_test.go
@@ -1,0 +1,169 @@
+package config
+
+import "testing"
+
+// Nanobot System (Trello 0kLti5GR). These tests pin the three pieces that give
+// nanobots a real economic role: a Modern-age producer, the nanobot tech line,
+// and digital/cyberpunk buildings that consume nanobots as a build material.
+
+// prodValue returns a building/tech's "production" effect value for a target.
+func prodEffectValue(effects []Effect, target string) (float64, bool) {
+	for _, e := range effects {
+		if e.Type == "production" && e.Target == target {
+			return e.Value, true
+		}
+	}
+	return 0, false
+}
+
+func bonusEffectValue(effects []Effect, target string) (float64, bool) {
+	for _, e := range effects {
+		if e.Type == "bonus" && e.Target == target {
+			return e.Value, true
+		}
+	}
+	return 0, false
+}
+
+// TestNanobots_FoundryProducerExists asserts the Modern-age nano_foundry exists,
+// is gated to modern_age, produces a positive amount of nanobots, has a worker
+// domain, and is wired into the Modern Age's unlock list.
+func TestNanobots_FoundryProducerExists(t *testing.T) {
+	def, ok := BuildingByKey()["nano_foundry"]
+	if !ok {
+		t.Fatal("nano_foundry building is not defined")
+	}
+	if def.RequiredAge != "modern_age" {
+		t.Errorf("nano_foundry RequiredAge = %q, want modern_age", def.RequiredAge)
+	}
+	if def.Category != "production" {
+		t.Errorf("nano_foundry Category = %q, want production", def.Category)
+	}
+	rate, hasProd := prodEffectValue(def.Effects, "nanobots")
+	if !hasProd || rate <= 0 {
+		t.Errorf("nano_foundry must produce nanobots; got rate %v (present=%v)", rate, hasProd)
+	}
+	if def.WorkerDomain == "" || def.WorkerCapacity <= 0 {
+		t.Errorf("nano_foundry needs a worker domain + capacity; got domain=%q cap=%d",
+			def.WorkerDomain, def.WorkerCapacity)
+	}
+
+	// Must be unlocked by the Modern Age (reachability + it shows up in views).
+	unlocked := false
+	for _, age := range Ages() {
+		if age.Key != "modern_age" {
+			continue
+		}
+		for _, k := range age.UnlockBuildings {
+			if k == "nano_foundry" {
+				unlocked = true
+			}
+		}
+	}
+	if !unlocked {
+		t.Error("nano_foundry is not listed in modern_age UnlockBuildings")
+	}
+}
+
+// TestNanobots_ProducerUnlocksWithResource guards the core fix: nanobots unlock
+// as a resource in the Modern Age, and there must now be a nanobot producer
+// buildable in that same age (previously the first producer was 2 ages later).
+func TestNanobots_ProducerUnlocksWithResource(t *testing.T) {
+	ageOrder := map[string]int{}
+	for _, a := range Ages() {
+		ageOrder[a.Key] = a.Order
+	}
+	resAge, ok := ResourceByKey()["nanobots"]
+	if !ok {
+		t.Fatal("nanobots resource not defined")
+	}
+	unlockOrder := ageOrder[resAge.Age]
+
+	earliest := 1 << 30
+	for _, b := range BaseBuildings() {
+		if _, prod := prodEffectValue(b.Effects, "nanobots"); !prod {
+			continue
+		}
+		if o := ageOrder[b.RequiredAge]; o < earliest {
+			earliest = o
+		}
+	}
+	if earliest > unlockOrder {
+		t.Errorf("no nanobot producer at or before the unlock age %q (order %d); earliest producer age order = %d",
+			resAge.Age, unlockOrder, earliest)
+	}
+}
+
+// TestNanobots_TechsExistAndGated asserts the three nanobot techs exist, are
+// gated to modern+ ages, cost knowledge, and carry their intended effects.
+func TestNanobots_TechsExistAndGated(t *testing.T) {
+	byKey := TechByKey()
+	ageOrder := map[string]int{}
+	for _, a := range Ages() {
+		ageOrder[a.Key] = a.Order
+	}
+	modernOrder := ageOrder["modern_age"]
+
+	for _, key := range []string{"nanofabrication", "medical_nanobots", "self_replication"} {
+		tech, ok := byKey[key]
+		if !ok {
+			t.Errorf("tech %q is not defined", key)
+			continue
+		}
+		if ageOrder[tech.Age] < modernOrder {
+			t.Errorf("tech %q age %q is before modern_age", key, tech.Age)
+		}
+		if tech.Cost <= 0 {
+			t.Errorf("tech %q has non-positive knowledge cost %v", key, tech.Cost)
+		}
+	}
+
+	// Nanofabrication reduces build cost (negative build_cost bonus).
+	if v, ok := bonusEffectValue(byKey["nanofabrication"].Effects, "build_cost"); !ok || v >= 0 {
+		t.Errorf("nanofabrication must reduce build_cost; got %v (present=%v)", v, ok)
+	}
+	// Self-Replication boosts nanobot production.
+	if v, ok := prodEffectValue(byKey["self_replication"].Effects, "nanobots"); !ok || v <= 0 {
+		t.Errorf("self_replication must add nanobot production; got %v (present=%v)", v, ok)
+	}
+	// Medical Nanobots is a clearly-beneficial tech (pop cap and/or food).
+	mn := byKey["medical_nanobots"].Effects
+	_, hasPop := func() (float64, bool) {
+		for _, e := range mn {
+			if e.Type == "capacity" && e.Target == "population" {
+				return e.Value, true
+			}
+		}
+		return 0, false
+	}()
+	_, hasFood := prodEffectValue(mn, "food")
+	if !hasPop && !hasFood {
+		t.Error("medical_nanobots must grant a beneficial effect (population cap and/or food)")
+	}
+}
+
+// TestNanobots_ConsumedAsBuildMaterial asserts that several digital/cyberpunk
+// buildings now require nanobots to construct, giving produced nanobots a sink.
+func TestNanobots_ConsumedAsBuildMaterial(t *testing.T) {
+	want := []string{
+		"data_center", "neural_grid", "quantum_battery_array", "nano_alloy_plant",
+		"cyber_hub", "augmentation_foundry", "dark_energy_tap",
+	}
+	byKey := BuildingByKey()
+	count := 0
+	for _, key := range want {
+		def, ok := byKey[key]
+		if !ok {
+			t.Errorf("expected building %q not found", key)
+			continue
+		}
+		if amt, has := def.BaseCost["nanobots"]; !has || amt <= 0 {
+			t.Errorf("building %q should cost nanobots to build; got %v (present=%v)", key, amt, has)
+		} else {
+			count++
+		}
+	}
+	if count < 4 {
+		t.Errorf("expected at least 4 buildings to consume nanobots, got %d", count)
+	}
+}

--- a/config/research.go
+++ b/config/research.go
@@ -499,6 +499,15 @@ func Technologies() []TechDef {
 				{Type: "bonus", Target: "knowledge_rate", Value: 0.6},
 			},
 		},
+		{
+			Name: "Nanofabrication", Key: "nanofabrication",
+			Age: "modern_age", Cost: 1100000, ResearchTicks: 19000,
+			Prerequisites: []string{"computers"},
+			Description:   "Nanobot swarms assemble structures atom-by-atom, cutting construction costs.",
+			Effects: []Effect{
+				{Type: "bonus", Target: "build_cost", Value: -0.08},
+			},
+		},
 
 		// === INFORMATION AGE === (~1.5 hr each)
 		{
@@ -531,6 +540,21 @@ func Technologies() []TechDef {
 				{Type: "production", Target: "gold", Value: 5.0},
 			},
 		},
+		{
+			// note: the original spec wanted this to cut worker FOOD COST, but the
+			// food drain (wc.FoodCost * count in game/villagers.go) has no bonus hook
+			// and threading one through WorkerManager isn't a "tiny" engine change.
+			// Substituted a supported, clearly-beneficial effect instead: nanobots
+			// keep the population healthier (bigger pop cap) and better fed (+food).
+			Name: "Medical Nanobots", Key: "medical_nanobots",
+			Age: "information_age", Cost: 1700000, ResearchTicks: 24000,
+			Prerequisites: []string{"nanofabrication"},
+			Description:   "Bloodstream nanobots heal and sustain workers — larger, better-fed population.",
+			Effects: []Effect{
+				{Type: "capacity", Target: "population", Value: 10},
+				{Type: "production", Target: "food", Value: 8.0},
+			},
+		},
 
 		// === DIGITAL AGE === (~1.8 hr each)
 		{
@@ -551,6 +575,15 @@ func Technologies() []TechDef {
 			Effects: []Effect{
 				{Type: "production", Target: "data", Value: 8.0},
 				{Type: "storage", Target: "all", Value: 10000},
+			},
+		},
+		{
+			Name: "Self-Replication", Key: "self_replication",
+			Age: "digital_age", Cost: 3200000, ResearchTicks: 33000,
+			Prerequisites: []string{"medical_nanobots", "machine_learning"},
+			Description:   "Nanobots that build copies of themselves — runaway nanobot output.",
+			Effects: []Effect{
+				{Type: "production", Target: "nanobots", Value: 200.0},
 			},
 		},
 

--- a/game/nanobots_test.go
+++ b/game/nanobots_test.go
@@ -1,0 +1,58 @@
+package game
+
+import (
+	"math"
+	"testing"
+)
+
+// Nanobot System (Trello 0kLti5GR) — engine-level checks that the new content
+// actually plugs into the live economy: the producer makes nanobots, and the
+// Nanofabrication tech's build-cost reduction flows through recalculateRates.
+
+// TestNanobots_FoundryProducesThroughEngine verifies the nano_foundry building
+// is known to the engine's BuildingManager and carries a positive nanobot
+// production effect (the engine sources building production from these defs).
+func TestNanobots_FoundryProducesThroughEngine(t *testing.T) {
+	ge := NewGameEngine()
+	def, ok := ge.Buildings.defs["nano_foundry"]
+	if !ok {
+		t.Fatal("engine BuildingManager has no nano_foundry def")
+	}
+	found := false
+	for _, eff := range def.Effects {
+		if eff.Type == "production" && eff.Target == "nanobots" && eff.Value > 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("nano_foundry def carries no positive nanobots production effect: %+v", def.Effects)
+	}
+}
+
+// TestNanobots_NanofabricationReducesBuildCost researches Nanofabrication and
+// asserts the charged build cost drops by ~8% — proving the tech's build_cost
+// effect flows through the resolver into the BuildingManager cost multiplier.
+func TestNanobots_NanofabricationReducesBuildCost(t *testing.T) {
+	ge := NewGameEngine()
+	base := ge.Buildings.defs["hut"].BaseCost["wood"]
+
+	// Baseline: no tech → full base cost.
+	ge.recalculateRates()
+	if got, _ := ge.Buildings.BuildBatchCost("hut", 1, nil); got["wood"] != base {
+		t.Fatalf("pre-research: charged wood = %v, want base %v", got["wood"], base)
+	}
+
+	// Research Nanofabrication (LoadState marks it researched AND applies its
+	// effects into the research bonus pool that buildResolver reads).
+	ge.Research.LoadState([]string{"nanofabrication"}, "", 0, 0)
+	ge.recalculateRates()
+
+	want := math.Floor(base * 0.92) // -8% build_cost
+	charged, _ := ge.Buildings.BuildBatchCost("hut", 1, nil)
+	if charged["wood"] != want {
+		t.Errorf("post-Nanofabrication: charged wood = %v, want %v (-8%% of %v)", charged["wood"], want, base)
+	}
+	if charged["wood"] >= base {
+		t.Errorf("Nanofabrication did not reduce build cost: %v >= base %v", charged["wood"], base)
+	}
+}

--- a/site/docs/buildings.md
+++ b/site/docs/buildings.md
@@ -138,7 +138,7 @@ Costs were rebalanced to flatter curves. Production, military, research, and tra
 
 ### Build-cost reductions
 
-A handful of **milestone rewards** (Master Builder, Grand Architect, and others) and one **research tech** (Civil Engineering) grant build-cost reductions of −3% to −5% each. These now apply to your cumulative scaled cost: the cost above is multiplied by `(1 + Σ build_cost)`, floored so the cost never drops below 10% of base. Stacked, the currently available reductions reach roughly **−24%**. The discount is reflected in the cost the build menu shows you and in what you're actually charged — there's no hidden mismatch between display and charge. You don't need to do anything to opt in; earning the milestone or completing the tech is enough.
+A handful of **milestone rewards** (Master Builder, Grand Architect, and others) and two **research techs** (Civil Engineering −5%, Nanofabrication −8%) grant build-cost reductions of −3% to −8% each. These now apply to your cumulative scaled cost: the cost above is multiplied by `(1 + Σ build_cost)`, floored so the cost never drops below 10% of base. Stacked, the currently available reductions reach roughly **−32%**. The discount is reflected in the cost the build menu shows you and in what you're actually charged — there's no hidden mismatch between display and charge. You don't need to do anything to opt in; earning the milestone or completing the tech is enough.
 
 **Example:** Gathering Camp, BaseCost=16 wood, CostScale=1.15, none built or queued:
 - 1st: 16 wood
@@ -225,6 +225,8 @@ Several lineages change what resource they produce as you advance through epochs
 | Electric Era | oil |
 | Digital Era+ | nanobots |
 | Neon / Cosmic Era | quantum flux |
+
+**Nano Foundry** (Modern Age) is a standalone nanobot producer outside the lineage chain — it gives nanobots a production path as soon as they unlock, two ages before the lineage's own Bio Fabrication Lab. Built by `engineering` workers; +80 nanobots/tick.
 
 ### Geological Extraction (Lineage 4)
 

--- a/site/docs/resources.md
+++ b/site/docs/resources.md
@@ -40,7 +40,7 @@ These resources are produced by Geological Extraction buildings and consumed by 
 | Iron Ore | `iron_ore` | Iron Age | 30 | Raw ore before smelting — feeds Metallurgy lineage |
 | Titanium Ore | `titanium_ore` | Modern Age | 20 | Raw titanium ore — refines into titanium via Metallurgy |
 | Dark Matter Crystals | `dark_matter_crystals` | Cyberpunk Age | 10 | Crystallised dark matter — refines into dark matter |
-| Nanobots | `nanobots` | Modern Age | 20 | Microscopic machines from Organic Extraction in Digital Era+ |
+| Nanobots | `nanobots` | Modern Age | 20 | Microscopic machines. Built by the **Nano Foundry** (Modern Age) and Organic Extraction from Digital Era+; consumed as a build material by several digital/cyberpunk buildings |
 
 ### Industrial Resources
 

--- a/site/docs/technologies.md
+++ b/site/docs/technologies.md
@@ -231,6 +231,7 @@ Prerequisites are listed using tech keys. "—" means no prerequisite.
 | `electricity_tech` | Electricity | 800,000 kp | 18,000 | `nuclear_fission` | +50% all production, +5.0 electricity/tick |
 | `computers` | Computers | 1,000,000 kp | 20,000 | `electricity_tech` | +80% knowledge rate |
 | `satellite_tech` | Satellite Technology | 1,200,000 kp | 19,000 | `rocketry`, `electricity_tech` | +1.0 data/tick, +60% knowledge rate |
+| `nanofabrication` | Nanofabrication | 1,100,000 kp | 19,000 | `computers` | −8% build cost |
 
 ---
 
@@ -241,6 +242,7 @@ Prerequisites are listed using tech keys. "—" means no prerequisite.
 | `internet` | Internet | 2,000,000 kp | 26,000 | `computers`, `satellite_tech` | +3.0 data/tick, +120% knowledge rate |
 | `cybersecurity` | Cybersecurity | 1,800,000 kp | 24,000 | `computers` | +100% military power, +5,000 data storage |
 | `social_media` | Social Media | 1,500,000 kp | 23,000 | `internet` | +5.0 culture/tick, +5.0 gold/tick |
+| `medical_nanobots` | Medical Nanobots | 1,700,000 kp | 24,000 | `nanofabrication` | +10 population cap, +8.0 food/tick |
 
 ---
 
@@ -250,6 +252,7 @@ Prerequisites are listed using tech keys. "—" means no prerequisite.
 |---|---|---|---|---|---|
 | `machine_learning` | Machine Learning | 3,500,000 kp | 34,000 | `internet`, `cybersecurity` | +5.0 data/tick, +50% all production |
 | `cloud_computing` | Cloud Computing | 3,000,000 kp | 32,000 | `internet` | +8.0 data/tick, +10,000 all storage |
+| `self_replication` | Self-Replication | 3,200,000 kp | 33,000 | `medical_nanobots`, `machine_learning` | +200 nanobots/tick |
 
 ---
 
@@ -461,13 +464,14 @@ These add a flat amount to all resource storage caps (or, for Banking, just gold
 
 ### `build_cost` — Construction Cost Reduction
 
-Only one tech reduces build cost:
+Two techs reduce build cost:
 
 | Tech | Bonus |
 |---|---|
 | Civil Engineering | −5% |
+| Nanofabrication | −8% |
 
-This reduction is live: it multiplies your cumulative build cost by `(1 + Σ build_cost)` (floored at 10% of base) alongside the build-cost milestone rewards, and the saving is reflected in the cost the build menu shows. Small but permanent, it stacks with those milestones toward the current ceiling of roughly −24%, so it's worth taking when you're building dozens of structures. See [Buildings](buildings.md#build-cost-reductions).
+This reduction is live: it multiplies your cumulative build cost by `(1 + Σ build_cost)` (floored at 10% of base) alongside the build-cost milestone rewards, and the saving is reflected in the cost the build menu shows. Small but permanent, it stacks with those milestones toward the current ceiling of roughly −32%, so it's worth taking when you're building dozens of structures. See [Buildings](buildings.md#build-cost-reductions).
 
 ---
 


### PR DESCRIPTION
Resolves the **Nanobot System** card — turns a dead resource into a real one.

**The actual gap (card premise was half-right):** nanobots unlock as a resource in Modern (order 12) but the Organic Extraction lineage's first nanobot output isn't until Digital (order 14) — so for two full ages they existed with no way to produce *or* consume them.

- **Production:** new `nano_foundry` (Modern, engineering domain, +80/tick), deliberately outside the lineage tier chain so age transitions don't remap its output.
- **Techs (modern+):** Nanofabrication (−8% build cost), Medical Nanobots (+pop cap + food), Self-Replication (+200 nanobot output).
- **Consumption:** 7 digital/cyberpunk buildings now cost nanobots to build — a real sink.
- **No engine changes** — stays within existing effect types. 6 new tests (incl. end-to-end: Nanofabrication actually drops a charged build cost). Wiki + changelog updated.

One note: `Medical Nanobots` gives pop+food rather than literal food-cost reduction (no engine hook for that; the card listed it as an "e.g."). Easy follow-up if you want the literal effect. `go build/vet/test` green.