### PR TITLE
feat(events): Age Awakenings — one-time epoch-entry events (card f0fYovZc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to AgeForge are documented here.
 - **Main-screen UI overhaul** — a framed command bar, a scannable ✓/✗ age-progress strip, a cleaner log, lifted secondary-text contrast, an early-game onboarding panel, and rebalanced panel widths.
 - Nanobots are a real resource now — a Modern-age producer building (Nano Foundry, +80 nanobots/tick), 3 nanobot techs (Nanofabrication cuts build costs −8%, Medical Nanobots boosts population and food, Self-Replication ramps nanobot output), and several digital/cyberpunk buildings now cost nanobots to construct.
 - Culture has sinks now — Cultural Monuments (spend culture for a permanent production bonus) and a `festival` command (spend a lump of culture for a temporary multi-resource buff); prestige gates remain the primary long-term sink.
+- **Age Awakenings** — a one-time deterministic boost fires the first time you enter each epoch's signature age (7 epochs, 7 awakenings): Pottery Mastery, Discovery of Metallurgy, Steam Breakthrough, Electrification, Information Age Dawns, Cybernetic Awakening, and First Contact Signal. Each grants a modest temporary production bonus, fires at most once per prestige run, persists across save/load, and resets on prestige so the next run can earn them again.
 
 ### Balance
 - Flattened building cost curves and raised age-advancement requirements.

--- a/config/awakenings.go
+++ b/config/awakenings.go
@@ -1,0 +1,137 @@
+package config
+
+// AwakeningDef defines a one-time "Age Awakening" — a pivotal moment that fires
+// exactly once per civilisation cycle (prestige run) the FIRST time the player
+// advances INTO that epoch's trigger age. There are 7 awakenings, one per epoch,
+// marking each epoch transition as a defining event in the run.
+//
+// Unlike the random epoch-transition roll (GoodEpochEvents / ChallengingEpochEvents,
+// which is a gamble gated on faith/culture), an awakening is deterministic: it always
+// fires, always grants a modest thematic boost, and never carries a downside.
+//
+// The effect is delivered through the existing ActiveEvent / InjectEvent mechanism —
+// a TEMPORARY boost that decays after Duration ticks. Two effect shapes are used,
+// both of which active events already feed into recalculateRates:
+//   - Type "production_all", Value v   → +v multiplier on ALL positive rates while active
+//   - Type "production", Target res, Value v → +v FLAT additive to that resource's rate
+//
+// No new effect engine is introduced; these are the same Effect types regular and
+// epoch events already use.
+type AwakeningDef struct {
+	Key        string   // unique key, also used for the ActiveEvent key + fired-set tracking
+	EpochKey   string   // epoch this awakening belongs to (one per epoch)
+	TriggerAge string   // age key whose FIRST entry fires this awakening
+	Name       string   // display name shown in the log/splash
+	FlavorText string   // 1-2 line dry/evocative description, matches the game's tone
+	Duration   int      // ticks the temporary effect lasts (ticks are ~2s of real time)
+	Effects    []Effect // temporary boost applied via InjectEvent
+}
+
+// Awakenings returns all 7 age-awakening definitions, one per epoch, in epoch order.
+//
+// Trigger ages are chosen as the first "meaningful" age of each epoch. The Stone Era
+// triggers on the Stone Age rather than the Primitive Age (the tutorial/starting age),
+// and the Steel Era's Steam Breakthrough triggers on the Industrial Age where steam
+// power thematically arrives. The remaining five trigger on their epoch's first age.
+//
+// Duration tuning (1 tick ≈ 2s real time):
+//
+//	~250 ticks ≈ 8 min, ~500 ticks ≈ 16 min, ~200 ticks ≈ 6.5 min.
+func Awakenings() []AwakeningDef {
+	return []AwakeningDef{
+		{
+			Key:      "awakening_pottery_mastery",
+			EpochKey: "stone_era", TriggerAge: "stone_age",
+			Name:       "Pottery Mastery",
+			FlavorText: "Clay yields to patient hands. Sealed vessels hold the harvest through the lean months — and the surplus, for once, keeps.",
+			Duration:   250,
+			Effects: []Effect{
+				{Type: "production", Target: "food", Value: 1.0},
+				{Type: "production", Target: "stone", Value: 0.5},
+			},
+		},
+		{
+			Key:      "awakening_metallurgy",
+			EpochKey: "iron_era", TriggerAge: "iron_age",
+			Name:       "Discovery of Metallurgy",
+			FlavorText: "The forge runs hotter than any fire before it. Ore that once defied you now bleeds into ingots — and the smiths cannot smelt fast enough.",
+			Duration:   500,
+			Effects: []Effect{
+				{Type: "production", Target: "iron", Value: 2.0},
+			},
+		},
+		{
+			Key:      "awakening_steam_breakthrough",
+			EpochKey: "steel_era", TriggerAge: "industrial_age",
+			Name:       "Steam Breakthrough",
+			FlavorText: "Pressure, piston, purpose. The first engine coughs, catches, and roars — and every workshop in the land suddenly works twice as hard.",
+			Duration:   200,
+			Effects: []Effect{
+				{Type: "production_all", Value: 0.25},
+			},
+		},
+		{
+			Key:      "awakening_electrification",
+			EpochKey: "electric_era", TriggerAge: "victorian_age",
+			Name:       "Electrification",
+			FlavorText: "Night surrenders. The grid hums to life, lamps bloom across the skyline, and machines that never sleep take up the long shift.",
+			Duration:   300,
+			Effects: []Effect{
+				{Type: "production", Target: "electricity", Value: 2.0},
+				{Type: "production_all", Value: 0.10},
+			},
+		},
+		{
+			Key:      "awakening_information_age",
+			EpochKey: "digital_era", TriggerAge: "modern_age",
+			Name:       "Information Age Dawns",
+			FlavorText: "Knowledge stops being scarce. The networks wake, the archives open, and insight compounds faster than anyone can read it.",
+			Duration:   300,
+			Effects: []Effect{
+				{Type: "production", Target: "data", Value: 2.0},
+				{Type: "production", Target: "knowledge", Value: 1.0},
+			},
+		},
+		{
+			Key:      "awakening_cybernetic",
+			EpochKey: "neon_era", TriggerAge: "cyberpunk_age",
+			Name:       "Cybernetic Awakening",
+			FlavorText: "Flesh and circuit reach an accord. Augmented crews never tire, never blink — and the city's output climbs to a neon-lit fever pitch.",
+			Duration:   250,
+			Effects: []Effect{
+				{Type: "production_all", Value: 0.20},
+			},
+		},
+		{
+			Key:      "awakening_first_contact",
+			EpochKey: "cosmic_era", TriggerAge: "interstellar_age",
+			Name:       "First Contact Signal",
+			FlavorText: "A pattern threads through the static — too regular to be noise, too strange to be us. Whatever sent it, your engineers cannot stop listening.",
+			Duration:   400,
+			Effects: []Effect{
+				{Type: "production", Target: "dark_matter", Value: 1.5},
+				{Type: "production_all", Value: 0.10},
+			},
+		},
+	}
+}
+
+// AwakeningByKey returns a map of awakening key -> AwakeningDef.
+func AwakeningByKey() map[string]AwakeningDef {
+	m := make(map[string]AwakeningDef)
+	for _, a := range Awakenings() {
+		m[a.Key] = a
+	}
+	return m
+}
+
+// AwakeningForAge returns the awakening whose TriggerAge matches ageKey, and true,
+// or a zero AwakeningDef and false if no awakening triggers on that age.
+func AwakeningForAge(ageKey string) (AwakeningDef, bool) {
+	for _, a := range Awakenings() {
+		if a.TriggerAge == ageKey {
+			return a, true
+		}
+	}
+	return AwakeningDef{}, false
+}

--- a/game/awakenings_test.go
+++ b/game/awakenings_test.go
@@ -1,0 +1,263 @@
+package game
+
+import (
+	"os"
+	"testing"
+
+	"github.com/espresso20/ageforge/config"
+)
+
+// activeEventByKey returns the active ActiveEvent with the given key, or nil.
+func activeEventByKey(ge *GameEngine, key string) *ActiveEvent {
+	for i := range ge.Events.active {
+		if ge.Events.active[i].Key == key {
+			return &ge.Events.active[i]
+		}
+	}
+	return nil
+}
+
+// TestAwakening_FiresOnceOnTriggerAge verifies that advancing into an epoch's
+// trigger age fires that epoch's awakening exactly once: it injects the timed
+// boost event and records the awakening as fired.
+func TestAwakening_FiresOnceOnTriggerAge(t *testing.T) {
+	ge := NewGameEngine()
+
+	// stone_age is the Stone Era's awakening trigger (Pottery Mastery).
+	def, ok := config.AwakeningForAge("stone_age")
+	if !ok {
+		t.Fatal("expected an awakening to trigger on stone_age")
+	}
+
+	if ge.awakeningsFired[def.Key] {
+		t.Fatalf("awakening %q should not be fired before advancing", def.Key)
+	}
+
+	ge.advanceAge("stone_age")
+
+	if !ge.awakeningsFired[def.Key] {
+		t.Errorf("awakening %q should be recorded as fired after advancing to stone_age", def.Key)
+	}
+
+	ae := activeEventByKey(ge, def.Key)
+	if ae == nil {
+		t.Fatalf("awakening %q should have injected an active event", def.Key)
+	}
+	if ae.Name != def.Name {
+		t.Errorf("injected event name = %q, want %q", ae.Name, def.Name)
+	}
+	if ae.TicksLeft != def.Duration {
+		t.Errorf("injected event TicksLeft = %d, want %d", ae.TicksLeft, def.Duration)
+	}
+	if len(ae.Effects) != len(def.Effects) {
+		t.Errorf("injected event has %d effects, want %d", len(ae.Effects), len(def.Effects))
+	}
+}
+
+// TestAwakening_DoesNotRefireOnReentry verifies that advancing into the same
+// trigger age twice fires the awakening only once (no duplicate injected event,
+// fired flag stays set).
+func TestAwakening_DoesNotRefireOnReentry(t *testing.T) {
+	ge := NewGameEngine()
+	def, _ := config.AwakeningForAge("stone_age")
+
+	ge.advanceAge("stone_age")
+	// Drain the first injected event so a second fire would be unmistakable.
+	ge.Events.active = nil
+
+	// Re-enter stone_age (e.g. an age-set edge case). Must NOT re-fire.
+	ge.advanceAge("stone_age")
+
+	if ae := activeEventByKey(ge, def.Key); ae != nil {
+		t.Errorf("awakening %q re-fired on re-entry; should fire at most once per run", def.Key)
+	}
+	if !ge.awakeningsFired[def.Key] {
+		t.Errorf("awakening %q fired flag should remain set", def.Key)
+	}
+}
+
+// TestAwakening_NoFireOnNonTriggerAge verifies that advancing into an age that is
+// not any awakening's trigger age fires nothing. primitive_age (the starting age)
+// is deliberately not an awakening trigger.
+func TestAwakening_NoFireOnNonTriggerAge(t *testing.T) {
+	ge := NewGameEngine()
+
+	if _, ok := config.AwakeningForAge("primitive_age"); ok {
+		t.Fatal("primitive_age should NOT be an awakening trigger age")
+	}
+
+	ge.advanceAge("primitive_age")
+
+	if len(ge.awakeningsFired) != 0 {
+		t.Errorf("no awakening should fire on primitive_age, got fired set: %v", ge.awakeningsFired)
+	}
+}
+
+// TestAwakening_ReloadDoesNotRefire verifies the one-time guard survives a real
+// save/load round-trip: after firing an awakening and saving, loading the save and
+// re-advancing into the trigger age does NOT re-fire it.
+func TestAwakening_ReloadDoesNotRefire(t *testing.T) {
+	ge := NewGameEngine()
+	def, _ := config.AwakeningForAge("stone_age")
+
+	ge.advanceAge("stone_age")
+	if !ge.awakeningsFired[def.Key] {
+		t.Fatalf("precondition: awakening %q should be fired", def.Key)
+	}
+
+	if err := ge.SaveGame("test_awakening_reload"); err != nil {
+		t.Fatalf("SaveGame failed: %v", err)
+	}
+	defer os.Remove("data/saves/test_awakening_reload.json")
+
+	ge2 := NewGameEngine()
+	if err := ge2.LoadGame("test_awakening_reload"); err != nil {
+		t.Fatalf("LoadGame failed: %v", err)
+	}
+
+	// Fired set must have survived the round-trip.
+	if !ge2.awakeningsFired[def.Key] {
+		t.Errorf("awakening %q fired flag did not persist across save/load", def.Key)
+	}
+
+	// Re-advancing into the trigger age on the loaded engine must not re-fire.
+	ge2.Events.active = nil
+	ge2.advanceAge("stone_age")
+	if ae := activeEventByKey(ge2, def.Key); ae != nil {
+		t.Errorf("awakening %q re-fired after reload; one-time guard not honoured", def.Key)
+	}
+}
+
+// TestAwakening_PrestigeClearsFiredSet verifies that the fired set resets on
+// prestige/reset so awakenings can fire again next run. We poke the reset path
+// that DoPrestige/Reset use (re-initialising the map) and confirm a fresh fire.
+func TestAwakening_PrestigeClearsFiredSet(t *testing.T) {
+	ge := NewGameEngine()
+	def, _ := config.AwakeningForAge("stone_age")
+
+	ge.advanceAge("stone_age")
+	if !ge.awakeningsFired[def.Key] {
+		t.Fatalf("precondition: awakening %q should be fired", def.Key)
+	}
+
+	// Reset (mirrors the prestige/succumb/wipe paths, which all re-init this map
+	// alongside epochEventFired). After reset the run should be able to fire again.
+	ge.Reset()
+
+	if len(ge.awakeningsFired) != 0 {
+		t.Errorf("awakeningsFired should be cleared after Reset, got: %v", ge.awakeningsFired)
+	}
+
+	// Bring the engine back to the age before the trigger so advanceAge crosses in.
+	ge.age = "primitive_age"
+	ge.advanceAge("stone_age")
+	if !ge.awakeningsFired[def.Key] {
+		t.Errorf("awakening %q should fire again in the new run after reset", def.Key)
+	}
+	if activeEventByKey(ge, def.Key) == nil {
+		t.Errorf("awakening %q should re-inject its event in the new run", def.Key)
+	}
+}
+
+// TestAwakening_AllDefinitionsValid verifies there are exactly 7 awakenings (one
+// per epoch) and that every awakening references real config: a valid epoch key, a
+// trigger age that exists and belongs to that epoch, a non-empty name/flavor, a
+// positive duration, and effects whose targets are real resources (or no target for
+// production_all). Guards against typos in keys/targets at the config layer.
+func TestAwakening_AllDefinitionsValid(t *testing.T) {
+	awakenings := config.Awakenings()
+
+	epochs := config.EpochByKey()
+	if len(awakenings) != len(epochs) {
+		t.Errorf("got %d awakenings, want one per epoch (%d)", len(awakenings), len(epochs))
+	}
+
+	// Build the set of valid resource keys for effect-target validation.
+	validResource := make(map[string]bool)
+	for _, r := range config.BaseResources() {
+		validResource[r.Key] = true
+	}
+
+	seenEpoch := make(map[string]bool)
+	seenKey := make(map[string]bool)
+
+	for _, a := range awakenings {
+		if a.Key == "" {
+			t.Errorf("awakening for epoch %q has empty Key", a.EpochKey)
+		}
+		if seenKey[a.Key] {
+			t.Errorf("duplicate awakening key %q", a.Key)
+		}
+		seenKey[a.Key] = true
+
+		ep, ok := epochs[a.EpochKey]
+		if !ok {
+			t.Errorf("awakening %q references unknown epoch %q", a.Key, a.EpochKey)
+			continue
+		}
+		if seenEpoch[a.EpochKey] {
+			t.Errorf("epoch %q has more than one awakening", a.EpochKey)
+		}
+		seenEpoch[a.EpochKey] = true
+
+		// Trigger age must exist and belong to this awakening's epoch.
+		if config.EpochForAge(a.TriggerAge) != a.EpochKey {
+			t.Errorf("awakening %q trigger age %q does not belong to epoch %q",
+				a.Key, a.TriggerAge, a.EpochKey)
+		}
+		ageInEpoch := false
+		for _, age := range ep.Ages {
+			if age == a.TriggerAge {
+				ageInEpoch = true
+				break
+			}
+		}
+		if !ageInEpoch {
+			t.Errorf("awakening %q trigger age %q not listed in epoch %q ages %v",
+				a.Key, a.TriggerAge, a.EpochKey, ep.Ages)
+		}
+
+		if a.Name == "" {
+			t.Errorf("awakening %q has empty Name", a.Key)
+		}
+		if a.FlavorText == "" {
+			t.Errorf("awakening %q has empty FlavorText", a.Key)
+		}
+		if a.Duration <= 0 {
+			t.Errorf("awakening %q has non-positive Duration %d", a.Key, a.Duration)
+		}
+		if len(a.Effects) == 0 {
+			t.Errorf("awakening %q has no effects", a.Key)
+		}
+		for _, eff := range a.Effects {
+			switch eff.Type {
+			case "production_all":
+				// No target required; value is a multiplier.
+				if eff.Value <= 0 {
+					t.Errorf("awakening %q production_all value %.2f should be positive", a.Key, eff.Value)
+				}
+			case "production":
+				if !validResource[eff.Target] {
+					t.Errorf("awakening %q production effect targets unknown resource %q", a.Key, eff.Target)
+				}
+				if eff.Value <= 0 {
+					t.Errorf("awakening %q production effect on %q has non-positive value %.2f",
+						a.Key, eff.Target, eff.Value)
+				}
+			default:
+				t.Errorf("awakening %q uses unexpected effect type %q (use production / production_all)",
+					a.Key, eff.Type)
+			}
+		}
+	}
+
+	// Sanity: the card's 7 named trigger ages must each resolve to an awakening.
+	for _, age := range []string{
+		"stone_age", "iron_age", "industrial_age", "victorian_age",
+		"modern_age", "cyberpunk_age", "interstellar_age",
+	} {
+		if _, ok := config.AwakeningForAge(age); !ok {
+			t.Errorf("expected an awakening to trigger on %q", age)
+		}
+	}
+}

--- a/game/bus.go
+++ b/game/bus.go
@@ -15,6 +15,7 @@ const (
 	EventChainCompleted      = "chain_completed"
 	EventEpochAdvanced       = "epoch_advanced"
 	EventEpochEventFired     = "epoch_event_fired"
+	EventAwakeningFired      = "awakening_fired"
 )
 
 // EventData carries data for an event

--- a/game/engine.go
+++ b/game/engine.go
@@ -127,6 +127,10 @@ type GameEngine struct {
 	survivedEpochs     map[string]bool // epochs where player chose Endure
 	pendingCatastrophe string          // epoch key when catastrophe modal should show; "" otherwise
 	epochEventHistory  []EpochEventRecord
+	// awakeningsFired tracks which one-time Age Awakenings have fired this run, so each
+	// fires at most once per prestige cycle and a save/reload does not re-fire. Keyed by
+	// AwakeningDef.Key. Cleared on prestige/reset alongside epochEventFired.
+	awakeningsFired map[string]bool
 
 	// Phase 9: catastrophe system — these fields intentionally survive Succumb and Prestige
 	// resets so that legacy bonuses and civilization history accumulate across multiple runs.
@@ -184,6 +188,7 @@ func NewGameEngine() *GameEngine {
 		stopCh:           make(chan struct{}),
 		currentEpoch:     config.EpochForAge("primitive_age"),
 		epochEventFired:  make(map[string]bool),
+		awakeningsFired:  make(map[string]bool),
 		survivedEpochs:   make(map[string]bool),
 		legacyBonuses:    make(map[string]bool),
 		History:          NewHistoryCollector(),
@@ -1459,6 +1464,11 @@ func (ge *GameEngine) advanceAge(newAge string) {
 	// Phase 8: detect epoch transition and roll epoch event
 	ge.detectEpochTransition(newAge)
 
+	// Age Awakening: one-time epoch awakening on first entry to its trigger age.
+	// Fires after the epoch roll so the awakening's deterministic boost lands on top
+	// of any epoch-event flavor, and logs as the pivotal "this is a new era" beat.
+	ge.fireAwakening(newAge)
+
 	// Age advancement celebration morale boost
 	ge.applyMorale(0.08)
 }
@@ -1499,6 +1509,47 @@ func (ge *GameEngine) detectEpochTransition(newAge string) {
 		},
 	})
 	ge.rollEpochEvent(newEpoch)
+}
+
+// fireAwakening fires the one-time Age Awakening for newAge, if one triggers on that
+// age and it has not already fired this run. An awakening is deterministic (always
+// grants its modest thematic boost, no downside) and one-time per prestige cycle:
+// the awakeningsFired set guards against double-fire on re-entry or save/reload.
+//
+// The boost is delivered through the existing ActiveEvent / InjectEvent mechanism so
+// it decays after Duration ticks and surfaces in the active-events panel like any
+// other timed event. Must be called under the engine write lock (advanceAge holds it);
+// it touches no lock-acquiring methods and is safe in that path.
+func (ge *GameEngine) fireAwakening(newAge string) {
+	def, ok := config.AwakeningForAge(newAge)
+	if !ok {
+		return // no awakening triggers on this age
+	}
+	if ge.awakeningsFired[def.Key] {
+		return // already fired this run
+	}
+	ge.awakeningsFired[def.Key] = true
+
+	ge.Events.InjectEvent(ActiveEvent{
+		Key:       def.Key,
+		Name:      def.Name,
+		TicksLeft: def.Duration,
+		Effects:   def.Effects,
+	})
+
+	ep := config.EpochByKey()[def.EpochKey]
+	// One log line per awakening — the pivotal "new era" beat. Coloured by the epoch
+	// so the awakening visually belongs to the era it ushers in.
+	ge.addLog("event", fmt.Sprintf("[%s]✦ Awakening: %s — %s[-]", ep.Color, def.Name, def.FlavorText))
+
+	ge.Bus.Publish(EventData{
+		Type: EventAwakeningFired,
+		Payload: map[string]interface{}{
+			"awakening_key":  def.Key,
+			"awakening_name": def.Name,
+			"epoch_key":      def.EpochKey,
+		},
+	})
 }
 
 // rollEpochEvent performs the epoch transition event roll.
