### PR TITLE
feat(culture): Cultural Monuments + festival command (card olNDO3wv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to AgeForge are documented here.
 - **Help panel** — `help` opens a panel instead of dumping inline text.
 - **Main-screen UI overhaul** — a framed command bar, a scannable ✓/✗ age-progress strip, a cleaner log, lifted secondary-text contrast, an early-game onboarding panel, and rebalanced panel widths.
 - Nanobots are a real resource now — a Modern-age producer building (Nano Foundry, +80 nanobots/tick), 3 nanobot techs (Nanofabrication cuts build costs −8%, Medical Nanobots boosts population and food, Self-Replication ramps nanobot output), and several digital/cyberpunk buildings now cost nanobots to construct.
+- Culture has sinks now — Cultural Monuments (spend culture for a permanent production bonus) and a `festival` command (spend a lump of culture for a temporary multi-resource buff); prestige gates remain the primary long-term sink.
 
 ### Balance
 - Flattened building cost curves and raised age-advancement requirements.

--- a/config/ages.go
+++ b/config/ages.go
@@ -79,7 +79,7 @@ func Ages() []AgeDef {
 			Description:     "Great empires are built and philosophy flourishes.",
 			ResourceReqs:    map[string]float64{"stone": 75000, "iron": 15000, "gold": 8000, "knowledge": 20000},
 			BuildingReqs:    map[string]int{"barracks": 15, "agora": 8, "market": 5},
-			UnlockBuildings: []string{"villa", "classical_vault", "estate_farm", "wood_workshop", "marble_works", "library", "oracle_house", "military_academy", "merchant_quarter", "aqueduct", "forge", "amphitheater", "parthenon"},
+			UnlockBuildings: []string{"villa", "classical_vault", "estate_farm", "wood_workshop", "marble_works", "library", "oracle_house", "military_academy", "merchant_quarter", "aqueduct", "forge", "amphitheater", "parthenon", "cultural_obelisk"},
 			UnlockResources: []string{"culture"},
 		},
 		// === 5: MEDIEVAL AGE (Iron Era) ===
@@ -89,7 +89,7 @@ func Ages() []AgeDef {
 			Description:     "Kingdoms rise and feudalism takes hold.",
 			ResourceReqs:    map[string]float64{"stone": 125000, "iron": 30000, "gold": 20000, "knowledge": 50000},
 			BuildingReqs:    map[string]int{"merchant_quarter": 3, "library": 20, "barracks": 30},
-			UnlockBuildings: []string{"manor", "keep", "demesne", "sawmill", "stonemasons_guild", "monastery_library", "cathedral", "castle_keep", "guildhall", "workshop", "ironmonger", "great_hall", "great_library"},
+			UnlockBuildings: []string{"manor", "keep", "demesne", "sawmill", "stonemasons_guild", "monastery_library", "cathedral", "castle_keep", "guildhall", "workshop", "ironmonger", "great_hall", "great_library", "grand_amphitheatre_monument"},
 			UnlockResources: []string{"steel"},
 		},
 		// === 6: RENAISSANCE AGE (Steel Era) ===
@@ -118,7 +118,7 @@ func Ages() []AgeDef {
 			Description:     "Machines revolutionize production.",
 			ResourceReqs:    map[string]float64{"steel": 310000, "gold": 2500000, "knowledge": 2000000},
 			BuildingReqs:    map[string]int{"plantation": 5, "port": 8, "market_garden": 5},
-			UnlockBuildings: []string{"tenement", "industrial_depot", "agricultural_works", "steam_coal_plant", "steam_mine", "research_institute", "church", "military_base", "stock_exchange", "iron_works_complex", "steel_mill", "coal_plant", "opera_house", "crystal_palace"},
+			UnlockBuildings: []string{"tenement", "industrial_depot", "agricultural_works", "steam_coal_plant", "steam_mine", "research_institute", "church", "military_base", "stock_exchange", "iron_works_complex", "steel_mill", "coal_plant", "opera_house", "crystal_palace", "eternal_library_monument"},
 			UnlockResources: []string{"oil"},
 		},
 		// === 9: VICTORIAN AGE (Electric Era) ===
@@ -147,7 +147,7 @@ func Ages() []AgeDef {
 			Description:     "Nuclear power unleashes terrifying potential.",
 			ResourceReqs:    map[string]float64{"steel": 85625000, "electricity": 9250000, "oil": 6125000},
 			BuildingReqs:    map[string]int{"electric_arc_furnace": 20, "steam_works": 20, "physics_laboratory": 15},
-			UnlockBuildings: []string{"housing_project", "atomic_vault", "agricultural_complex", "petroleum_refinery", "uranium_processing_works", "research_campus", "spiritual_center", "bunker_complex", "corporate_hq", "nuclear_plant", "advanced_alloy_plant", "nuclear_reactor", "cinema", "particle_accelerator"},
+			UnlockBuildings: []string{"housing_project", "atomic_vault", "agricultural_complex", "petroleum_refinery", "uranium_processing_works", "research_campus", "spiritual_center", "bunker_complex", "corporate_hq", "nuclear_plant", "advanced_alloy_plant", "nuclear_reactor", "cinema", "particle_accelerator", "monument_of_ages"},
 			UnlockResources: []string{"uranium"},
 		},
 		// === 12: MODERN AGE (Digital Era) ===

--- a/config/buildings_monuments.go
+++ b/config/buildings_monuments.go
@@ -1,0 +1,80 @@
+package config
+
+// buildingsMonuments returns the Cultural Monuments — a culture sink.
+//
+// Culture accumulates endlessly (9+ buildings produce it) but its only sink
+// used to be the one-time prestige/epoch gates, so billions sat idle late game.
+// Monuments turn a LARGE lump of culture into a PERMANENT production bonus.
+//
+// Mechanism (construction-cost, NOT upkeep): there is no per-tick upkeep system
+// in AgeForge, so Monuments are modelled as normal buildable structures whose
+// BaseCost is paid almost entirely in culture. They are Category "monument" so
+// the engine's static-bonus pass (getStaticBonuses) folds their "bonus" effects
+// into the production_all multiplier — the same path wonders use — without
+// routing them through the wonder-bank flow (that gate keys on Category
+// "wonder"). Each is MaxCount 1 and gives a small, permanent +production_all.
+//
+// Balance intent: each monument's culture cost is roughly the culture a player
+// has banked by the time its age unlocks, so building one is a real drain but
+// never trivialises the prestige gates (which remain the primary long-term
+// sink). Bonuses are deliberately modest (+1% → +5%, +11% total if all built).
+func buildingsMonuments() []BuildingDef {
+	return []BuildingDef{
+		// Classical Age — first real culture stockpiles appear. Small primer.
+		{
+			Name: "Cultural Obelisk", Key: "cultural_obelisk", Category: "monument",
+			BaseCost:  map[string]float64{"culture": 2500, "stone": 60000},
+			CostScale: 1.0,
+			Effects: []Effect{
+				{Type: "bonus", Target: "production_all", Value: 0.01},
+			},
+			RequiredAge: "classical_age",
+			MaxCount:    1,
+			BuildTicks:  2000,
+			Description: "A carved obelisk celebrating your people's golden age. Costs 2,500 culture. Permanent +1% to all production.",
+			LineageKey:  "monument",
+		},
+		// Medieval Age — culture flows steadily from great halls and cathedrals.
+		{
+			Name: "Grand Amphitheatre", Key: "grand_amphitheatre_monument", Category: "monument",
+			BaseCost:  map[string]float64{"culture": 25000, "stone": 400000, "gold": 120000},
+			CostScale: 1.0,
+			Effects: []Effect{
+				{Type: "bonus", Target: "production_all", Value: 0.02},
+			},
+			RequiredAge: "medieval_age",
+			MaxCount:    1,
+			BuildTicks:  5000,
+			Description: "A monumental arena for the games and pageants of an age. Costs 25,000 culture. Permanent +2% to all production.",
+			LineageKey:  "monument",
+		},
+		// Industrial Age — mass media and museums pour out culture; bigger sink.
+		{
+			Name: "Eternal Library", Key: "eternal_library_monument", Category: "monument",
+			BaseCost:  map[string]float64{"culture": 500000, "steel": 600000, "gold": 2.0e6},
+			CostScale: 1.0,
+			Effects: []Effect{
+				{Type: "bonus", Target: "production_all", Value: 0.03},
+			},
+			RequiredAge: "industrial_age",
+			MaxCount:    1,
+			BuildTicks:  9000,
+			Description: "A vast archive preserving the knowledge of every age. Costs 500,000 culture. Permanent +3% to all production.",
+			LineageKey:  "monument",
+		},
+		// Modern Age — late-game culture runs to the billions; the heavy sink.
+		{
+			Name: "Monument of Ages", Key: "monument_of_ages", Category: "monument",
+			BaseCost:  map[string]float64{"culture": 2.5e7, "titanium": 5.0e6, "gold": 5.0e7},
+			CostScale: 1.0,
+			Effects: []Effect{
+				{Type: "bonus", Target: "production_all", Value: 0.05},
+			},
+			RequiredAge: "modern_age",
+			MaxCount:    1,
+			BuildTicks:  15000,
+			Description: "A timeless edifice commemorating the whole span of your civilization. Costs 25,000,000 culture. Permanent +5% to all production.",
+			LineageKey:  "monument",
+		},
+	}
+}

--- a/config/buildings_new_merge.go
+++ b/config/buildings_new_merge.go
@@ -33,5 +33,7 @@ func NewProductionBuildings() []BuildingDef {
 	out = append(out, buildingsLineageMetallurgy()...)
 	out = append(out, buildingsLineageEnergy()...)
 	out = append(out, buildingsLineageHacker()...)
+	// Cultural Monuments — culture sink; a permanent production bonus per build.
+	out = append(out, buildingsMonuments()...)
 	return out
 }

--- a/game/engine.go
+++ b/game/engine.go
@@ -28,6 +28,13 @@ const (
 	// push production below 10% of its pre-bonus value or flip it negative.
 	productionFloor = 0.10
 
+	// Festival (culture sink) tuning.
+	festivalBuffPercent   = 0.20 // +20% production_all while active
+	festivalBuffTicks     = 150  // ~5 minutes at 2s/tick
+	festivalCooldownTicks = 300  // ~10 minutes between festivals
+	festivalMinCost       = 2000.0
+	festivalCostFraction  = 0.05 // of culture storage cap
+
 	// buildCostFloor / buildCostCap clamp the build-cost factor the engine derives
 	// from the resolver's build_cost pool. build_cost values are negative cost
 	// reductions; the factor is clamp(1+Σ, floor, cap). The 0.10 floor means costs
@@ -140,6 +147,10 @@ type GameEngine struct {
 	// starts at moraleNeutral (0.50). Drives production via moraleMultiplier().
 	morale          float64 // 0.10–moraleCap(); starts at moraleNeutral (0.50)
 	lowMoraleWarned bool    // true after morale warning fired; reset when morale rises above 0.40
+
+	// festivalReadyTick is the earliest game tick a new festival may be held
+	// (cooldown anti-spam for the `festival` culture sink). 0 = ready now.
+	festivalReadyTick int
 }
 
 // BuildQueueItem represents a building under construction
@@ -1811,11 +1822,84 @@ func (ge *GameEngine) reapplyLegacyBonuses() {
 	}
 }
 
+// FestivalStatus is the snapshot the `festival` command renders: the live cost,
+// the player's current culture, the buff parameters, and cooldown state.
+type FestivalStatus struct {
+	Cost          float64 // culture required to hold a festival right now
+	Culture       float64 // player's current culture
+	BuffPercent   float64 // production_all bonus the festival grants (e.g. 0.20)
+	BuffTicks     int     // how long the buff lasts
+	CooldownTicks int     // cooldown imposed after a festival
+	CooldownLeft  int     // ticks remaining on the current cooldown (0 if ready)
+	Ready         bool    // true when not on cooldown
+}
+
+// festivalCost returns the culture cost of a festival at the current progression:
+// max(festivalMinCost, festivalCostFraction × culture storage cap). It scales with
+// the player's culture cap so it stays a meaningful drain into the late game.
+func (ge *GameEngine) festivalCost() float64 {
+	cultureCap := ge.Resources.GetStorage("culture")
+	cost := cultureCap * festivalCostFraction
+	if cost < festivalMinCost {
+		cost = festivalMinCost
+	}
+	return cost
+}
+
+// FestivalStatus returns the live festival cost, the player's culture, the buff
+// parameters, and cooldown state for the `festival` command UI. Read-only.
+func (ge *GameEngine) FestivalStatus() FestivalStatus {
+	ge.mu.RLock()
+	defer ge.mu.RUnlock()
+	cd := ge.festivalReadyTick - ge.tick
+	if cd < 0 {
+		cd = 0
+	}
+	return FestivalStatus{
+		Cost:          ge.festivalCost(),
+		Culture:       ge.Resources.Get("culture"),
+		BuffPercent:   festivalBuffPercent,
+		BuffTicks:     festivalBuffTicks,
+		CooldownTicks: festivalCooldownTicks,
+		CooldownLeft:  cd,
+		Ready:         cd == 0,
+	}
+}
+
+// DoFestival spends a lump of culture to inject a temporary empire-wide
+// production buff (+festivalBuffPercent production_all for festivalBuffTicks).
+// It is gated by a cooldown so it can't be spammed every tick. This is the
+// repeatable, player-initiated culture sink; prestige gates remain primary.
+func (ge *GameEngine) DoFestival() error {
+	ge.mu.Lock()
+	defer ge.mu.Unlock()
+
+	if ge.tick < ge.festivalReadyTick {
+		return fmt.Errorf("festival is on cooldown (%d ticks remaining)", ge.festivalReadyTick-ge.tick)
+	}
+	cost := ge.festivalCost()
+	have := ge.Resources.Get("culture")
+	if have < cost {
+		return fmt.Errorf("not enough culture for a festival: need %.0f, have %.0f", cost, have)
+	}
+	ge.Resources.Remove("culture", cost)
+	ge.Events.InjectEvent(ActiveEvent{
+		Key:       "cultural_festival",
+		Name:      "Cultural Festival",
+		TicksLeft: festivalBuffTicks,
+		Effects:   []config.Effect{{Type: "production_all", Value: festivalBuffPercent}},
+	})
+	ge.festivalReadyTick = ge.tick + festivalCooldownTicks
+	ge.addLog("success", fmt.Sprintf("Held a cultural festival — spent %.0f culture for +%.0f%% production (%d ticks).",
+		cost, festivalBuffPercent*100, festivalBuffTicks))
+	return nil
+}
+
 // getWonderBonuses returns a map of bonus-type effects from all currently built
-// wonders (those with count > 0). Effects with Type "bonus" represent percentage
-// multipliers (e.g. production_all, knowledge_rate, expedition_reward) rather
-// than flat resource production rates. The returned map is keyed by Target and
-// holds the summed Value across all built wonders.
+// wonders and cultural monuments (those with count > 0). Effects with Type "bonus"
+// represent percentage multipliers (e.g. production_all, knowledge_rate,
+// expedition_reward) rather than flat resource production rates. The returned map
+// is keyed by Target and holds the summed Value across all built wonders and monuments.
 // Must be called with the engine lock held.
 func (ge *GameEngine) getWonderBonuses() map[string]float64 {
 	out := make(map[string]float64)
@@ -1824,7 +1908,7 @@ func (ge *GameEngine) getWonderBonuses() map[string]float64 {
 			continue
 		}
 		def, ok := ge.Buildings.defs[key]
-		if !ok || def.Category != "wonder" {
+		if !ok || (def.Category != "wonder" && def.Category != "monument") {
 			continue
 		}
 		for _, eff := range def.Effects {

--- a/game/festival_monument_test.go
+++ b/game/festival_monument_test.go
@@ -1,0 +1,207 @@
+package game
+
+import (
+	"math"
+	"testing"
+
+	"github.com/espresso20/ageforge/config"
+)
+
+// ---------------------------------------------------------------------------
+// Cultural Monuments — culture sink via construction cost + permanent bonus
+// ---------------------------------------------------------------------------
+
+// TestMonuments_ExistAndCostCulture asserts the four cultural monuments are real
+// buildable defs, each priced in culture (the sink) with a permanent
+// production_all "bonus" effect (the payoff), MaxCount 1, in the "monument"
+// category.
+func TestMonuments_ExistAndCostCulture(t *testing.T) {
+	byKey := config.BuildingByKey()
+	want := map[string]float64{
+		"cultural_obelisk":            0.01,
+		"grand_amphitheatre_monument": 0.02,
+		"eternal_library_monument":    0.03,
+		"monument_of_ages":            0.05,
+	}
+	for key, wantBonus := range want {
+		b, ok := byKey[key]
+		if !ok {
+			t.Fatalf("monument %q missing from BuildingByKey", key)
+		}
+		if b.Category != "monument" {
+			t.Errorf("monument %q category = %q, want \"monument\"", key, b.Category)
+		}
+		if b.MaxCount != 1 {
+			t.Errorf("monument %q MaxCount = %d, want 1", key, b.MaxCount)
+		}
+		if got := b.BaseCost["culture"]; got <= 0 {
+			t.Errorf("monument %q has no culture cost (BaseCost[culture]=%v) — it is supposed to be a culture sink", key, got)
+		}
+		// permanent production_all bonus effect present with the expected value.
+		var bonus float64
+		for _, eff := range b.Effects {
+			if eff.Type == "bonus" && eff.Target == "production_all" {
+				bonus = eff.Value
+			}
+		}
+		if math.Abs(bonus-wantBonus) > 1e-9 {
+			t.Errorf("monument %q production_all bonus = %v, want %v", key, bonus, wantBonus)
+		}
+	}
+}
+
+// TestMonuments_GrantPermanentProductionBonus proves a built monument feeds the
+// production_all multiplier through the same static-bonus path wonders use:
+// getWonderBonuses (now wonders+monuments) and the resolver both reflect it.
+func TestMonuments_GrantPermanentProductionBonus(t *testing.T) {
+	ge := NewGameEngine()
+
+	// Register a monument def (mirrors config) and mark one built.
+	ge.Buildings.defs["monument_of_ages"] = config.BuildingDef{
+		Key:      "monument_of_ages",
+		Name:     "Monument of Ages",
+		Category: "monument",
+		Effects:  []config.Effect{{Type: "bonus", Target: "production_all", Value: 0.05}},
+	}
+
+	if got := ge.getWonderBonuses()["production_all"]; got != 0 {
+		t.Fatalf("baseline static production_all bonus = %v, want 0 (nothing built yet)", got)
+	}
+
+	ge.Buildings.counts["monument_of_ages"] = 1
+
+	if got := ge.getWonderBonuses()["production_all"]; math.Abs(got-0.05) > 1e-9 {
+		t.Errorf("getWonderBonuses[production_all] with monument built = %v, want 0.05", got)
+	}
+	// And it must surface in the resolver pool the engine multiplies rates by.
+	if got := ge.buildResolver().AddTotal("production_all"); math.Abs(got-0.05) > 1e-9 {
+		t.Errorf("resolver production_all with monument built = %v, want 0.05", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Festival — repeatable, player-initiated culture sink (temporary buff)
+// ---------------------------------------------------------------------------
+
+// TestFestival_RefusesWhenCultureInsufficient asserts DoFestival errors and
+// spends nothing / injects nothing when the player can't afford it.
+func TestFestival_RefusesWhenCultureInsufficient(t *testing.T) {
+	ge := NewGameEngine()
+	ge.Resources.UnlockResource("culture")
+	// Set culture below the minimum cost.
+	ge.Resources.LoadAmounts(map[string]float64{"culture": festivalMinCost - 1})
+
+	before := ge.Resources.Get("culture")
+	if err := ge.DoFestival(); err == nil {
+		t.Fatal("DoFestival should fail when culture is insufficient")
+	}
+	if got := ge.Resources.Get("culture"); got != before {
+		t.Errorf("culture changed on a failed festival: %v -> %v (must spend nothing)", before, got)
+	}
+	if n := len(ge.Events.GetActive()); n != 0 {
+		t.Errorf("a failed festival injected %d active events, want 0", n)
+	}
+}
+
+// TestFestival_DeductsCultureAndInjectsBuff is the happy path: enough culture →
+// culture is spent, a temporary production_all buff event is injected, and the
+// cooldown is armed.
+func TestFestival_DeductsCultureAndInjectsBuff(t *testing.T) {
+	ge := NewGameEngine()
+	ge.Resources.UnlockResource("culture")
+	// Give plenty of culture so cost = festivalMinCost (cap is small early).
+	ge.Resources.LoadAmounts(map[string]float64{"culture": 1_000_000})
+
+	cost := ge.festivalCost()
+	before := ge.Resources.Get("culture")
+
+	if err := ge.DoFestival(); err != nil {
+		t.Fatalf("DoFestival failed with ample culture: %v", err)
+	}
+
+	// Culture actually consumed.
+	spent := before - ge.Resources.Get("culture")
+	if math.Abs(spent-cost) > 1e-9 {
+		t.Errorf("festival spent %v culture, want %v", spent, cost)
+	}
+
+	// Buff event injected with the right key, duration, and production_all value.
+	active := ge.Events.GetActive()
+	var found *ActiveEventState
+	for i := range active {
+		if active[i].Key == "cultural_festival" {
+			found = &active[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("festival did not inject a cultural_festival active event")
+	}
+	if found.TicksLeft != festivalBuffTicks {
+		t.Errorf("festival buff TicksLeft = %d, want %d", found.TicksLeft, festivalBuffTicks)
+	}
+	var buf float64
+	for _, eff := range found.Effects {
+		if eff.Type == "production_all" {
+			buf = eff.Value
+		}
+	}
+	if math.Abs(buf-festivalBuffPercent) > 1e-9 {
+		t.Errorf("festival production_all = %v, want %v", buf, festivalBuffPercent)
+	}
+
+	// The buff must reach the resolver pool the engine applies to rates.
+	if got := ge.buildResolver().AddTotal("production_all"); math.Abs(got-festivalBuffPercent) > 1e-9 {
+		t.Errorf("resolver production_all during festival = %v, want %v", got, festivalBuffPercent)
+	}
+}
+
+// TestFestival_RespectsCooldown asserts a second festival is refused while the
+// cooldown is active, and allowed again once enough ticks have passed.
+func TestFestival_RespectsCooldown(t *testing.T) {
+	ge := NewGameEngine()
+	ge.Resources.UnlockResource("culture")
+	ge.Resources.LoadAmounts(map[string]float64{"culture": 1_000_000})
+
+	if err := ge.DoFestival(); err != nil {
+		t.Fatalf("first festival failed: %v", err)
+	}
+	// Immediately: on cooldown.
+	st := ge.FestivalStatus()
+	if st.Ready {
+		t.Errorf("festival reported Ready immediately after holding one; CooldownLeft=%d", st.CooldownLeft)
+	}
+	if err := ge.DoFestival(); err == nil {
+		t.Error("second festival during cooldown should fail")
+	}
+
+	// Advance the game clock past the cooldown window.
+	ge.tick += festivalCooldownTicks
+	st = ge.FestivalStatus()
+	if !st.Ready {
+		t.Errorf("festival not Ready after cooldown elapsed; CooldownLeft=%d", st.CooldownLeft)
+	}
+	if err := ge.DoFestival(); err != nil {
+		t.Errorf("festival after cooldown elapsed should succeed, got: %v", err)
+	}
+}
+
+// TestFestivalStatus_ReportsCostAndBuff sanity-checks the snapshot the command
+// renders: cost ≥ minimum, buff params match the constants.
+func TestFestivalStatus_ReportsCostAndBuff(t *testing.T) {
+	ge := NewGameEngine()
+	ge.Resources.UnlockResource("culture")
+	st := ge.FestivalStatus()
+	if st.Cost < festivalMinCost {
+		t.Errorf("festival cost %v below minimum %v", st.Cost, festivalMinCost)
+	}
+	if st.BuffPercent != festivalBuffPercent {
+		t.Errorf("status BuffPercent = %v, want %v", st.BuffPercent, festivalBuffPercent)
+	}
+	if st.BuffTicks != festivalBuffTicks {
+		t.Errorf("status BuffTicks = %d, want %d", st.BuffTicks, festivalBuffTicks)
+	}
+	if st.CooldownTicks != festivalCooldownTicks {
+		t.Errorf("status CooldownTicks = %d, want %d", st.CooldownTicks, festivalCooldownTicks)
+	}
+}

--- a/site/docs/buildings.md
+++ b/site/docs/buildings.md
@@ -316,6 +316,21 @@ Storage buildings also participate in the upgrade system on age advance — use 
 
 ---
 
+## Cultural Monuments (4)
+
+Cultural Monuments are one-off structures (Category: `monument`, capped at one copy each) that exist to turn surplus **culture** into a permanent payoff. Each costs a large lump of culture (plus other age-appropriate materials) and grants a permanent `production_all` bonus on construction. Unlike wonders, they need no resource banking — build them with the normal `build <key>` command.
+
+| Monument | Age | Culture Cost | Permanent Bonus |
+|----------|-----|--------------|-----------------|
+| Cultural Obelisk | Classical | 2,500 | +1% all production |
+| Grand Amphitheatre | Medieval | 25,000 | +2% all production |
+| Eternal Library | Industrial | 500,000 | +3% all production |
+| Monument of Ages | Modern | 25,000,000 | +5% all production |
+
+Monuments are one of the two culture sinks (the other is the `festival` command); prestige gates remain the primary long-term sink. See [Culture](resources.md#culture).
+
+---
+
 ## Wonders (22)
 
 Wonders are unique one-of-a-kind buildings — you can only build each wonder once. They require resource banking before construction can begin:

--- a/site/docs/commands.md
+++ b/site/docs/commands.md
@@ -177,6 +177,17 @@ Available upgrades and costs are shown in **Stats** overlay (`stats`).
 
 ---
 
+## Festival
+
+| Command | Description |
+|---|---|
+| `festival` | Show festival status — culture cost, current culture, and the buff it grants |
+| `festival confirm yes` | Hold a cultural festival now — spends culture for a temporary production boost |
+
+Spend a lump of **culture** (max(2,000, 5% of your culture storage cap)) for **+20% to all production for 150 ticks** (~5 minutes). There's a **300-tick cooldown** (~10 minutes) between festivals, so it stays a rare, deliberate boost rather than a per-tick reflex. This is one of the culture sinks — see [Resources](resources.md#culture). Prestige gates remain the primary long-term culture sink.
+
+---
+
 ## Civilization History
 
 | Command | Description |

--- a/site/docs/resources.md
+++ b/site/docs/resources.md
@@ -118,7 +118,7 @@ Your faith level as a **percentage of your storage cap** determines epoch event 
 
 ## Culture
 
-Culture **accumulates permanently** rather than draining. Your culture storage cap grows as you build Culture/Arts lineage buildings. Once accumulated culture passes a threshold, the bonus is permanent — it does not require maintaining a balance.
+Culture grows as you build Culture/Arts lineage buildings. Passing a threshold grants a permanent knowledge bonus — once reached, it does not require maintaining a balance.
 
 | Threshold | Bonus |
 |-----------|-------|
@@ -132,6 +132,23 @@ Culture **accumulates permanently** rather than draining. Your culture storage c
 **On prestige:** Culture is reduced to 20% of its current value. Bonuses from thresholds you already passed remain permanently — only the current culture total is cut.
 
 Culture buildings (Lineage 10: Amphitheater → ...) auto-produce culture without requiring worker assignment. Build them passively while focusing workers on higher-priority domains.
+
+### Culture sinks
+
+Beyond the prestige/threshold gates, culture now has two ways to spend the surplus that used to sit idle:
+
+**Cultural Monuments** — four one-off structures (Category: monument, MaxCount 1 each) built with the normal `build <key>` command. Each costs a large lump of culture (plus other materials) and grants a small **permanent** `production_all` bonus on construction.
+
+| Monument | Age | Culture Cost | Permanent Bonus |
+|----------|-----|--------------|-----------------|
+| Cultural Obelisk | Classical | 2,500 | +1% all production |
+| Grand Amphitheatre | Medieval | 25,000 | +2% all production |
+| Eternal Library | Industrial | 500,000 | +3% all production |
+| Monument of Ages | Modern | 25,000,000 | +5% all production |
+
+**`festival` command** — spend a scaling lump of culture (`max(2,000, 5% of your culture cap)`) for **+20% to all production for 150 ticks**, on a **300-tick cooldown**. See [Commands](commands.md).
+
+**Prestige gates remain the primary long-term culture sink** — monuments and festivals are supplementary ways to spend surplus culture, not a replacement for it.
 
 ---
 

--- a/ui/autocomplete.go
+++ b/ui/autocomplete.go
@@ -31,6 +31,7 @@ var commands = []string{
 	"status", "s",
 	"help", "h",
 	"prestige",
+	"festival",
 	"upgrade",
 	"advance", "rates", "speed", "save", "saves", "load",
 	"account",
@@ -152,6 +153,14 @@ func suggestArg(cmd string, completed []string, partial string, prefix string, e
 		}
 		if strings.ToLower(completed[0]) == "buy" {
 			return filterPrefix(prestigeUpgradeKeys(state), partial, prefix)
+		}
+		if strings.ToLower(completed[0]) == "confirm" {
+			return filterPrefix([]string{"yes"}, partial, prefix)
+		}
+
+	case "festival":
+		if len(completed) == 0 {
+			return filterPrefix([]string{"confirm"}, partial, prefix)
 		}
 		if strings.ToLower(completed[0]) == "confirm" {
 			return filterPrefix([]string{"yes"}, partial, prefix)

--- a/ui/input.go
+++ b/ui/input.go
@@ -72,6 +72,8 @@ func HandleCommand(input string, engine *game.GameEngine) CommandResult {
 		return cmdWonder(args, engine)
 	case "prestige":
 		return cmdPrestige(args, engine)
+	case "festival":
+		return cmdFestival(args, engine)
 	case "rates":
 		return cmdRates(engine)
 	case "speed":
@@ -1174,6 +1176,74 @@ func cmdCampaign(args []string, engine *game.GameEngine) CommandResult {
 		Message: fmt.Sprintf("Campaign launched: %s!", name),
 		Type:    "success",
 	}
+}
+
+// cmdFestival handles the `festival` culture-sink command. Bare `festival`
+// shows status (cost, cooldown, what it does). `festival confirm yes` spends a
+// lump of culture to inject a temporary empire-wide production buff. Mirrors the
+// prestige confirm UX so the muscle memory carries over.
+func cmdFestival(args []string, engine *game.GameEngine) CommandResult {
+	if len(args) == 0 {
+		return cmdFestivalStatus(engine)
+	}
+	subcmd := strings.ToLower(args[0])
+
+	switch subcmd {
+	case "confirm":
+		if len(args) >= 2 && strings.ToLower(args[1]) == "yes" {
+			if err := engine.DoFestival(); err != nil {
+				return CommandResult{Message: err.Error(), Type: "error"}
+			}
+			st := engine.FestivalStatus()
+			return CommandResult{
+				Message: fmt.Sprintf("Festival underway! Spent %.0f culture. +%.0f%% to all production for %d ticks.",
+					st.Cost, st.BuffPercent*100, st.BuffTicks),
+				Type: "success",
+			}
+		}
+		// Show the confirm prompt with the live cost.
+		st := engine.FestivalStatus()
+		if !st.Ready {
+			return CommandResult{
+				Message: fmt.Sprintf("[yellow]Festival on cooldown[-] — %d ticks until the next one can be held.", st.CooldownLeft),
+				Type:    "warning",
+			}
+		}
+		var lines []string
+		lines = append(lines, "[gold]Hold a Cultural Festival?[-]")
+		lines = append(lines, fmt.Sprintf("  Cost: [cyan]%.0f culture[-] (you have %.0f)", st.Cost, st.Culture))
+		lines = append(lines, fmt.Sprintf("  Effect: [green]+%.0f%%[-] to all production for [cyan]%d[-] ticks.", st.BuffPercent*100, st.BuffTicks))
+		lines = append(lines, fmt.Sprintf("  Cooldown afterward: [cyan]%d[-] ticks.", st.CooldownTicks))
+		if st.Culture < st.Cost {
+			lines = append(lines, "")
+			lines = append(lines, "  [red]Not enough culture.[-]")
+		}
+		lines = append(lines, "")
+		lines = append(lines, "  Type [cyan]festival confirm yes[-] to celebrate.")
+		return CommandResult{Message: strings.Join(lines, "\n"), Type: "warning"}
+	default:
+		return CommandResult{Message: "Usage: festival [confirm yes]", Type: "error"}
+	}
+}
+
+// cmdFestivalStatus renders the bare `festival` status panel.
+func cmdFestivalStatus(engine *game.GameEngine) CommandResult {
+	st := engine.FestivalStatus()
+	var lines []string
+	lines = append(lines, "[gold]Cultural Festival[-]")
+	lines = append(lines, "  Spend a lump of culture for a temporary empire-wide production boost.")
+	lines = append(lines, fmt.Sprintf("  Cost: [cyan]%.0f culture[-]  (you have %.0f)", st.Cost, st.Culture))
+	lines = append(lines, fmt.Sprintf("  Effect: [green]+%.0f%%[-] to all production for [cyan]%d[-] ticks.", st.BuffPercent*100, st.BuffTicks))
+	if st.Ready {
+		if st.Culture >= st.Cost {
+			lines = append(lines, "  Status: [green]ready[-] — type [cyan]festival confirm yes[-].")
+		} else {
+			lines = append(lines, "  Status: [yellow]not enough culture yet.[-]")
+		}
+	} else {
+		lines = append(lines, fmt.Sprintf("  Status: [yellow]on cooldown[-] — %d ticks remaining.", st.CooldownLeft))
+	}
+	return CommandResult{Message: strings.Join(lines, "\n"), Type: "info"}
 }
 
 func cmdPrestige(args []string, engine *game.GameEngine) CommandResult {

--- a/ui/overlay_help.go
+++ b/ui/overlay_help.go
@@ -57,6 +57,8 @@ func helpProvider(_ game.GameState, _ int) string {
 	sb.WriteString("  [cyan]prestige[-] confirm yes            - Reset game with prestige bonus\n")
 	sb.WriteString("  [cyan]prestige[-] shop                   - View prestige upgrades\n")
 	sb.WriteString("  [cyan]prestige[-] buy <key>              - Buy a prestige upgrade\n")
+	sb.WriteString("  [cyan]festival[-]                        - Spend culture for a temporary production boost\n")
+	sb.WriteString("  [cyan]festival confirm yes[-]            - Hold the festival now\n")
 	sb.WriteString("  [cyan]catastrophe invoke[-]              - Voluntarily trigger the epoch catastrophe\n")
 
 	sb.WriteString("\n[gold]═══ Game ═══[-]\n")


### PR DESCRIPTION
Resolves the **Culture Consumption** card — culture only had one sink (prestige gates, once per run), so billions sat idle late-game. Two supplementary sinks; **prestige stays the primary long-term sink.**

- **Cultural Monuments** — 4 one-off buildings (Classical→Modern) costed in *culture* (2.5K → 25M), each granting a permanent `production_all` bonus (+1% → +5%). Built via the normal `build` flow. One minimal engine change: `getWonderBonuses` now folds `Category:"monument"` bonus effects into the same resolver pool wonders already use (no new system, no migration).
- **`festival` command** — spend a lump of culture (max 2K or 5% of your culture cap) for **+20% production for 150 ticks**, on a 300-tick cooldown so it stays rare. Bare `festival` shows status; `festival confirm yes` fires it (mirrors the prestige command UX).
- 6 new tests, wiki (resources/commands/buildings) + changelog. `go build/vet/test` green.

Upkeep-style monuments (culture/tick) weren't viable — there's no upkeep subsystem and adding one is out of scope — so monuments are a construction-cost sink instead.