### PR TITLE
feat(help): list dev commands in Help — only when dev mode is active

### DIFF
--- a/ui/overlay_help.go
+++ b/ui/overlay_help.go
@@ -114,6 +114,26 @@ func helpProvider(_ game.GameState, _ int) string {
 	sb.WriteString("\n[gold]═══ Shortcuts ═══[-]\n")
 	sb.WriteString("[gray]g=gather, b=build, r=recruit, a=assign, u=unassign, s=status, res=research, exp=expedition, t=trade, dip=diplomacy[-]\n")
 
+	// Developer Console — only listed when dev mode is active (Ctrl+K passphrase).
+	// Hidden entirely otherwise so the reference stays clean for normal play.
+	if game.DevModeActive {
+		sb.WriteString("\n[gold]═══ Developer Console ═══[-]\n")
+		sb.WriteString("[gray]DEV mode active — type these in the [-][cyan]>[-][gray] prompt:[-]\n")
+		for _, d := range []struct{ cmd, desc string }{
+			{"/god", "Toggle godmode — free costs, instant builds"},
+			{"/fill", "Fill all resources to their storage cap"},
+			{"/give <resource> <amount>", "Add an amount of a resource"},
+			{"/build <building_key>", "Instantly place one building"},
+			{"/techs", "Unlock all techs up to the current age"},
+			{"/age <age_key>", "Jump to any age"},
+			{"/ages", "List all age keys"},
+			{"/prestige <level 0-9>", "Set prestige level"},
+			{"/speed <multiplier>", "Set the tick-speed multiplier"},
+		} {
+			sb.WriteString("  [cyan]" + padRight(d.cmd, 28) + "[-] — " + d.desc + "\n")
+		}
+	}
+
 	return sb.String()
 }
 

--- a/ui/overlay_help_test.go
+++ b/ui/overlay_help_test.go
@@ -1,0 +1,40 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/espresso20/ageforge/game"
+)
+
+// TestHelpProviderDevSectionGated verifies the Developer Console section (and the
+// dev commands) appear in the Help overlay only while dev mode is active, and are
+// hidden entirely during normal play.
+func TestHelpProviderDevSectionGated(t *testing.T) {
+	devCmds := []string{"/god", "/fill", "/give", "/build", "/techs", "/age", "/ages", "/prestige", "/speed"}
+
+	// Dev mode OFF — no section, no commands.
+	game.DevModeActive = false
+	off := helpProvider(game.GameState{}, 0)
+	if strings.Contains(off, "Developer Console") {
+		t.Fatal("help must not show the Developer Console section when dev mode is off")
+	}
+	for _, c := range devCmds {
+		if strings.Contains(off, c) {
+			t.Fatalf("help must not list dev command %q when dev mode is off", c)
+		}
+	}
+
+	// Dev mode ON — section + every command present.
+	game.DevModeActive = true
+	defer func() { game.DevModeActive = false }()
+	on := helpProvider(game.GameState{}, 0)
+	if !strings.Contains(on, "Developer Console") {
+		t.Fatal("help must show the Developer Console section when dev mode is on")
+	}
+	for _, c := range devCmds {
+		if !strings.Contains(on, c) {
+			t.Fatalf("dev help missing command %q", c)
+		}
+	}
+}


### PR DESCRIPTION
The Help overlay now surfaces the developer commands, but **only when dev mode is active** (`game.DevModeActive`, unlocked via the Ctrl+K passphrase). Hidden entirely during normal play so the reference stays clean.

Lists the full set from `game/devmode.go`: `/god`, `/fill`, `/give`, `/build`, `/techs`, `/age`, `/ages`, `/prestige`, `/speed`.

Test (`TestHelpProviderDevSectionGated`) asserts both directions — section + every command absent when dev mode is off, present when on. `go build/vet/test` green.