@@ -2133,6 +2184,7 @@ func (ge *GameEngine) Succumb() error {
 	ge.starvationTicks = 0
 	ge.currentEpoch = config.EpochForAge("primitive_age")
 	ge.epochEventFired = make(map[string]bool)
+	ge.awakeningsFired = make(map[string]bool)
 	ge.survivedEpochs = make(map[string]bool)
 	ge.pendingCatastrophe = ""
 	ge.morale = 0.50
@@ -2844,6 +2896,7 @@ func (ge *GameEngine) DoPrestige() error {
 	ge.log = nil
 	ge.currentEpoch = config.EpochForAge("primitive_age")
 	ge.epochEventFired = make(map[string]bool)
+	ge.awakeningsFired = make(map[string]bool)
 	ge.survivedEpochs = make(map[string]bool)
 	ge.pendingCatastrophe = ""
 	ge.epochEventHistory = nil
@@ -2932,6 +2985,7 @@ func (ge *GameEngine) Reset() {
 	ge.eliteBadge = false
 	ge.currentEpoch = config.EpochForAge("primitive_age")
 	ge.epochEventFired = make(map[string]bool)
+	ge.awakeningsFired = make(map[string]bool)
 	ge.survivedEpochs = make(map[string]bool)
 	ge.pendingCatastrophe = ""
 	ge.epochEventHistory = nil

--- a/game/save.go
+++ b/game/save.go
@@ -58,6 +58,7 @@ type GameSave struct {
 	// Phase 8: epoch system
 	CurrentEpoch       string             `json:"current_epoch,omitempty"`
 	EpochEventFired    map[string]bool    `json:"epoch_event_fired,omitempty"`
+	AwakeningsFired    map[string]bool    `json:"awakenings_fired,omitempty"`
 	SurvivedEpochs     map[string]bool    `json:"survived_epochs,omitempty"`
 	PendingCatastrophe string             `json:"pending_catastrophe,omitempty"`
 	EpochEventHistory  []EpochEventRecord `json:"epoch_event_history,omitempty"`
@@ -475,6 +476,7 @@ func (ge *GameEngine) buildSaveSnapshot() GameSave {
 		ParentName:         ge.activeParentName,
 		CurrentEpoch:       ge.currentEpoch,
 		EpochEventFired:    copyBoolMap(ge.epochEventFired),
+		AwakeningsFired:    copyBoolMap(ge.awakeningsFired),
 		SurvivedEpochs:     copyBoolMap(ge.survivedEpochs),
 		PendingCatastrophe: ge.pendingCatastrophe,
 		EpochEventHistory:  append([]EpochEventRecord(nil), ge.epochEventHistory...),
@@ -673,6 +675,11 @@ func (ge *GameEngine) LoadGame(filename string) error {
 		ge.epochEventFired = save.EpochEventFired
 	} else {
 		ge.epochEventFired = make(map[string]bool)
+	}
+	if save.AwakeningsFired != nil {
+		ge.awakeningsFired = save.AwakeningsFired
+	} else {
+		ge.awakeningsFired = make(map[string]bool)
 	}
 	if save.SurvivedEpochs != nil {
 		ge.survivedEpochs = save.SurvivedEpochs

--- a/site/docs/epochs.md
+++ b/site/docs/epochs.md
@@ -45,6 +45,24 @@ Dark matter and antimatter at scales that make earlier resources feel quaint. Th
 
 ---
 
+## Age Awakenings (One Per Epoch)
+
+Each epoch has a single **Awakening** — a deterministic, one-time production boost that fires the first time you enter that epoch's signature age, marking its arrival. These are distinct from the gambled epoch-event roll documented below: an awakening always fires and is always positive (the roll can come up bad), but the boost is temporary and decays. An awakening fires at most once per prestige run and resets on prestige so the next run can earn it again.
+
+| Epoch | Awakening | Triggers On | Effect |
+|-------|-----------|-------------|--------|
+| ◈ Stone Era | Pottery Mastery | Stone Age | +1 food/tick, +0.5 stone/tick for ~8 min |
+| ⚔ Iron Era | Discovery of Metallurgy | Iron Age | +2 iron/tick for ~16 min |
+| ⚙ Steel Era | Steam Breakthrough | Industrial Age | +25% all production for ~6.5 min |
+| ⚡ Electric Era | Electrification | Victorian Age | +2 electricity/tick, +10% all production for ~10 min |
+| ▣ Digital Era | Information Age Dawns | Modern Age | +2 data/tick, +1 knowledge/tick for ~10 min |
+| ◉ Neon Era | Cybernetic Awakening | Cyberpunk Age | +20% all production for ~8 min |
+| ✦ Cosmic Era | First Contact Signal | Interstellar Age | +1.5 dark matter/tick, +10% all production for ~13 min |
+
+See [Events](events.md#age-awakenings) for full flavor, exact durations, and how awakenings surface in the active-events panel.
+
+---
+
 ## How Epoch Events Work
 
 ### The Roll

--- a/site/docs/events.md
+++ b/site/docs/events.md
@@ -146,6 +146,40 @@ For the full list of epoch-exclusive events including effects, durations, and st
 
 ---
 
+## Age Awakenings
+
+Awakenings are one-time, per-epoch milestones that fire the first time you enter an epoch's signature age — seven epochs, seven awakenings. Unlike the gambled epoch transition events (a faith/culture roll that can come up good or bad), an awakening is **deterministic**: it always fires, always grants a modest thematic production boost, and never carries a downside. The boost is **temporary** — delivered through the same active-event mechanism as any timed event, it decays after its listed duration. Each awakening fires at most once per prestige run; the fired set persists across save/load (a reload won't re-fire one you've already earned) and clears on prestige/reset, so the next run can earn them all again.
+
+| Epoch | Trigger Age | Awakening | Temporary Effect | Duration |
+|-------|-------------|-----------|------------------|----------|
+| Stone Era ◈ | Stone Age | Pottery Mastery | +1.0 food/tick, +0.5 stone/tick | 250 ticks (~8 min) |
+| Iron Era ⚔ | Iron Age | Discovery of Metallurgy | +2.0 iron/tick | 500 ticks (~16 min) |
+| Steel Era ⚙ | Industrial Age | Steam Breakthrough | +25% to all production | 200 ticks (~6.5 min) |
+| Electric Era ⚡ | Victorian Age | Electrification | +2.0 electricity/tick, +10% all production | 300 ticks (~10 min) |
+| Digital Era ▣ | Modern Age | Information Age Dawns | +2.0 data/tick, +1.0 knowledge/tick | 300 ticks (~10 min) |
+| Neon Era ◉ | Cyberpunk Age | Cybernetic Awakening | +20% to all production | 250 ticks (~8 min) |
+| Cosmic Era ✦ | Interstellar Age | First Contact Signal | +1.5 dark matter/tick, +10% all production | 400 ticks (~13 min) |
+
+Awakenings appear in the active-events panel like any timed event and tick down over their duration, so you can see exactly how long the boost has left.
+
+### Awakening Flavor
+
+**Pottery Mastery** — "Clay yields to patient hands. Sealed vessels hold the harvest through the lean months — and the surplus, for once, keeps."
+
+**Discovery of Metallurgy** — "The forge runs hotter than any fire before it. Ore that once defied you now bleeds into ingots — and the smiths cannot smelt fast enough."
+
+**Steam Breakthrough** — "Pressure, piston, purpose. The first engine coughs, catches, and roars — and every workshop in the land suddenly works twice as hard."
+
+**Electrification** — "Night surrenders. The grid hums to life, lamps bloom across the skyline, and machines that never sleep take up the long shift."
+
+**Information Age Dawns** — "Knowledge stops being scarce. The networks wake, the archives open, and insight compounds faster than anyone can read it."
+
+**Cybernetic Awakening** — "Flesh and circuit reach an accord. Augmented crews never tire, never blink — and the city's output climbs to a neon-lit fever pitch."
+
+**First Contact Signal** — "A pattern threads through the static — too regular to be noise, too strange to be us. Whatever sent it, your engineers cannot stop listening."
+
+---
+
 ## Managing Events
 
 ### Viewing Your Event Log


### PR DESCRIPTION
Resolves the **Age Awakening Events** card. A one-time, always-positive **Awakening** fires on first entry to each epoch's signature age — 7 epochs, 7 awakenings — marking epoch transitions as pivotal moments (distinct from the gambled epoch-catastrophe roll).

| Epoch | Trigger | Temporary boost |
|---|---|---|
| Stone | Stone Age | +food/+stone, 250t |
| Iron | Iron Age | +iron, 500t |
| Steel | Industrial | +25% production, 200t |
| Electric | Victorian | +electricity +10% prod, 300t |
| Digital | Modern | +data/+knowledge, 300t |
| Neon | Cyberpunk | +20% production, 250t |
| Cosmic | Interstellar | +dark matter +10% prod, 400t |

**Design call:** `TriggerAge` is explicit per awakening rather than derived as "first age of epoch" — the card's own examples don't all match that (Steel's Steam Breakthrough is the *Industrial* Age, the epoch's third; Stone's is Stone Age, not the epoch-opening primitive_age). Explicit honors the 7 concrete examples.

Fires via the existing `InjectEvent` mechanism (no new effect engine), tracked in a persisted `awakeningsFired` map that resets on prestige so they fire again each run. 6 race-clean tests (fires once, no re-fire, save round-trip, prestige-clears). Wiki + changelog. `go build/vet/test` green.